### PR TITLE
Support external authorization for personal MCP clients

### DIFF
--- a/docs/deployment/personal-mcp-gateway.md
+++ b/docs/deployment/personal-mcp-gateway.md
@@ -46,6 +46,9 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 
 ## Route browser and machine traffic
 
+The following OAuth routes and consent flow apply to the default `MINDROOM_MCP_AUTH_MODE=builtin` mode.
+For externally issued credentials, see [External authorization](#external-authorization); `/mcp` and protected-resource discovery remain common.
+
 Forward these paths to the MindRoom API:
 
 | Paths | Authentication at the access proxy |
@@ -79,7 +82,7 @@ The consent form still requires a signed browser identity, a one-use nonce, and 
 ## Connect an MCP client
 
 Configure a Streamable HTTP server with URL `https://assistant.example.org/mcp`.
-The supported client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
+The built-in client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
 
 1. Read the resource metadata URL from the gateway's `401` bearer challenge.
 2. Discover the authorization server at issuer `https://assistant.example.org/mcp/oauth`.
@@ -90,17 +93,95 @@ The supported client flow uses OAuth authorization code with PKCE S256 and dynam
 
 The exact resource is required for both code exchange and refresh.
 Client callbacks must be registered HTTPS URLs or loopback HTTP URLs.
-Dashboard API keys, browser cookies, upstream identity headers, and third-party provider tokens do not authenticate the MCP endpoint.
-MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
+Dashboard API keys, browser cookies, and unsigned identity headers do not authenticate the MCP endpoint.
+In built-in mode, MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
 
 This implementation uses the Python MCP SDK 1.x Streamable HTTP protocol, tested with protocol version `2025-11-25`.
 It uses stateless requests and JSON responses; it does not offer resumable SSE sessions, resources, prompts, or newer protocol features outside that SDK version.
 The gateway validates SDK request and notification envelopes before dispatch and returns fixed errors without logging malformed input or unknown tool names.
 Valid unsolicited response/error envelopes are acknowledged with an empty HTTP 202 and dropped: this stateless gateway never sends correlated client-result requests.
 If bidirectional requests or stateful sessions are added later, their client responses must instead reach the owning session.
-Client applications need support for this OAuth registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+Client applications need support for the chosen authorization server's registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+
+## External authorization
+
+External mode verifies signed credentials from one configured authority, then checks an active [provisioned account](#managed-account-provisioning) and current personal-agent access on every MCP request and again before tool dispatch.
+It requires `MINDROOM_MCP_SCIM_TOKEN`; the portal prerequisites above still apply.
+
+```bash
+MINDROOM_MCP_AUTH_MODE=external
+MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_ISSUER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_AUDIENCE=https://assistant.example.org/mcp
+MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.json
+MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
+```
+
+Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
+Manage external authorizations at their issuer; provider connections in the portal remain separate.
+Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
+
+By default, send `Authorization: Bearer <JWT>`.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+`MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
+Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
+Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
+
+Shared issuer keys, an operator-entered audience, and an email domain do not establish tenant isolation.
+Trust requires exclusive resource/identity namespaces or a verified issuer-owned client binding.
+Set optional `MINDROOM_MCP_EXTERNAL_CLIENT_ID=registered-client` to require that exact signed string `client_id`, the standard [JWT access-token client claim](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2).
+Missing, differently typed, or different client IDs are rejected when pinned.
+The issuer must guarantee that other tenants cannot select or override this claim and must guarantee the signed user's identity within the intended tenant.
+This pin restricts one registered client; it does not prove an identity provider's claim contract or certify provider compatibility.
+A pinned client must use its preregistered client ID and support the chosen authorization server's discovery and authorization flow.
+Omit it only when the authority or assertion edge already enforces exclusive tenant resource and identity namespaces.
+
+Alternatively, omit `MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM` and configure both:
+
+```bash
+MINDROOM_MCP_EXTERNAL_EMAIL_DOMAIN=example.org
+MINDROOM_MCP_EXTERNAL_EMAIL_TO_MATRIX_USER_ID_TEMPLATE='@{localpart}:example.org'
+```
+
+Only the configured email domain is accepted by this mapping; the complete signed email must match SCIM `userName` exactly, including case.
+The issuer must control these identity claims. Unsigned headers, browser cookies, owner API keys, and local gateway tokens cannot substitute for external credentials.
+
+### Direct OAuth and signed proxy assertions
+
+Direct JumpCloud JWT authentication is unverified and not currently recommended.
+[JumpCloud's OIDC guide](https://jumpcloud.com/support/sso-with-oidc) documents JWT access tokens and additional audiences, but its subject-mapping guarantee applies to ID tokens.
+The shared regional issuer/JWKS, an added MCP audience, and an email mapping do not demonstrate tenant isolation.
+Direct use would require a verified issuer-owned, non-overridable `client_id` pin and a verified access-token identity contract; the documented connector settings do not establish either guarantee.
+Use JumpCloud as the identity provider behind an OAuth-aware proxy that enforces the intended tenant's login policy and supplies trusted signed origin assertions instead.
+
+An OAuth-aware proxy can instead send a raw signed JWT in the header configured by `MINDROOM_MCP_EXTERNAL_TOKEN_HEADER`.
+For example, [Cloudflare Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/) uses `Cf-Access-Jwt-Assertion`; configure that header, the assertion issuer/JWKS, the MCP Access application's audience, and the OAuth discovery issuer separately.
+The edge must own OAuth, enforce the MCP policy, replace client-supplied assertions, and prevent origin bypass; do not retain a bypass policy on `/mcp` or combine Managed OAuth with built-in mode.
+SCIM still needs its separately authenticated route without interactive login redirects.
+Cloudflare labels Managed OAuth beta.
+
+### External lifecycle and validation
+
+Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
+Integer-second issue times in the same second as a security change require renewal in a later second.
+Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
+SCIM disable takes effect when received and committed; already-started provider actions may finish.
+The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
+
+External per-user concurrency limits span tokens; the per-grant limit and cancellation ownership use the exact signed token's digest.
+Cancelling a call requires the same token used to start it; renewing a token or proxy assertion does not transfer cancellation ownership.
+
+Local tests cover signed issuer profiles, HTTP SCIM offboarding, native tool use, and user isolation.
+Hosted tenant login and connector delivery have not been verified.
+Before general access, verify real client login/resource handling, two users' tools, disable with an existing client, refresh rejection, and reactivation against the intended service.
 
 ## Access and lifecycle
+
+The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.
 Refresh tokens rotate on use; replay revokes the grant family.
@@ -215,9 +296,9 @@ Do not share the provisioning secret with MCP clients or browser applications.
 The provisioning routes do not allow browser CORS access.
 
 The endpoint implements a restricted SCIM 2.0 User lifecycle profile: create, list, read, replace, PATCH, and delete, plus service-provider/schema discovery.
-User names match verified browser email exactly, including case; schema discovery advertises this case-sensitive policy.
+User names match verified email exactly, including case; schema discovery advertises this case-sensitive policy.
 This differs from the general SCIM core userName case-insensitive convention, so check connector matching behavior during enrollment.
-Configure the connector's `userName` attribute to the same email verified by the signed browser identity; provisioning does not authenticate the browser or grant tool permissions.
+Configure the connector's `userName` attribute to the email verified by browser identity in built-in mode or the signed MCP credential in external mode; provisioning does not authenticate the browser or grant tool permissions.
 Group management, bulk operations, password management, and sorting are unsupported.
 Disable group management in the connector; unsupported group requests return an explicit error.
 Connectors that insist on a successful test-group operation need a compatible configuration before this endpoint can be used.
@@ -228,7 +309,7 @@ An unsupported operation rolls back the entire PATCH, including any accompanying
 Configure and test the connector's actual update and deactivation payloads against this profile before relying on provisioning for offboarding.
 
 Use the base URL `https://assistant.example.org/mcp/scim/v2` with the dedicated bearer token in a compatible custom SCIM connector.
-Provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
+In built-in mode, provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
 Account deactivation, user-name changes, and deletion remove all bound grants and pending consent atomically.
 Reactivation permits a new approval and never restores old grants.
 Unknown or inactive accounts cannot authorize clients in managed-account mode.

--- a/docs/deployment/personal-mcp-gateway.md
+++ b/docs/deployment/personal-mcp-gateway.md
@@ -117,14 +117,15 @@ MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.jso
 MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
 ```
 
-Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
-This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+Protected-resource metadata's `authorization_servers` field advertises `MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from `MINDROOM_MCP_EXTERNAL_ISSUER`; preserve significant trailing slashes.
 External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
 Manage external authorizations at their issuer; provider connections in the portal remain separate.
 Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
 
 By default, send `Authorization: Bearer <JWT>`.
-Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, and the configured email claim.
+Unless the email-domain/template mapping below is configured, they must also contain the configured Matrix identity claim.
 `MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
 Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
 Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
@@ -164,9 +165,11 @@ Cloudflare labels Managed OAuth beta.
 
 ### External lifecycle and validation
 
-Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
-Integer-second issue times in the same second as a security change require renewal in a later second.
-Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+Account creation, migration, rename, reactivation, and delete/recreate require a fresh JWT whose `iat` is strictly more than 60 seconds after the latest account security event recorded by the gateway; profile-only updates preserve access.
+With synchronized clocks, obtain that fresh JWT more than 60 seconds after the event; initial provisioning also incurs this delay, and issuer lag can extend it.
+Strict future-`iat` rejection remains in force.
+The revocation guarantee assumes the issuer is at most 60 seconds ahead of the gateway and the gateway clock does not move backward: keep stable, synchronized clocks; unbounded skew is unsupported.
+Existing accounts receive a one-time event cutoff when upgrading; the same 60-second margin also applies to already-persisted cutoffs.
 JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
 SCIM disable takes effect when received and committed; already-started provider actions may finish.
 The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
@@ -180,7 +183,8 @@ Before general access, verify real client login/resource handling, two users' to
 
 ## Access and lifecycle
 
-The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+The OAuth token lifetimes, client-management controls, and issuer-storage limits in this section govern built-in credentials.
+External mode reuses the shared provider/account store, so its provider and storage configuration still validates at startup; leave unused `MINDROOM_MCP_OAUTH_*` settings at valid defaults.
 Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18697,14 +18697,15 @@ MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.jso
 MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
 ```
 
-Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
-This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+Protected-resource metadata's `authorization_servers` field advertises `MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from `MINDROOM_MCP_EXTERNAL_ISSUER`; preserve significant trailing slashes.
 External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
 Manage external authorizations at their issuer; provider connections in the portal remain separate.
 Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
 
 By default, send `Authorization: Bearer <JWT>`.
-Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, and the configured email claim.
+Unless the email-domain/template mapping below is configured, they must also contain the configured Matrix identity claim.
 `MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
 Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
 Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
@@ -18744,9 +18745,11 @@ Cloudflare labels Managed OAuth beta.
 
 ### External lifecycle and validation
 
-Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
-Integer-second issue times in the same second as a security change require renewal in a later second.
-Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+Account creation, migration, rename, reactivation, and delete/recreate require a fresh JWT whose `iat` is strictly more than 60 seconds after the latest account security event recorded by the gateway; profile-only updates preserve access.
+With synchronized clocks, obtain that fresh JWT more than 60 seconds after the event; initial provisioning also incurs this delay, and issuer lag can extend it.
+Strict future-`iat` rejection remains in force.
+The revocation guarantee assumes the issuer is at most 60 seconds ahead of the gateway and the gateway clock does not move backward: keep stable, synchronized clocks; unbounded skew is unsupported.
+Existing accounts receive a one-time event cutoff when upgrading; the same 60-second margin also applies to already-persisted cutoffs.
 JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
 SCIM disable takes effect when received and committed; already-started provider actions may finish.
 The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
@@ -18760,7 +18763,8 @@ Before general access, verify real client login/resource handling, two users' to
 
 ## Access and lifecycle
 
-The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+The OAuth token lifetimes, client-management controls, and issuer-storage limits in this section govern built-in credentials.
+External mode reuses the shared provider/account store, so its provider and storage configuration still validates at startup; leave unused `MINDROOM_MCP_OAUTH_*` settings at valid defaults.
 Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18626,6 +18626,9 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 
 ## Route browser and machine traffic
 
+The following OAuth routes and consent flow apply to the default `MINDROOM_MCP_AUTH_MODE=builtin` mode.
+For externally issued credentials, see [External authorization](#external-authorization); `/mcp` and protected-resource discovery remain common.
+
 Forward these paths to the MindRoom API:
 
 | Paths | Authentication at the access proxy |
@@ -18659,7 +18662,7 @@ The consent form still requires a signed browser identity, a one-use nonce, and 
 ## Connect an MCP client
 
 Configure a Streamable HTTP server with URL `https://assistant.example.org/mcp`.
-The supported client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
+The built-in client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
 
 1. Read the resource metadata URL from the gateway's `401` bearer challenge.
 2. Discover the authorization server at issuer `https://assistant.example.org/mcp/oauth`.
@@ -18670,17 +18673,95 @@ The supported client flow uses OAuth authorization code with PKCE S256 and dynam
 
 The exact resource is required for both code exchange and refresh.
 Client callbacks must be registered HTTPS URLs or loopback HTTP URLs.
-Dashboard API keys, browser cookies, upstream identity headers, and third-party provider tokens do not authenticate the MCP endpoint.
-MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
+Dashboard API keys, browser cookies, and unsigned identity headers do not authenticate the MCP endpoint.
+In built-in mode, MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
 
 This implementation uses the Python MCP SDK 1.x Streamable HTTP protocol, tested with protocol version `2025-11-25`.
 It uses stateless requests and JSON responses; it does not offer resumable SSE sessions, resources, prompts, or newer protocol features outside that SDK version.
 The gateway validates SDK request and notification envelopes before dispatch and returns fixed errors without logging malformed input or unknown tool names.
 Valid unsolicited response/error envelopes are acknowledged with an empty HTTP 202 and dropped: this stateless gateway never sends correlated client-result requests.
 If bidirectional requests or stateful sessions are added later, their client responses must instead reach the owning session.
-Client applications need support for this OAuth registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+Client applications need support for the chosen authorization server's registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+
+## External authorization
+
+External mode verifies signed credentials from one configured authority, then checks an active [provisioned account](#managed-account-provisioning) and current personal-agent access on every MCP request and again before tool dispatch.
+It requires `MINDROOM_MCP_SCIM_TOKEN`; the portal prerequisites above still apply.
+
+```bash
+MINDROOM_MCP_AUTH_MODE=external
+MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_ISSUER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_AUDIENCE=https://assistant.example.org/mcp
+MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.json
+MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
+```
+
+Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
+Manage external authorizations at their issuer; provider connections in the portal remain separate.
+Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
+
+By default, send `Authorization: Bearer <JWT>`.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+`MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
+Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
+Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
+
+Shared issuer keys, an operator-entered audience, and an email domain do not establish tenant isolation.
+Trust requires exclusive resource/identity namespaces or a verified issuer-owned client binding.
+Set optional `MINDROOM_MCP_EXTERNAL_CLIENT_ID=registered-client` to require that exact signed string `client_id`, the standard [JWT access-token client claim](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2).
+Missing, differently typed, or different client IDs are rejected when pinned.
+The issuer must guarantee that other tenants cannot select or override this claim and must guarantee the signed user's identity within the intended tenant.
+This pin restricts one registered client; it does not prove an identity provider's claim contract or certify provider compatibility.
+A pinned client must use its preregistered client ID and support the chosen authorization server's discovery and authorization flow.
+Omit it only when the authority or assertion edge already enforces exclusive tenant resource and identity namespaces.
+
+Alternatively, omit `MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM` and configure both:
+
+```bash
+MINDROOM_MCP_EXTERNAL_EMAIL_DOMAIN=example.org
+MINDROOM_MCP_EXTERNAL_EMAIL_TO_MATRIX_USER_ID_TEMPLATE='@{localpart}:example.org'
+```
+
+Only the configured email domain is accepted by this mapping; the complete signed email must match SCIM `userName` exactly, including case.
+The issuer must control these identity claims. Unsigned headers, browser cookies, owner API keys, and local gateway tokens cannot substitute for external credentials.
+
+### Direct OAuth and signed proxy assertions
+
+Direct JumpCloud JWT authentication is unverified and not currently recommended.
+[JumpCloud's OIDC guide](https://jumpcloud.com/support/sso-with-oidc) documents JWT access tokens and additional audiences, but its subject-mapping guarantee applies to ID tokens.
+The shared regional issuer/JWKS, an added MCP audience, and an email mapping do not demonstrate tenant isolation.
+Direct use would require a verified issuer-owned, non-overridable `client_id` pin and a verified access-token identity contract; the documented connector settings do not establish either guarantee.
+Use JumpCloud as the identity provider behind an OAuth-aware proxy that enforces the intended tenant's login policy and supplies trusted signed origin assertions instead.
+
+An OAuth-aware proxy can instead send a raw signed JWT in the header configured by `MINDROOM_MCP_EXTERNAL_TOKEN_HEADER`.
+For example, [Cloudflare Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/) uses `Cf-Access-Jwt-Assertion`; configure that header, the assertion issuer/JWKS, the MCP Access application's audience, and the OAuth discovery issuer separately.
+The edge must own OAuth, enforce the MCP policy, replace client-supplied assertions, and prevent origin bypass; do not retain a bypass policy on `/mcp` or combine Managed OAuth with built-in mode.
+SCIM still needs its separately authenticated route without interactive login redirects.
+Cloudflare labels Managed OAuth beta.
+
+### External lifecycle and validation
+
+Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
+Integer-second issue times in the same second as a security change require renewal in a later second.
+Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
+SCIM disable takes effect when received and committed; already-started provider actions may finish.
+The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
+
+External per-user concurrency limits span tokens; the per-grant limit and cancellation ownership use the exact signed token's digest.
+Cancelling a call requires the same token used to start it; renewing a token or proxy assertion does not transfer cancellation ownership.
+
+Local tests cover signed issuer profiles, HTTP SCIM offboarding, native tool use, and user isolation.
+Hosted tenant login and connector delivery have not been verified.
+Before general access, verify real client login/resource handling, two users' tools, disable with an existing client, refresh rejection, and reactivation against the intended service.
 
 ## Access and lifecycle
+
+The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.
 Refresh tokens rotate on use; replay revokes the grant family.
@@ -18795,9 +18876,9 @@ Do not share the provisioning secret with MCP clients or browser applications.
 The provisioning routes do not allow browser CORS access.
 
 The endpoint implements a restricted SCIM 2.0 User lifecycle profile: create, list, read, replace, PATCH, and delete, plus service-provider/schema discovery.
-User names match verified browser email exactly, including case; schema discovery advertises this case-sensitive policy.
+User names match verified email exactly, including case; schema discovery advertises this case-sensitive policy.
 This differs from the general SCIM core userName case-insensitive convention, so check connector matching behavior during enrollment.
-Configure the connector's `userName` attribute to the same email verified by the signed browser identity; provisioning does not authenticate the browser or grant tool permissions.
+Configure the connector's `userName` attribute to the email verified by browser identity in built-in mode or the signed MCP credential in external mode; provisioning does not authenticate the browser or grant tool permissions.
 Group management, bulk operations, password management, and sorting are unsupported.
 Disable group management in the connector; unsupported group requests return an explicit error.
 Connectors that insist on a successful test-group operation need a compatible configuration before this endpoint can be used.
@@ -18808,7 +18889,7 @@ An unsupported operation rolls back the entire PATCH, including any accompanying
 Configure and test the connector's actual update and deactivation payloads against this profile before relying on provisioning for offboarding.
 
 Use the base URL `https://assistant.example.org/mcp/scim/v2` with the dedicated bearer token in a compatible custom SCIM connector.
-Provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
+In built-in mode, provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
 Account deactivation, user-name changes, and deletion remove all bound grants and pending consent atomically.
 Reactivation permits a new approval and never restores old grants.
 Unknown or inactive accounts cannot authorize clients in managed-account mode.

--- a/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
@@ -113,14 +113,15 @@ MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.jso
 MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
 ```
 
-Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
-This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+Protected-resource metadata's `authorization_servers` field advertises `MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from `MINDROOM_MCP_EXTERNAL_ISSUER`; preserve significant trailing slashes.
 External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
 Manage external authorizations at their issuer; provider connections in the portal remain separate.
 Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
 
 By default, send `Authorization: Bearer <JWT>`.
-Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, and the configured email claim.
+Unless the email-domain/template mapping below is configured, they must also contain the configured Matrix identity claim.
 `MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
 Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
 Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
@@ -160,9 +161,11 @@ Cloudflare labels Managed OAuth beta.
 
 ### External lifecycle and validation
 
-Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
-Integer-second issue times in the same second as a security change require renewal in a later second.
-Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+Account creation, migration, rename, reactivation, and delete/recreate require a fresh JWT whose `iat` is strictly more than 60 seconds after the latest account security event recorded by the gateway; profile-only updates preserve access.
+With synchronized clocks, obtain that fresh JWT more than 60 seconds after the event; initial provisioning also incurs this delay, and issuer lag can extend it.
+Strict future-`iat` rejection remains in force.
+The revocation guarantee assumes the issuer is at most 60 seconds ahead of the gateway and the gateway clock does not move backward: keep stable, synchronized clocks; unbounded skew is unsupported.
+Existing accounts receive a one-time event cutoff when upgrading; the same 60-second margin also applies to already-persisted cutoffs.
 JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
 SCIM disable takes effect when received and committed; already-started provider actions may finish.
 The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
@@ -176,7 +179,8 @@ Before general access, verify real client login/resource handling, two users' to
 
 ## Access and lifecycle
 
-The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+The OAuth token lifetimes, client-management controls, and issuer-storage limits in this section govern built-in credentials.
+External mode reuses the shared provider/account store, so its provider and storage configuration still validates at startup; leave unused `MINDROOM_MCP_OAUTH_*` settings at valid defaults.
 Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.

--- a/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
@@ -42,6 +42,9 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 
 ## Route browser and machine traffic
 
+The following OAuth routes and consent flow apply to the default `MINDROOM_MCP_AUTH_MODE=builtin` mode.
+For externally issued credentials, see [External authorization](#external-authorization); `/mcp` and protected-resource discovery remain common.
+
 Forward these paths to the MindRoom API:
 
 | Paths | Authentication at the access proxy |
@@ -75,7 +78,7 @@ The consent form still requires a signed browser identity, a one-use nonce, and 
 ## Connect an MCP client
 
 Configure a Streamable HTTP server with URL `https://assistant.example.org/mcp`.
-The supported client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
+The built-in client flow uses OAuth authorization code with PKCE S256 and dynamic public-client registration:
 
 1. Read the resource metadata URL from the gateway's `401` bearer challenge.
 2. Discover the authorization server at issuer `https://assistant.example.org/mcp/oauth`.
@@ -86,17 +89,95 @@ The supported client flow uses OAuth authorization code with PKCE S256 and dynam
 
 The exact resource is required for both code exchange and refresh.
 Client callbacks must be registered HTTPS URLs or loopback HTTP URLs.
-Dashboard API keys, browser cookies, upstream identity headers, and third-party provider tokens do not authenticate the MCP endpoint.
-MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
+Dashboard API keys, browser cookies, and unsigned identity headers do not authenticate the MCP endpoint.
+In built-in mode, MindRoom issues its own client grant; upstream service tokens stay in the existing personal credential store.
 
 This implementation uses the Python MCP SDK 1.x Streamable HTTP protocol, tested with protocol version `2025-11-25`.
 It uses stateless requests and JSON responses; it does not offer resumable SSE sessions, resources, prompts, or newer protocol features outside that SDK version.
 The gateway validates SDK request and notification envelopes before dispatch and returns fixed errors without logging malformed input or unknown tool names.
 Valid unsolicited response/error envelopes are acknowledged with an empty HTTP 202 and dropped: this stateless gateway never sends correlated client-result requests.
 If bidirectional requests or stateful sessions are added later, their client responses must instead reach the owning session.
-Client applications need support for this OAuth registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+Client applications need support for the chosen authorization server's registration and discovery flow; a static bearer-only configuration screen cannot perform initial login.
+
+## External authorization
+
+External mode verifies signed credentials from one configured authority, then checks an active [provisioned account](#managed-account-provisioning) and current personal-agent access on every MCP request and again before tool dispatch.
+It requires `MINDROOM_MCP_SCIM_TOKEN`; the portal prerequisites above still apply.
+
+```bash
+MINDROOM_MCP_AUTH_MODE=external
+MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_ISSUER=https://identity.example.org
+MINDROOM_MCP_EXTERNAL_AUDIENCE=https://assistant.example.org/mcp
+MINDROOM_MCP_EXTERNAL_JWKS_URL=https://identity.example.org/.well-known/jwks.json
+MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM=matrix_user_id
+```
+
+Protected-resource metadata advertises `AUTHORIZATION_SERVER`, whose discovery document supplies the client's OAuth endpoints.
+This issuer identifier may differ from the JWT `ISSUER`; preserve significant trailing slashes.
+External mode disables MindRoom's OAuth registration, authorization, consent, token, revocation, authorization-server metadata, and client-management controls.
+Manage external authorizations at their issuer; provider connections in the portal remain separate.
+Restart the API after changing authentication settings: changed or invalid settings fail closed until restart.
+
+By default, send `Authorization: Bearer <JWT>`.
+Credentials must use RS256 or ES256 and contain signed `iss`, `aud`, `exp`, `iat`, `sub`, email, and the configured Matrix identity claim.
+`MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM` defaults to `email`.
+Opaque tokens, introspection, and OIDC ID tokens are unsupported; use an audience dedicated to this MCP resource, distinct from a client ID or browser application's audience.
+Set optional `MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES` to whitespace-separated scopes required in the signed `scope` claim; no tool scope is implicitly required in external mode.
+
+Shared issuer keys, an operator-entered audience, and an email domain do not establish tenant isolation.
+Trust requires exclusive resource/identity namespaces or a verified issuer-owned client binding.
+Set optional `MINDROOM_MCP_EXTERNAL_CLIENT_ID=registered-client` to require that exact signed string `client_id`, the standard [JWT access-token client claim](https://www.rfc-editor.org/rfc/rfc9068.html#section-2.2).
+Missing, differently typed, or different client IDs are rejected when pinned.
+The issuer must guarantee that other tenants cannot select or override this claim and must guarantee the signed user's identity within the intended tenant.
+This pin restricts one registered client; it does not prove an identity provider's claim contract or certify provider compatibility.
+A pinned client must use its preregistered client ID and support the chosen authorization server's discovery and authorization flow.
+Omit it only when the authority or assertion edge already enforces exclusive tenant resource and identity namespaces.
+
+Alternatively, omit `MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM` and configure both:
+
+```bash
+MINDROOM_MCP_EXTERNAL_EMAIL_DOMAIN=example.org
+MINDROOM_MCP_EXTERNAL_EMAIL_TO_MATRIX_USER_ID_TEMPLATE='@{localpart}:example.org'
+```
+
+Only the configured email domain is accepted by this mapping; the complete signed email must match SCIM `userName` exactly, including case.
+The issuer must control these identity claims. Unsigned headers, browser cookies, owner API keys, and local gateway tokens cannot substitute for external credentials.
+
+### Direct OAuth and signed proxy assertions
+
+Direct JumpCloud JWT authentication is unverified and not currently recommended.
+[JumpCloud's OIDC guide](https://jumpcloud.com/support/sso-with-oidc) documents JWT access tokens and additional audiences, but its subject-mapping guarantee applies to ID tokens.
+The shared regional issuer/JWKS, an added MCP audience, and an email mapping do not demonstrate tenant isolation.
+Direct use would require a verified issuer-owned, non-overridable `client_id` pin and a verified access-token identity contract; the documented connector settings do not establish either guarantee.
+Use JumpCloud as the identity provider behind an OAuth-aware proxy that enforces the intended tenant's login policy and supplies trusted signed origin assertions instead.
+
+An OAuth-aware proxy can instead send a raw signed JWT in the header configured by `MINDROOM_MCP_EXTERNAL_TOKEN_HEADER`.
+For example, [Cloudflare Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/) uses `Cf-Access-Jwt-Assertion`; configure that header, the assertion issuer/JWKS, the MCP Access application's audience, and the OAuth discovery issuer separately.
+The edge must own OAuth, enforce the MCP policy, replace client-supplied assertions, and prevent origin bypass; do not retain a bypass policy on `/mcp` or combine Managed OAuth with built-in mode.
+SCIM still needs its separately authenticated route without interactive login redirects.
+Cloudflare labels Managed OAuth beta.
+
+### External lifecycle and validation
+
+Account creation, rename, disable, reactivation, and delete/recreate reject tokens issued before the latest account security change; profile-only updates preserve access.
+Integer-second issue times in the same second as a security change require renewal in a later second.
+Existing accounts receive a one-time issue-time cutoff when upgrading, so external clients need fresh credentials.
+JWKS refresh is shared and bounded; signing-key revocation can lag by up to 60 seconds.
+SCIM disable takes effect when received and committed; already-started provider actions may finish.
+The issuer owns refresh revocation and login policy: after account reactivation, silent renewal can produce an accepted fresh token without interactive login.
+
+External per-user concurrency limits span tokens; the per-grant limit and cancellation ownership use the exact signed token's digest.
+Cancelling a call requires the same token used to start it; renewing a token or proxy assertion does not transfer cancellation ownership.
+
+Local tests cover signed issuer profiles, HTTP SCIM offboarding, native tool use, and user isolation.
+Hosted tenant login and connector delivery have not been verified.
+Before general access, verify real client login/resource handling, two users' tools, disable with an existing client, refresh rejection, and reactivation against the intended service.
 
 ## Access and lifecycle
+
+The OAuth token, client-management, and issuer-storage limits in this section apply to built-in mode.
+Personal-agent authorization, persistence, and active MCP call limits apply to both modes; external credential lifecycle is described above.
 
 Access tokens last up to 15 minutes.
 Refresh tokens rotate on use; replay revokes the grant family.
@@ -211,9 +292,9 @@ Do not share the provisioning secret with MCP clients or browser applications.
 The provisioning routes do not allow browser CORS access.
 
 The endpoint implements a restricted SCIM 2.0 User lifecycle profile: create, list, read, replace, PATCH, and delete, plus service-provider/schema discovery.
-User names match verified browser email exactly, including case; schema discovery advertises this case-sensitive policy.
+User names match verified email exactly, including case; schema discovery advertises this case-sensitive policy.
 This differs from the general SCIM core userName case-insensitive convention, so check connector matching behavior during enrollment.
-Configure the connector's `userName` attribute to the same email verified by the signed browser identity; provisioning does not authenticate the browser or grant tool permissions.
+Configure the connector's `userName` attribute to the email verified by browser identity in built-in mode or the signed MCP credential in external mode; provisioning does not authenticate the browser or grant tool permissions.
 Group management, bulk operations, password management, and sorting are unsupported.
 Disable group management in the connector; unsupported group requests return an explicit error.
 Connectors that insist on a successful test-group operation need a compatible configuration before this endpoint can be used.
@@ -224,7 +305,7 @@ An unsupported operation rolls back the entire PATCH, including any accompanying
 Configure and test the connector's actual update and deactivation payloads against this profile before relying on provisioning for offboarding.
 
 Use the base URL `https://assistant.example.org/mcp/scim/v2` with the dedicated bearer token in a compatible custom SCIM connector.
-Provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
+In built-in mode, provision an active test user, approve an MCP client through the existing portal login, then deactivate the provisioned user and verify that token refresh, tool use, and further consent are rejected.
 Account deactivation, user-name changes, and deletion remove all bound grants and pending consent atomically.
 Reactivation permits a new approval and never restores old grants.
 Unknown or inactive accounts cannot authorize clients in managed-account mode.

--- a/src/mindroom/api/mcp_gateway.py
+++ b/src/mindroom/api/mcp_gateway.py
@@ -32,6 +32,7 @@ from mindroom.mcp.manager import MCPServerManager
 from mindroom.mcp_gateway.accounts import GatewayAccounts
 from mindroom.mcp_gateway.admission import OnboardingRateLimiter
 from mindroom.mcp_gateway.consent import render_consent_page
+from mindroom.mcp_gateway.external_auth import ExternalAuth, ExternalAuthSettings
 from mindroom.mcp_gateway.oauth import GatewayOAuthProvider
 from mindroom.mcp_gateway.server import GatewayServer, read_gateway_body, replay_gateway_body
 from mindroom.mcp_gateway.store import GatewayOAuthCapacityError
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
 
     from mindroom.api.personal_agent import PersonalAgentContext
     from mindroom.constants import RuntimePaths
+    from mindroom.mcp_gateway.external_auth import ExternalIdentity
     from mindroom.mcp_gateway.oauth import GatewayAccessToken
     from mindroom.mcp_gateway.types import GatewayToolResponse
 
@@ -124,6 +126,11 @@ class GatewayRuntime:
     """Own client grants, lazy upstream sessions and one stateless MCP server."""
 
     def __init__(self, paths: RuntimePaths) -> None:
+        self.external_settings = ExternalAuthSettings.from_paths(paths)
+        if self.external_settings is not None and not paths.env_value("MINDROOM_MCP_SCIM_TOKEN"):
+            msg = "External MCP authentication requires account provisioning"
+            raise ValueError(msg)
+        self.external_auth = ExternalAuth(self.external_settings) if self.external_settings is not None else None
         self._onboarding_limiter = OnboardingRateLimiter(
             int(paths.env_value("MINDROOM_MCP_GATEWAY_ONBOARDING_RATE_LIMIT") or "60"),
             int(paths.env_value("MINDROOM_MCP_GATEWAY_ONBOARDING_SOURCE_RATE_LIMIT") or "10"),
@@ -161,21 +168,42 @@ class GatewayRuntime:
         """Return the configured public origin, independent of forwarded headers."""
         return self.provider.resource_url.removesuffix("/mcp")
 
-    async def principal(self, request: Request) -> tuple[GatewayAccessToken, PersonalAgentContext]:
-        """Resolve only a gateway bearer against current personal access policy."""
+    async def principal(self, request: Request) -> tuple[GatewayPrincipal, PersonalAgentContext]:
+        """Resolve verified MCP authority against current account and personal access policy."""
+        _runtime(request)
+        scopes = self.external_settings.required_scopes if self.external_settings is not None else ("mcp:tools",)
+        challenge = f'Bearer resource_metadata="{self.origin}/.well-known/oauth-protected-resource/mcp"'
+        if scopes:
+            challenge += f', scope="{" ".join(scopes)}"'
+        headers = {"WWW-Authenticate": challenge}
+        if self.external_auth is not None:
+            try:
+                identity: ExternalIdentity = await self.external_auth.verify(request)
+            except HTTPException as exc:
+                if exc.status_code == 403:
+                    headers["WWW-Authenticate"] += ', error="insufficient_scope"'
+                raise HTTPException(exc.status_code, exc.detail, headers=headers) from exc
+            if await self.accounts.resolve_external(identity.email, identity.issued_at) is None:
+                raise HTTPException(401, "An active provisioned account is required", headers=headers)
+            snapshot = rebind_current_request_snapshot(request)
+            _runtime(request, paths=snapshot.runtime_paths)
+            try:
+                context = resolve_personal_agent(snapshot, identity.matrix_user_id)
+            except HTTPException as exc:
+                raise HTTPException(401, "External principal is no longer authorized", headers=headers) from exc
+            return GatewayPrincipal(grant_id=identity.token_digest, requester_id=context.requester_id), context
         value = request.headers.get("authorization", "")
         scheme, _, raw = value.partition(" ")
-        token = (
+        token: GatewayAccessToken | None = (
             await self.provider.load_access_token(raw) if scheme.lower() == "bearer" and 0 < len(raw) <= 256 else None
         )
-        headers = {
-            "WWW-Authenticate": f'Bearer resource_metadata="{self.origin}/.well-known/oauth-protected-resource/mcp", scope="mcp:tools"',
-        }
         if token is None:
             raise HTTPException(401, "Gateway bearer required", headers=headers)
+        snapshot = rebind_current_request_snapshot(request)
+        _runtime(request, paths=snapshot.runtime_paths)
         try:
             context = resolve_personal_agent(
-                rebind_current_request_snapshot(request),
+                snapshot,
                 token.authenticated_user_id,
                 expected_agent_name=token.agent_name,
             )
@@ -183,15 +211,17 @@ class GatewayRuntime:
             raise HTTPException(401, "Gateway grant is no longer authorized", headers=headers) from exc
         if context.requester_id != token.requester_id:
             raise HTTPException(401, "Gateway principal changed", headers=headers)
-        return token, context
+        return GatewayPrincipal(grant_id=token.grant_id, requester_id=token.requester_id), context
 
     async def authenticate(self, request: Request) -> GatewayPrincipal:
         """Authenticate every HTTP message, including discovery and cancellation."""
-        token, _ = await self.principal(request)
-        return GatewayPrincipal(grant_id=token.grant_id, requester_id=token.requester_id)
+        principal, _ = await self.principal(request)
+        return principal
 
     async def _record_activity(self, request: Request) -> None:
         """Record successful use without turning completed provider actions into retryable failures."""
+        if self.external_auth is not None:
+            return
         _, _, raw = request.headers.get("authorization", "").partition(" ")
         try:
             token = await self.provider.load_access_token(raw)
@@ -239,7 +269,7 @@ async def gateway_lifespan(app: FastAPI) -> AsyncIterator[None]:
     try:
         runtime = GatewayRuntime(paths)
     except ValueError:
-        logger.warning("MCP gateway disabled: configure a valid public origin and limits")
+        logger.warning("MCP gateway disabled: check public origin, limits, authentication, and account provisioning")
         yield
         return
     state.mcp_gateway_runtime = runtime
@@ -252,16 +282,29 @@ async def gateway_lifespan(app: FastAPI) -> AsyncIterator[None]:
         await runtime.manager.shutdown()
 
 
-def _runtime(request: Request) -> GatewayRuntime:
+def _runtime(request: Request, *, paths: RuntimePaths | None = None) -> GatewayRuntime:
     runtime = app_state(request.app).mcp_gateway_runtime
-    paths = require_api_state(request.app).snapshot.runtime_paths
+    if paths is None:
+        paths = require_api_state(request.app).snapshot.runtime_paths
+    try:
+        external_settings = ExternalAuthSettings.from_paths(paths)
+    except ValueError as exc:
+        raise HTTPException(404, "MCP gateway is disabled", headers=PERSONAL_RESPONSE_HEADERS) from exc
     if (
         runtime is None
+        or runtime.external_settings != external_settings
         or not _enabled(paths)
         or (paths.env_value("MINDROOM_PUBLIC_URL") or "").rstrip("/") != runtime.origin
         or (paths.env_value("MINDROOM_MCP_SCIM_TOKEN") or "") != runtime.scim_token
     ):
         raise HTTPException(404, "MCP gateway is disabled", headers=PERSONAL_RESPONSE_HEADERS)
+    return runtime
+
+
+def _local_runtime(request: Request) -> GatewayRuntime:
+    runtime = _runtime(request)
+    if runtime.external_settings is not None:
+        raise HTTPException(404, "Built-in MCP authorization is disabled", headers=PERSONAL_RESPONSE_HEADERS)
     return runtime
 
 
@@ -316,7 +359,7 @@ def _oauth_admission(request: Request, runtime: GatewayRuntime, operation: str) 
 
 
 async def _oauth(request: Request) -> Response:
-    runtime = _runtime(request)
+    runtime = _local_runtime(request)
     operation = request.scope["path"].rsplit("/", 1)[-1]
     admission = _oauth_admission(request, runtime, operation)
     if admission is not None:
@@ -363,13 +406,15 @@ async def _metadata(request: Request) -> Response:
     runtime = _runtime(request)
     provider = runtime.provider
     if "oauth-protected-resource" in request.scope["path"]:
+        external = runtime.external_settings
         payload = {
             "resource": provider.resource_url,
-            "authorization_servers": [provider.issuer_url],
-            "scopes_supported": ["mcp:tools"],
+            "authorization_servers": [external.authorization_server if external is not None else provider.issuer_url],
+            "scopes_supported": list(external.required_scopes) if external is not None else ["mcp:tools"],
             "bearer_methods_supported": ["header"],
         }
     else:
+        _local_runtime(request)
         payload = {
             "issuer": provider.issuer_url,
             "authorization_endpoint": provider.issuer_url + "/authorize",
@@ -387,7 +432,7 @@ async def _metadata(request: Request) -> Response:
 
 
 async def _consent(request: Request) -> Response:
-    runtime = _runtime(request)
+    runtime = _local_runtime(request)
     user = await require_personal_connections_user(request)
     context = resolve_personal_agent(rebind_current_request_snapshot(request), user["matrix_user_id"], channel="matrix")
     account_id = None
@@ -475,7 +520,7 @@ def install_gateway_routes(app: FastAPI) -> None:
     """Register exact machine and browser routes before the frontend catch-all."""
     app.router.routes.extend(
         [
-            *client_routes(_runtime),
+            *client_routes(_local_runtime),
             *scim_routes(_runtime),
             Route("/mcp", _MCPEndpoint(), methods=["GET", "POST", "DELETE"]),
             Route("/.well-known/oauth-authorization-server/mcp/oauth", _metadata, methods=["GET"]),

--- a/src/mindroom/mcp_gateway/accounts.py
+++ b/src/mindroom/mcp_gateway/accounts.py
@@ -7,6 +7,7 @@ must bound physical storage with the runtime volume quota.
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 import time
 import uuid
@@ -36,8 +37,11 @@ def migrate_accounts(connection: sqlite3.Connection) -> None:
         account_id TEXT PRIMARY KEY, user_name TEXT UNIQUE NOT NULL,
         active INTEGER NOT NULL CHECK(active IN (0, 1)),
         created_at REAL NOT NULL, updated_at REAL NOT NULL,
-        profile TEXT NOT NULL DEFAULT '{}'
+        profile TEXT NOT NULL DEFAULT '{}', token_valid_after REAL NOT NULL
     )""")
+    if "token_valid_after" not in {row["name"] for row in connection.execute("PRAGMA table_info(gateway_accounts)")}:
+        connection.execute("ALTER TABLE gateway_accounts ADD COLUMN token_valid_after REAL NOT NULL DEFAULT 0")
+        connection.execute("UPDATE gateway_accounts SET token_valid_after = ?", (time.time(),))
 
 
 def account_is_active(connection: sqlite3.Connection, account_id: str | None) -> bool:
@@ -157,14 +161,30 @@ class GatewayAccounts:
             account_id = str(uuid.uuid4())
             try:
                 connection.execute(
-                    "INSERT INTO gateway_accounts VALUES (?, ?, ?, ?, ?, ?)",
-                    (account_id, clean["userName"], int(clean["active"]), now, now, json.dumps(clean)),
+                    "INSERT INTO gateway_accounts "
+                    "(account_id, user_name, active, created_at, updated_at, profile, token_valid_after) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (account_id, clean["userName"], int(clean["active"]), now, now, json.dumps(clean), now),
                 )
             except sqlite3.IntegrityError as error:
                 raise AccountConflictError from error
             return self._get(connection, account_id)
 
         return await self.store.transact(write)
+
+    async def resolve_external(self, user_name: str, issued_at: float) -> str | None:
+        """Require exact active email and a JWT issued strictly after the durable cutoff."""
+        if isinstance(issued_at, bool) or not isinstance(issued_at, (int, float)) or not math.isfinite(issued_at):
+            return None
+
+        def read(connection: sqlite3.Connection) -> str | None:
+            row = connection.execute(
+                "SELECT account_id FROM gateway_accounts WHERE user_name = ? AND active = 1 AND token_valid_after < ?",
+                (user_name, issued_at),
+            ).fetchone()
+            return row["account_id"] if row else None
+
+        return await self.store.read(read)
 
     @staticmethod
     def _get(connection: sqlite3.Connection, account_id: str) -> dict[str, Any]:
@@ -226,11 +246,23 @@ class GatewayAccounts:
                 clean = _validate_account(transform(dict(old)))
                 if clean == _validate_account(old):
                     continue
+                authority_changed = old["userName"] != clean["userName"] or old["active"] != clean["active"]
+                now = time.time()
                 try:
                     connection.execute(
                         "UPDATE gateway_accounts SET user_name = ?, active = ?, profile = ?, "
-                        "updated_at = MAX(updated_at, ?) WHERE account_id = ?",
-                        (clean["userName"], int(clean["active"]), json.dumps(clean), time.time(), account_id),
+                        "updated_at = MAX(updated_at, ?), "
+                        "token_valid_after = CASE WHEN ? THEN MAX(token_valid_after, ?) ELSE token_valid_after END "
+                        "WHERE account_id = ?",
+                        (
+                            clean["userName"],
+                            int(clean["active"]),
+                            json.dumps(clean),
+                            now,
+                            authority_changed,
+                            now,
+                            account_id,
+                        ),
                     )
                 except sqlite3.IntegrityError as error:
                     raise AccountConflictError from error

--- a/src/mindroom/mcp_gateway/accounts.py
+++ b/src/mindroom/mcp_gateway/accounts.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
     from mindroom.mcp_gateway.store import GatewayOAuthStore
 
+_EXTERNAL_CLOCK_SKEW_SECONDS = 60
+
 
 class AccountConflictError(Exception):
     """The exact provisioned user name already exists."""
@@ -173,14 +175,14 @@ class GatewayAccounts:
         return await self.store.transact(write)
 
     async def resolve_external(self, user_name: str, issued_at: float) -> str | None:
-        """Require exact active email and a JWT issued strictly after the durable cutoff."""
+        """Require exact active email and issue time beyond the cutoff plus bounded issuer skew."""
         if isinstance(issued_at, bool) or not isinstance(issued_at, (int, float)) or not math.isfinite(issued_at):
             return None
 
         def read(connection: sqlite3.Connection) -> str | None:
             row = connection.execute(
                 "SELECT account_id FROM gateway_accounts WHERE user_name = ? AND active = 1 AND token_valid_after < ?",
-                (user_name, issued_at),
+                (user_name, issued_at - _EXTERNAL_CLOCK_SKEW_SECONDS),
             ).fetchone()
             return row["account_id"] if row else None
 

--- a/src/mindroom/mcp_gateway/external_auth.py
+++ b/src/mindroom/mcp_gateway/external_auth.py
@@ -1,0 +1,249 @@
+"""Verify external signed MCP credentials without browser authentication fallback."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import re
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+import jwt
+from fastapi import HTTPException
+
+from mindroom.matrix.identity import try_parse_historical_matrix_user_id
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+    from mindroom.constants import RuntimePaths
+
+_ALGORITHMS = ("RS256", "ES256")
+_MAX_TOKEN_BYTES = 16384
+_KEY_CACHE_SECONDS = 60
+
+
+def _text(value: object, *, limit: int = 1024) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > limit
+        or value != value.strip()
+        or any(ord(char) < 32 or ord(char) == 127 or 0xD800 <= ord(char) <= 0xDFFF for char in value)
+    ):
+        msg = "Invalid external authentication text"
+        raise ValueError(msg)
+    return value
+
+
+def _https_url(value: str) -> None:
+    parsed = urlsplit(_text(value))
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+        or parsed.query
+        or parsed.port == 0
+        or any(char.isspace() for char in value)
+    ):
+        msg = "External authentication URLs must use HTTPS without credentials, queries or fragments"
+        raise ValueError(msg)
+
+
+@dataclass(frozen=True)
+class ExternalAuthSettings:
+    """One explicit external authority and its signed identity mapping."""
+
+    authorization_server: str
+    issuer: str
+    audience: str
+    jwks_url: str
+    token_header: str = "authorization"  # noqa: S105 -- header name, not a secret
+    email_claim: str = "email"
+    matrix_user_id_claim: str | None = None
+    email_to_matrix_user_id_template: str | None = None
+    email_domain: str | None = None
+    required_scopes: tuple[str, ...] = ()
+    client_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Reject incomplete or ambiguous external trust settings."""
+        for value in (self.authorization_server, self.issuer, self.jwks_url):
+            _https_url(value)
+        _text(self.audience)
+        _text(self.email_claim)
+        if self.client_id is not None:
+            _text(self.client_id)
+        if re.fullmatch(r"[!#$%&'*+.^_`|~0-9a-z-]+", self.token_header) is None:
+            msg = "Invalid external token header"
+            raise ValueError(msg)
+        template = self.email_to_matrix_user_id_template
+        if (self.matrix_user_id_claim is None) == (template is None):
+            msg = "Configure exactly one external Matrix identity claim or email template"
+            raise ValueError(msg)
+        if self.matrix_user_id_claim is not None:
+            _text(self.matrix_user_id_claim)
+        if template is not None:
+            _text(template)
+            if (
+                template.count("{localpart}") != 1
+                or "{" in template.replace("{localpart}", "")
+                or "}" in template.replace("{localpart}", "")
+                or try_parse_historical_matrix_user_id(template.replace("{localpart}", "example")) is None
+                or self.email_domain is None
+                or re.fullmatch(r"[A-Za-z0-9.-]+", self.email_domain) is None
+            ):
+                msg = "External email mapping requires a valid template and explicit email domain"
+                raise ValueError(msg)
+        elif self.email_domain is not None:
+            msg = "External email domain requires an email template"
+            raise ValueError(msg)
+        if any(re.fullmatch(r"[\x21\x23-\x5b\x5d-\x7e]+", scope) is None for scope in self.required_scopes):
+            msg = "Invalid external required scope"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_paths(cls, paths: RuntimePaths) -> ExternalAuthSettings | None:
+        """Read mode and validate all external settings before accepting requests."""
+        mode = paths.env_value("MINDROOM_MCP_AUTH_MODE", default="builtin")
+        if mode == "builtin":
+            return None
+        if mode != "external":
+            msg = "MINDROOM_MCP_AUTH_MODE must be builtin or external"
+            raise ValueError(msg)
+
+        def value(name: str, default: str | None = None) -> str | None:
+            return paths.env_value(f"MINDROOM_MCP_EXTERNAL_{name}", default=default) or None
+
+        return cls(
+            authorization_server=_text(value("AUTHORIZATION_SERVER")),
+            issuer=_text(value("ISSUER")),
+            audience=_text(value("AUDIENCE")),
+            jwks_url=_text(value("JWKS_URL")),
+            token_header=_text(value("TOKEN_HEADER", "authorization")).lower(),
+            email_claim=_text(value("EMAIL_CLAIM", "email")),
+            matrix_user_id_claim=value("MATRIX_USER_ID_CLAIM"),
+            email_to_matrix_user_id_template=value("EMAIL_TO_MATRIX_USER_ID_TEMPLATE"),
+            email_domain=value("EMAIL_DOMAIN"),
+            required_scopes=tuple((value("REQUIRED_SCOPES") or "").split()),
+            client_id=value("CLIENT_ID"),
+        )
+
+
+@dataclass(frozen=True)
+class ExternalIdentity:
+    """Verified claims plus a credential-specific admission and cancellation binding."""
+
+    subject: str
+    email: str
+    matrix_user_id: str
+    issued_at: float
+    token_digest: str
+
+
+class ExternalAuth:
+    """Check signed credentials with bounded, shared JWKS refresh work."""
+
+    def __init__(self, settings: ExternalAuthSettings) -> None:
+        self.settings = settings
+        self._client = jwt.PyJWKClient(settings.jwks_url, cache_jwk_set=False, timeout=5)
+        self._keys: list[jwt.PyJWK] = []
+        self._refresh_after = 0.0
+        self._lock = asyncio.Lock()
+
+    async def _signing_key(self, key_id: str, algorithm: str) -> jwt.PyJWK:
+        async with self._lock:
+            if time.monotonic() >= self._refresh_after:
+                self._refresh_after = time.monotonic() + _KEY_CACHE_SECONDS
+                self._keys = []
+                self._keys = await asyncio.to_thread(self._client.get_signing_keys, refresh=True)
+            matches = [key for key in self._keys if key.key_id == key_id and key.algorithm_name == algorithm]
+            if len(matches) != 1:
+                raise jwt.InvalidTokenError
+            return matches[0]
+
+    def _token(self, request: Request) -> str:
+        values = request.headers.getlist(self.settings.token_header)
+        if len(values) != 1 or len(values[0]) > _MAX_TOKEN_BYTES + 7:
+            msg = "Invalid external credential header"
+            raise ValueError(msg)
+        token = values[0]
+        if self.settings.token_header == "authorization":  # noqa: S105 -- header name
+            scheme, separator, token = token.partition(" ")
+            if not separator or scheme.lower() != "bearer":
+                msg = "Invalid external bearer credential"
+                raise ValueError(msg)
+        if (
+            len(token) > _MAX_TOKEN_BYTES
+            or re.fullmatch(r"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+", token) is None
+        ):
+            msg = "Invalid external JWT encoding"
+            raise ValueError(msg)
+        return token
+
+    async def verify(self, request: Request) -> ExternalIdentity:
+        """Return only verified identity; reject invalid credentials and missing scopes."""
+        try:
+            token = self._token(request)
+            header = jwt.get_unverified_header(token)
+            algorithm = header.get("alg")
+            if algorithm not in _ALGORITHMS or header.get("crit"):
+                raise jwt.InvalidTokenError
+            key = await self._signing_key(_text(header.get("kid")), algorithm)
+            claims = jwt.decode(
+                token,
+                key.key,
+                algorithms=list(_ALGORITHMS),
+                audience=self.settings.audience,
+                issuer=self.settings.issuer,
+                options={"require": ["iss", "aud", "exp", "iat", "sub"]},
+            )
+            now = time.time()
+            for name in claims.keys() & {"exp", "iat", "nbf"}:
+                value = claims[name]
+                if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+                    raise jwt.InvalidTokenError
+                if (name == "exp" and value <= now) or (name != "exp" and value > now):
+                    raise jwt.InvalidTokenError
+            subject = _text(claims["sub"])
+            if self.settings.client_id is not None and _text(claims.get("client_id")) != self.settings.client_id:
+                raise jwt.InvalidTokenError
+            email = _text(claims.get(self.settings.email_claim), limit=320)
+            if email.count("@") != 1 or any(char.isspace() for char in email):
+                raise jwt.InvalidTokenError
+            localpart, domain = email.split("@")
+            if not localpart or not domain:
+                raise jwt.InvalidTokenError
+            matrix_id = self._matrix_identity(claims, localpart, domain)
+        except (jwt.PyJWTError, ValueError, TypeError, OverflowError) as error:
+            raise HTTPException(status_code=401, detail="Invalid external MCP credential") from error
+        scope = claims.get("scope", "")
+        if not isinstance(scope, str) or not set(self.settings.required_scopes).issubset(scope.split()):
+            raise HTTPException(status_code=403, detail="Insufficient external MCP scope")
+        return ExternalIdentity(
+            subject,
+            email,
+            matrix_id,
+            float(claims["iat"]),
+            hashlib.sha256(token.encode()).hexdigest(),
+        )
+
+    def _matrix_identity(self, claims: dict[str, Any], localpart: str, domain: str) -> str:
+        if self.settings.matrix_user_id_claim is not None:
+            value = _text(claims.get(self.settings.matrix_user_id_claim))
+        else:
+            if (
+                domain.lower() != (self.settings.email_domain or "").lower()
+                or not self.settings.email_to_matrix_user_id_template
+            ):
+                raise jwt.InvalidTokenError
+            value = self.settings.email_to_matrix_user_id_template.replace("{localpart}", localpart)
+        matrix_id = try_parse_historical_matrix_user_id(value)
+        if matrix_id is None:
+            raise jwt.InvalidTokenError
+        return matrix_id

--- a/src/mindroom/mcp_gateway/external_auth.py
+++ b/src/mindroom/mcp_gateway/external_auth.py
@@ -220,7 +220,7 @@ class ExternalAuth:
             if not localpart or not domain:
                 raise jwt.InvalidTokenError
             matrix_id = self._matrix_identity(claims, localpart, domain)
-        except (jwt.PyJWTError, ValueError, TypeError, OverflowError) as error:
+        except (jwt.PyJWTError, ValueError, TypeError, OverflowError, RecursionError) as error:
             raise HTTPException(status_code=401, detail="Invalid external MCP credential") from error
         scope = claims.get("scope", "")
         if not isinstance(scope, str) or not set(self.settings.required_scopes).issubset(scope.split()):

--- a/tach.toml
+++ b/tach.toml
@@ -5023,6 +5023,7 @@ depends_on = [
     "mindroom.mcp_gateway.admission",
     "mindroom.mcp_gateway.accounts",
     "mindroom.mcp_gateway.consent",
+    "mindroom.mcp_gateway.external_auth",
     "mindroom.mcp_gateway.oauth",
     "mindroom.mcp_gateway.server",
     "mindroom.mcp_gateway.store",
@@ -5064,6 +5065,10 @@ depends_on = ["mindroom.mcp_gateway.accounts"]
 [[modules]]
 path = "mindroom.mcp_gateway.accounts"
 depends_on = []
+
+[[modules]]
+path = "mindroom.mcp_gateway.external_auth"
+depends_on = ["mindroom.matrix.identity"]
 
 [[modules]]
 path = "mindroom.mcp_gateway.lifecycle"

--- a/tests/api/test_mcp_external_auth.py
+++ b/tests/api/test_mcp_external_auth.py
@@ -6,10 +6,13 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
+from datetime import datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import jwt
@@ -19,6 +22,7 @@ from fastapi.testclient import TestClient
 
 from mindroom import agents
 from mindroom.api import config_lifecycle
+from mindroom.mcp_gateway import accounts, external_auth
 from mindroom.tool_system.worker_routing import get_tool_execution_identity
 from tests.api.test_api import _trusted_upstream_jwks, _trusted_upstream_jwt_key
 from tests.api.test_mcp_gateway_api import (
@@ -34,6 +38,7 @@ from tests.api.test_mcp_gateway_api import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
+    from datetime import tzinfo
 
     import httpx
     from fastapi import FastAPI
@@ -64,6 +69,22 @@ def _settings(app: FastAPI, **updates: str) -> None:
         snapshot.runtime_paths,
         process_env={**snapshot.runtime_paths.process_env, **updates},
     )
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Control account and JWT wall clocks without changing process time or sleeping."""
+    now = [time.time()]
+
+    class ClockDateTime(datetime):
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> datetime:
+            return datetime.fromtimestamp(now[0], tz=tz)
+
+    monkeypatch.setattr(accounts, "time", SimpleNamespace(time=lambda: now[0]))
+    monkeypatch.setattr(external_auth, "time", SimpleNamespace(time=lambda: now[0], monotonic=time.monotonic))
+    monkeypatch.setattr(jwt.api_jwt, "datetime", ClockDateTime)
+    return now
 
 
 @pytest.fixture
@@ -98,13 +119,20 @@ def external_client(external_app: FastAPI) -> Iterator[TestClient]:
 
 
 @pytest.fixture
-def credential(profile: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> Callable[..., dict[str, str]]:
+def credential(
+    profile: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch,
+    clock: list[float],
+) -> Callable[..., dict[str, str]]:
     """Sign real JWTs; only replace the remote JWKS wire response."""
     key = _trusted_upstream_jwt_key()
     keys = _trusted_upstream_jwks(key)
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _client: keys)
+    serial = 0
 
     def headers(user: str = "alice", **claims: object) -> dict[str, str]:
+        nonlocal serial
+        serial += 1
         token = jwt.encode(
             {
                 "iss": profile["issuer"],
@@ -112,8 +140,9 @@ def credential(profile: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> Call
                 "sub": f"{user}@example.org",
                 "email": f"{user}@example.org",
                 "matrix_user_id": f"@{user}:example.org",
-                "iat": time.time(),
-                "exp": time.time() + 300,
+                "iat": clock[0],
+                "exp": clock[0] + 300,
+                "jti": f"token-{serial}",
                 "scope": "mcp:tools",
                 **({"client_id": "registered-client"} if profile["header"] == "authorization" else {}),
                 **claims,
@@ -155,6 +184,7 @@ def _active(client: TestClient, path: str, *, active: bool) -> None:
 
 
 def test_external_metadata_and_scim_offboarding(
+    clock: list[float],
     external_client: TestClient,
     profile: dict[str, str],
     credential: Callable[..., dict[str, str]],
@@ -171,7 +201,9 @@ def test_external_metadata_and_scim_offboarding(
     }
     assert _list(client, credential()).status_code == 401
     alice_path = _provision(client, "alice")
+    clock[0] += 61
     _provision(client, "bob")
+    clock[0] += 61
     alice, bob = credential("alice"), credential("bob")
     for headers in (alice, bob):
         response = _list(client, headers)
@@ -195,12 +227,47 @@ def test_external_metadata_and_scim_offboarding(
     assert _list(client, alice).status_code == 401
     assert _list(client, bob).status_code == 200
     _active(client, alice_path, active=True)
+    clock[0] += 61
     assert _list(client, alice).status_code == 401
     assert _list(client, credential()).status_code == 200
     assert _list(client, bob).status_code == 200
 
 
+def test_issuer_ahead_token_cannot_revive_after_scim_reactivation(
+    external_app: FastAPI,
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    clock: list[float],
+) -> None:
+    """A pre-disable token dated 30 seconds ahead stays denied when gateway time catches up."""
+    path = _provision(external_client, "alice")
+    clock[0] += 61
+    start = clock[0]
+    admitted = credential()
+    assert _list(external_client, admitted).status_code == 200
+    clock[0] = start + 1
+    old = credential(iat=start + 31)
+    assert _list(external_client, old).status_code == 401
+    clock[0] = start + 2
+    _active(external_client, path, active=False)
+    assert _list(external_client, admitted).status_code == 401
+    clock[0] = start + 3
+    _active(external_client, path, active=True)
+    runtime = config_lifecycle.app_state(external_app).mcp_gateway_runtime
+    assert runtime is not None
+    with sqlite3.connect(runtime.provider.store.path) as connection:
+        assert connection.execute("SELECT token_valid_after FROM gateway_accounts").fetchone()[0] == start + 3
+    clock[0] = start + 32
+    assert _list(external_client, old).status_code == 401
+    clock[0] = start + 63
+    assert _list(external_client, credential()).status_code == 401
+    clock[0] = start + 64
+    assert _list(external_client, old).status_code == 401
+    assert _list(external_client, credential()).status_code == 200
+
+
 def test_external_cancellation_and_user_limit_span_tokens(
+    clock: list[float],
     external_app: FastAPI,
     credential: Callable[..., dict[str, str]],
     monkeypatch: pytest.MonkeyPatch,
@@ -234,7 +301,9 @@ def test_external_cancellation_and_user_limit_span_tokens(
     cancel = {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {"requestId": 7}}
     with TestClient(external_app, base_url=ORIGIN) as client, ThreadPoolExecutor(max_workers=1) as executor:
         _provision(client, "alice")
+        clock[0] += 61
         _provision(client, "bob")
+        clock[0] += 61
         alice, renewed, bob = credential(), credential(), credential("bob")
         assert alice != renewed
         pending = executor.submit(client.post, "/mcp", json=call, headers={**MCP_HEADERS, **alice})
@@ -254,6 +323,7 @@ def test_external_cancellation_and_user_limit_span_tokens(
 
 
 def test_external_native_tools_keep_requester_identity(
+    clock: list[float],
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
     monkeypatch: pytest.MonkeyPatch,
@@ -273,6 +343,7 @@ def test_external_native_tools_keep_requester_identity(
     )
     for user in ("alice", "bob"):
         _provision(external_client, user)
+        clock[0] += 61
         response = external_client.post(
             "/mcp",
             headers={
@@ -297,6 +368,7 @@ def test_external_native_tools_keep_requester_identity(
 
 @pytest.mark.parametrize("change", ["account", "issuer", "mode"])
 def test_external_security_change_between_admission_and_dispatch(
+    clock: list[float],
     external_app: FastAPI,
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
@@ -305,6 +377,7 @@ def test_external_security_change_between_admission_and_dispatch(
 ) -> None:
     """A committed account or authority change after HTTP admission stops provider execution."""
     path = _provision(external_client, "alice")
+    clock[0] += 61
     runtime = config_lifecycle.app_state(external_app).mcp_gateway_runtime
     assert runtime is not None
     authenticate = runtime.authenticate
@@ -381,6 +454,7 @@ def _assert_native_call_denied(client: TestClient, headers: dict[str, str], monk
 @pytest.mark.parametrize("phase", ["verify", "account"])
 @pytest.mark.parametrize("change", ["issuer", "mode"])
 def test_external_setting_change_during_dispatch_lookup(
+    clock: list[float],
     external_app: FastAPI,
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
@@ -390,6 +464,7 @@ def test_external_setting_change_during_dispatch_lookup(
 ) -> None:
     """Authority changes during dispatch awaits cannot bind old credentials to a new snapshot."""
     _provision(external_client, "alice")
+    clock[0] += 61
     runtime = config_lifecycle.app_state(external_app).mcp_gateway_runtime
     assert runtime is not None
     assert runtime.external_auth is not None
@@ -447,12 +522,14 @@ def test_builtin_mode_change_during_dispatch_token_lookup(
 
 
 def test_external_credentials_do_not_fall_back(
+    clock: list[float],
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
     profile: dict[str, str],
 ) -> None:
     """Owner, browser, wrong audience, and wrong token transport cannot acquire MCP authority."""
     _provision(external_client, "alice")
+    clock[0] += 61
     valid = credential()
     assert _list(external_client, valid).status_code == 200
     raw = next(iter(valid.values())).removeprefix("Bearer ")
@@ -481,12 +558,14 @@ def test_external_credentials_do_not_fall_back(
 
 
 def test_external_client_pin_isolates_shared_issuer(
+    clock: list[float],
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
     profile: dict[str, str],
 ) -> None:
     """Another signed client cannot impersonate a provisioned user through the pinned bearer profile."""
     _provision(external_client, "alice")
+    clock[0] += 61
     assert _list(external_client, credential()).status_code == 200
     other = credential(client_id="other-client", aud=[RESOURCE, "other-client"])
     response = _list(external_client, other)
@@ -539,6 +618,7 @@ def test_external_disables_local_issuer_and_client_controls(
     ],
 )
 def test_external_setting_changes_fail_closed(
+    clock: list[float],
     external_app: FastAPI,
     external_client: TestClient,
     credential: Callable[..., dict[str, str]],
@@ -547,6 +627,7 @@ def test_external_setting_changes_fail_closed(
 ) -> None:
     """Hot configuration changes cannot silently weaken or replace the pinned authority."""
     _provision(external_client, "alice")
+    clock[0] += 61
     headers = credential()
     assert _list(external_client, headers).status_code == 200
     _settings(external_app, **{setting: value})

--- a/tests/api/test_mcp_external_auth.py
+++ b/tests/api/test_mcp_external_auth.py
@@ -1,0 +1,561 @@
+"""External signed credentials use real SCIM, MCP transport, and personal tools."""
+
+# Shared gateway fixtures are intentionally shadowed by pytest injection.
+# ruff: noqa: F811
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import jwt
+import pytest
+from agno.tools import Toolkit
+from fastapi.testclient import TestClient
+
+from mindroom import agents
+from mindroom.api import config_lifecycle
+from mindroom.tool_system.worker_routing import get_tool_execution_identity
+from tests.api.test_api import _trusted_upstream_jwks, _trusted_upstream_jwt_key
+from tests.api.test_mcp_gateway_api import (
+    MCP_HEADERS,
+    ORIGIN,
+    RESOURCE,
+    _code,
+    _exchange,
+    gateway_app,  # noqa: F401
+    gateway_client,  # noqa: F401
+    signed_headers,  # noqa: F401
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    import httpx
+    from fastapi import FastAPI
+    from starlette.requests import Request
+
+    from mindroom.mcp_gateway.oauth import GatewayAccessToken
+    from mindroom.mcp_gateway.types import GatewayPrincipal
+
+SCIM = "/mcp/scim/v2/Users"
+SCIM_HEADERS = {"Authorization": "Bearer synthetic-provisioning-secret-for-local-tests"}
+USER_SCHEMA = "urn:ietf:params:scim:schemas:core:2.0:User"
+PATCH_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+PROFILES = [
+    {"issuer": "https://identity.example.org/", "server": "https://identity.example.org/", "header": "authorization"},
+    {"issuer": "https://edge.example.org", "server": "https://login.example.org/oauth", "header": "x-access-assertion"},
+]
+
+
+@pytest.fixture(params=PROFILES, ids=["bearer", "signed-assertion"])
+def profile(request: pytest.FixtureRequest) -> dict[str, str]:
+    """Exercise distinct OAuth issuers and origin assertion issuers."""
+    return request.param
+
+
+def _settings(app: FastAPI, **updates: str) -> None:
+    snapshot = config_lifecycle.require_api_state(app).snapshot
+    snapshot.runtime_paths = replace(
+        snapshot.runtime_paths,
+        process_env={**snapshot.runtime_paths.process_env, **updates},
+    )
+
+
+@pytest.fixture
+def external_app(gateway_app: FastAPI, profile: dict[str, str]) -> FastAPI:
+    """Configure the external authority before starting the common runtime."""
+    _settings(
+        gateway_app,
+        MINDROOM_MCP_AUTH_MODE="external",
+        MINDROOM_MCP_SCIM_TOKEN="synthetic-provisioning-secret-for-local-tests",  # noqa: S106
+        MINDROOM_MCP_EXTERNAL_AUTHORIZATION_SERVER=profile["server"],
+        MINDROOM_MCP_EXTERNAL_ISSUER=profile["issuer"],
+        MINDROOM_MCP_EXTERNAL_AUDIENCE=RESOURCE,
+        MINDROOM_MCP_EXTERNAL_CLIENT_ID="registered-client" if profile["header"] == "authorization" else "",
+        MINDROOM_MCP_EXTERNAL_JWKS_URL=profile["issuer"].rstrip("/") + "/jwks",
+        MINDROOM_MCP_EXTERNAL_TOKEN_HEADER=profile["header"],
+        MINDROOM_MCP_EXTERNAL_EMAIL_CLAIM="sub" if profile["header"] == "authorization" else "email",
+        MINDROOM_MCP_EXTERNAL_EMAIL_DOMAIN="example.org" if profile["header"] == "authorization" else "",
+        MINDROOM_MCP_EXTERNAL_EMAIL_TO_MATRIX_USER_ID_TEMPLATE="@{localpart}:example.org"
+        if profile["header"] == "authorization"
+        else "",
+        MINDROOM_MCP_EXTERNAL_MATRIX_USER_ID_CLAIM="matrix_user_id" if profile["header"] != "authorization" else "",
+        MINDROOM_MCP_EXTERNAL_REQUIRED_SCOPES="mcp:tools",
+    )
+    return gateway_app
+
+
+@pytest.fixture
+def external_client(external_app: FastAPI) -> Iterator[TestClient]:
+    """Run real production routes, SDK and durable account storage."""
+    with TestClient(external_app, base_url=ORIGIN, follow_redirects=False) as client:
+        yield client
+
+
+@pytest.fixture
+def credential(profile: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> Callable[..., dict[str, str]]:
+    """Sign real JWTs; only replace the remote JWKS wire response."""
+    key = _trusted_upstream_jwt_key()
+    keys = _trusted_upstream_jwks(key)
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _client: keys)
+
+    def headers(user: str = "alice", **claims: object) -> dict[str, str]:
+        token = jwt.encode(
+            {
+                "iss": profile["issuer"],
+                "aud": RESOURCE,
+                "sub": f"{user}@example.org",
+                "email": f"{user}@example.org",
+                "matrix_user_id": f"@{user}:example.org",
+                "iat": time.time(),
+                "exp": time.time() + 300,
+                "scope": "mcp:tools",
+                **({"client_id": "registered-client"} if profile["header"] == "authorization" else {}),
+                **claims,
+            },
+            key,
+            algorithm="RS256",
+            headers={"kid": keys["keys"][0]["kid"]},
+        )
+        return {profile["header"]: f"Bearer {token}" if profile["header"] == "authorization" else token}
+
+    return headers
+
+
+def _provision(client: TestClient, user: str) -> str:
+    response = client.post(
+        SCIM,
+        headers=SCIM_HEADERS,
+        json={"schemas": [USER_SCHEMA], "userName": f"{user}@example.org", "active": True},
+    )
+    assert response.status_code == 201, response.text
+    return SCIM + "/" + response.json()["id"]
+
+
+def _list(client: TestClient, headers: dict[str, str]) -> httpx.Response:
+    return client.post(
+        "/mcp",
+        headers={**MCP_HEADERS, **headers},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+
+
+def _active(client: TestClient, path: str, *, active: bool) -> None:
+    response = client.patch(
+        path,
+        headers=SCIM_HEADERS,
+        json={"schemas": [PATCH_SCHEMA], "Operations": [{"op": "replace", "path": "active", "value": active}]},
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_external_metadata_and_scim_offboarding(
+    external_client: TestClient,
+    profile: dict[str, str],
+    credential: Callable[..., dict[str, str]],
+) -> None:
+    """External discovery and committed SCIM changes govern every user's next MCP request."""
+    client = external_client
+    metadata = client.get("/.well-known/oauth-protected-resource/mcp")
+    assert metadata.status_code == 200
+    assert metadata.json() == {
+        "resource": RESOURCE,
+        "authorization_servers": [profile["server"]],
+        "scopes_supported": ["mcp:tools"],
+        "bearer_methods_supported": ["header"],
+    }
+    assert _list(client, credential()).status_code == 401
+    alice_path = _provision(client, "alice")
+    _provision(client, "bob")
+    alice, bob = credential("alice"), credential("bob")
+    for headers in (alice, bob):
+        response = _list(client, headers)
+        assert response.status_code == 200, response.text
+        assert {tool["name"] for tool in response.json()["result"]["tools"]} == {
+            "search_tools",
+            "get_tool",
+            "invoke_tool",
+        }
+    profile_update = client.patch(
+        alice_path,
+        headers=SCIM_HEADERS,
+        json={
+            "schemas": [PATCH_SCHEMA],
+            "Operations": [{"op": "replace", "path": "displayName", "value": "Alice Updated"}],
+        },
+    )
+    assert profile_update.status_code == 200
+    assert _list(client, alice).status_code == 200
+    _active(client, alice_path, active=False)
+    assert _list(client, alice).status_code == 401
+    assert _list(client, bob).status_code == 200
+    _active(client, alice_path, active=True)
+    assert _list(client, alice).status_code == 401
+    assert _list(client, credential()).status_code == 200
+    assert _list(client, bob).status_code == 200
+
+
+def test_external_cancellation_and_user_limit_span_tokens(
+    external_app: FastAPI,
+    credential: Callable[..., dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Another user or renewed JWT cannot cancel a call or bypass the shared user allowance."""
+    _settings(external_app, MINDROOM_MCP_GATEWAY_MAX_USER_CALLS="1")
+    started, release = threading.Event(), threading.Event()
+
+    async def account() -> str:
+        current = get_tool_execution_identity()
+        assert current is not None
+        if current.requester_id == "@alice:example.org":
+            started.set()
+            await asyncio.to_thread(release.wait)
+        return current.requester_id
+
+    monkeypatch.setattr(
+        agents,
+        "build_agent_toolkit",
+        lambda *_args, **_kwargs: Toolkit(name="calculator", tools=[account]),
+    )
+    call = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {
+            "name": "invoke_tool",
+            "arguments": {"toolkit": "calculator", "function": "account", "arguments": {}},
+        },
+    }
+    cancel = {"jsonrpc": "2.0", "method": "notifications/cancelled", "params": {"requestId": 7}}
+    with TestClient(external_app, base_url=ORIGIN) as client, ThreadPoolExecutor(max_workers=1) as executor:
+        _provision(client, "alice")
+        _provision(client, "bob")
+        alice, renewed, bob = credential(), credential(), credential("bob")
+        assert alice != renewed
+        pending = executor.submit(client.post, "/mcp", json=call, headers={**MCP_HEADERS, **alice})
+        try:
+            assert started.wait(10), "Native tool never started"
+            for headers in (bob, renewed):
+                assert client.post("/mcp", json=cancel, headers={**MCP_HEADERS, **headers}).status_code == 202
+            busy = client.post("/mcp", json={**call, "id": 8}, headers={**MCP_HEADERS, **renewed})
+            assert busy.json()["result"]["structuredContent"]["error"]["code"] == "busy"
+            assert not pending.done()
+            other = client.post("/mcp", json=call, headers={**MCP_HEADERS, **bob})
+            assert other.json()["result"]["structuredContent"] == {"result": "@bob:example.org"}
+            assert client.post("/mcp", json=cancel, headers={**MCP_HEADERS, **alice}).status_code == 202
+            assert pending.result(timeout=10).json()["result"]["structuredContent"]["error"]["code"] == "cancelled"
+        finally:
+            release.set()
+
+
+def test_external_native_tools_keep_requester_identity(
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real native dispatch carries signed owner identity despite spoofed unsigned headers."""
+
+    def identity() -> str:
+        current = get_tool_execution_identity()
+        assert current is not None
+        assert current.agent_name == "personal"
+        return current.requester_id
+
+    monkeypatch.setattr(
+        agents,
+        "build_agent_toolkit",
+        lambda *_args, **_kwargs: Toolkit(name="calculator", tools=[identity]),
+    )
+    for user in ("alice", "bob"):
+        _provision(external_client, user)
+        response = external_client.post(
+            "/mcp",
+            headers={
+                **MCP_HEADERS,
+                **credential(user),
+                "X-Trusted-User": "mallory",
+                "X-Trusted-Email": "mallory@example.org",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "invoke_tool",
+                    "arguments": {"toolkit": "calculator", "function": "identity", "arguments": {}},
+                },
+            },
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()["result"]["structuredContent"] == {"result": f"@{user}:example.org"}
+
+
+@pytest.mark.parametrize("change", ["account", "issuer", "mode"])
+def test_external_security_change_between_admission_and_dispatch(
+    external_app: FastAPI,
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    change: str,
+) -> None:
+    """A committed account or authority change after HTTP admission stops provider execution."""
+    path = _provision(external_client, "alice")
+    runtime = config_lifecycle.app_state(external_app).mcp_gateway_runtime
+    assert runtime is not None
+    authenticate = runtime.authenticate
+    executed: list[str] = []
+
+    async def disable_after_admission(request: Request) -> GatewayPrincipal:
+        principal = await authenticate(request)
+        if change == "account":
+            await asyncio.to_thread(_active, external_client, path, active=False)
+        elif change == "mode":
+            _settings(external_app, MINDROOM_MCP_AUTH_MODE="builtin")
+        else:
+            _settings(external_app, MINDROOM_MCP_EXTERNAL_ISSUER="https://changed.example.org")
+        return principal
+
+    def forbidden_tool() -> str:
+        executed.append("provider body")
+        return "unexpected result"
+
+    monkeypatch.setattr(runtime.server, "_authenticate", disable_after_admission)
+    monkeypatch.setattr(
+        agents,
+        "build_agent_toolkit",
+        lambda *_args, **_kwargs: Toolkit(name="calculator", tools=[forbidden_tool]),
+    )
+    response = external_client.post(
+        "/mcp",
+        headers={**MCP_HEADERS, **credential()},
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "invoke_tool",
+                "arguments": {"toolkit": "calculator", "function": "forbidden_tool", "arguments": {}},
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert not executed, "Provider body ran after a committed security change"
+    assert response.json()["result"]["structuredContent"]["error"]["code"] == "tool_unavailable"
+
+
+def _assert_native_call_denied(client: TestClient, headers: dict[str, str], monkeypatch: pytest.MonkeyPatch) -> None:
+    executed: list[str] = []
+
+    def account() -> str:
+        executed.append("provider body")
+        return "unexpected result"
+
+    monkeypatch.setattr(
+        agents,
+        "build_agent_toolkit",
+        lambda *_args, **_kwargs: Toolkit(name="calculator", tools=[account]),
+    )
+    response = client.post(
+        "/mcp",
+        headers={**MCP_HEADERS, **headers},
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "invoke_tool",
+                "arguments": {"toolkit": "calculator", "function": "account", "arguments": {}},
+            },
+        },
+    )
+    assert response.status_code == 200
+    assert not executed, "Provider body ran after a committed security change"
+    assert response.json()["result"]["structuredContent"]["error"]["code"] == "tool_unavailable"
+
+
+@pytest.mark.parametrize("phase", ["verify", "account"])
+@pytest.mark.parametrize("change", ["issuer", "mode"])
+def test_external_setting_change_during_dispatch_lookup(
+    external_app: FastAPI,
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    phase: str,
+    change: str,
+) -> None:
+    """Authority changes during dispatch awaits cannot bind old credentials to a new snapshot."""
+    _provision(external_client, "alice")
+    runtime = config_lifecycle.app_state(external_app).mcp_gateway_runtime
+    assert runtime is not None
+    assert runtime.external_auth is not None
+    target = runtime.external_auth if phase == "verify" else runtime.accounts
+    method = "verify" if phase == "verify" else "resolve_external"
+    lookup = getattr(target, method)
+    calls = 0
+
+    async def change_after_lookup(*args: object) -> object:
+        nonlocal calls
+        result = await lookup(*args)
+        calls += 1
+        if calls == 2:
+            state = config_lifecycle.require_api_state(external_app)
+            with state.config_lock:
+                snapshot = state.snapshot
+                updates = (
+                    {"MINDROOM_MCP_EXTERNAL_ISSUER": "https://changed.example.org"}
+                    if change == "issuer"
+                    else {"MINDROOM_MCP_AUTH_MODE": "builtin"}
+                )
+                paths = replace(snapshot.runtime_paths, process_env={**snapshot.runtime_paths.process_env, **updates})
+                state.snapshot = replace(snapshot, runtime_paths=paths, revision=snapshot.revision + 1)
+        return result
+
+    monkeypatch.setattr(target, method, change_after_lookup)
+    _assert_native_call_denied(external_client, credential(), monkeypatch)
+    assert calls == 2
+
+
+def test_builtin_mode_change_during_dispatch_token_lookup(
+    gateway_app: FastAPI,
+    gateway_client: TestClient,
+    signed_headers: Callable,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Built-in grants also fail closed when authentication mode changes during token lookup."""
+    client_id, code = _code(gateway_client, signed_headers("alice"))
+    token = _exchange(gateway_client, client_id, code).json()["access_token"]
+    runtime = config_lifecycle.app_state(gateway_app).mcp_gateway_runtime
+    assert runtime is not None
+    lookup = runtime.provider.load_access_token
+    calls = 0
+
+    async def change_after_lookup(raw: str) -> GatewayAccessToken | None:
+        nonlocal calls
+        result = await lookup(raw)
+        calls += 1
+        if calls == 2:
+            _settings(gateway_app, MINDROOM_MCP_AUTH_MODE="unknown")
+        return result
+
+    monkeypatch.setattr(runtime.provider, "load_access_token", change_after_lookup)
+    _assert_native_call_denied(gateway_client, {"Authorization": f"Bearer {token}"}, monkeypatch)
+
+
+def test_external_credentials_do_not_fall_back(
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    profile: dict[str, str],
+) -> None:
+    """Owner, browser, wrong audience, and wrong token transport cannot acquire MCP authority."""
+    _provision(external_client, "alice")
+    valid = credential()
+    assert _list(external_client, valid).status_code == 200
+    raw = next(iter(valid.values())).removeprefix("Bearer ")
+    wrong_transport = (
+        {"x-access-assertion": raw} if profile["header"] == "authorization" else {"Authorization": f"Bearer {raw}"}
+    )
+    for headers in (
+        {},
+        {"Authorization": "Bearer owner-key"},
+        {"Cookie": "session=alice"},
+        credential(aud="mindroom-dashboard"),
+        credential(aud="https://other.example.org/mcp"),
+        wrong_transport,
+        {"X-Trusted-User": "alice", "X-Trusted-Email": "alice@example.org"},
+    ):
+        response = _list(external_client, headers)
+        assert response.status_code == 401, response.text
+        assert (
+            f'resource_metadata="{ORIGIN}/.well-known/oauth-protected-resource/mcp"'
+            in response.headers["www-authenticate"]
+        )
+    denied = _list(external_client, credential(scope="profile"))
+    assert denied.status_code == 403
+    assert 'error="insufficient_scope"' in denied.headers["www-authenticate"]
+    assert 'scope="mcp:tools"' in denied.headers["www-authenticate"]
+
+
+def test_external_client_pin_isolates_shared_issuer(
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    profile: dict[str, str],
+) -> None:
+    """Another signed client cannot impersonate a provisioned user through the pinned bearer profile."""
+    _provision(external_client, "alice")
+    assert _list(external_client, credential()).status_code == 200
+    other = credential(client_id="other-client", aud=[RESOURCE, "other-client"])
+    response = _list(external_client, other)
+    assert response.status_code == (401 if profile["header"] == "authorization" else 200)
+
+
+def test_external_disables_local_issuer_and_client_controls(
+    external_client: TestClient,
+    signed_headers: Callable,
+) -> None:
+    """External mode cannot register, issue, consent to, or manage local client grants."""
+    for path in (
+        "/.well-known/oauth-authorization-server/mcp/oauth",
+        "/mcp/oauth/.well-known/oauth-authorization-server",
+        "/mcp/oauth/authorize",
+        "/connections/mcp/authorize",
+    ):
+        assert external_client.get(path, headers=signed_headers("alice")).status_code == 404
+    for path in (
+        "/mcp/oauth/register",
+        "/mcp/oauth/token",
+        "/mcp/oauth/revoke",
+        "/mcp/oauth/authorize",
+        "/connections/mcp/authorize",
+    ):
+        assert external_client.post(path, json={}, headers=signed_headers("alice")).status_code == 404
+    clients = "/api/connections/mcp/clients"
+    assert external_client.get(clients, headers=signed_headers("alice")).json() == {"enabled": False, "clients": []}
+    for suffix in ("/revoke-all", "/unknown/revoke"):
+        assert (
+            external_client.post(
+                clients + suffix,
+                json={},
+                headers={**signed_headers("alice"), "Origin": ORIGIN},
+            ).status_code
+            == 404
+        )
+
+
+@pytest.mark.parametrize(
+    ("setting", "value"),
+    [
+        ("MINDROOM_MCP_AUTH_MODE", "builtin"),
+        ("MINDROOM_MCP_AUTH_MODE", "unknown"),
+        ("MINDROOM_MCP_EXTERNAL_ISSUER", "https://changed.example.org"),
+        ("MINDROOM_MCP_EXTERNAL_AUDIENCE", "other-resource"),
+        ("MINDROOM_MCP_EXTERNAL_CLIENT_ID", "changed-client"),
+        ("MINDROOM_MCP_EXTERNAL_JWKS_URL", ""),
+        ("MINDROOM_MCP_SCIM_TOKEN", ""),
+    ],
+)
+def test_external_setting_changes_fail_closed(
+    external_app: FastAPI,
+    external_client: TestClient,
+    credential: Callable[..., dict[str, str]],
+    setting: str,
+    value: str,
+) -> None:
+    """Hot configuration changes cannot silently weaken or replace the pinned authority."""
+    _provision(external_client, "alice")
+    headers = credential()
+    assert _list(external_client, headers).status_code == 200
+    _settings(external_app, **{setting: value})
+    assert _list(external_client, headers).status_code == 404
+    assert external_client.get("/.well-known/oauth-protected-resource/mcp").status_code == 404
+
+
+def test_external_requires_scim_at_startup(external_app: FastAPI) -> None:
+    """External mode never starts with an optional or absent account gate."""
+    _settings(external_app, MINDROOM_MCP_SCIM_TOKEN="")
+    with TestClient(external_app, base_url=ORIGIN) as client:
+        assert client.get("/.well-known/oauth-protected-resource/mcp").status_code == 404

--- a/tests/test_mcp_gateway_accounts.py
+++ b/tests/test_mcp_gateway_accounts.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import mindroom.mcp_gateway.accounts as accounts_module
 from mindroom.mcp_gateway.accounts import AccountConflictError, GatewayAccounts
 from mindroom.mcp_gateway.store import GatewayOAuthStore
 
@@ -102,3 +103,63 @@ async def test_failed_mutation_rolls_back_profile_and_revocation(tmp_path: Path)
     with pytest.raises(AccountConflictError):
         await directory.replace(first["id"], {"userName": "bob@example.org", "active": False})
     assert await directory.resolve_active("alice@example.org") == first["id"]
+
+
+@pytest.mark.parametrize("operation", ["deactivate", "rename", "delete"])
+async def test_external_token_cannot_revive_after_account_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    """Subsecond account cutoffs reject old JWTs after rename, reactivation or recreation."""
+    now = [100.1]
+    monkeypatch.setattr(accounts_module.time, "time", lambda: now[0])
+    directory = _directory(tmp_path)
+    account = await directory.create({"userName": "Alice@example.org", "active": True})
+    assert await directory.resolve_external("Alice@example.org", 100.0) is None
+    assert await directory.resolve_external("Alice@example.org", 100.2) == account["id"]
+    assert await directory.resolve_external("alice@example.org", 100.2) is None
+    now[0] = 100.3
+    if operation == "delete":
+        await directory.delete(account["id"])
+        account = await directory.create({"userName": "Alice@example.org", "active": True})
+    else:
+        await directory.replace(
+            account["id"],
+            {
+                "userName": "other@example.org" if operation == "rename" else "Alice@example.org",
+                "active": operation != "deactivate",
+            },
+        )
+        await directory.replace(account["id"], {"userName": "Alice@example.org", "active": True})
+    assert await directory.resolve_external("Alice@example.org", 100.2) is None
+    assert await directory.resolve_external("Alice@example.org", 100.3) is None
+    assert await directory.resolve_external("Alice@example.org", 100.4) == account["id"]
+    assert "token_valid_after" not in account
+    reopened = _directory(tmp_path)
+    assert await reopened.resolve_external("Alice@example.org", 100.2) is None
+
+
+async def test_external_profile_update_preserves_access(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unrelated profile updates do not invalidate an existing signed credential."""
+    now = [100.1]
+    monkeypatch.setattr(accounts_module.time, "time", lambda: now[0])
+    directory = _directory(tmp_path)
+    account = await directory.create({"userName": "Alice@example.org", "active": True})
+    now[0] = 101.1
+    await directory.replace(account["id"], {"userName": "Alice@example.org", "active": True, "displayName": "New Name"})
+    assert await directory.resolve_external("Alice@example.org", 100.2) == account["id"]
+
+
+async def test_migration_does_not_revive_preexisting_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Adding a cutoff to a legacy account requires fresh credentials once, durably."""
+    directory = _directory(tmp_path)
+    account = await directory.create({"userName": "Alice@example.org", "active": True})
+    with sqlite3.connect(directory.store.path) as connection:
+        connection.execute("ALTER TABLE gateway_accounts DROP COLUMN token_valid_after")
+    monkeypatch.setattr(accounts_module.time, "time", lambda: 200.5)
+    migrated = _directory(tmp_path)
+    assert await migrated.resolve_external("Alice@example.org", 200.4) is None
+    assert await migrated.resolve_external("Alice@example.org", 200.6) == account["id"]
+    monkeypatch.setattr(accounts_module.time, "time", lambda: 201.5)
+    assert await _directory(tmp_path).resolve_external("Alice@example.org", 200.6) == account["id"]

--- a/tests/test_mcp_gateway_accounts.py
+++ b/tests/test_mcp_gateway_accounts.py
@@ -117,9 +117,10 @@ async def test_external_token_cannot_revive_after_account_change(
     directory = _directory(tmp_path)
     account = await directory.create({"userName": "Alice@example.org", "active": True})
     assert await directory.resolve_external("Alice@example.org", 100.0) is None
-    assert await directory.resolve_external("Alice@example.org", 100.2) == account["id"]
-    assert await directory.resolve_external("alice@example.org", 100.2) is None
-    now[0] = 100.3
+    assert await directory.resolve_external("Alice@example.org", 160.1) is None
+    assert await directory.resolve_external("Alice@example.org", 160.2) == account["id"]
+    assert await directory.resolve_external("alice@example.org", 160.2) is None
+    now[0] = 160.3
     if operation == "delete":
         await directory.delete(account["id"])
         account = await directory.create({"userName": "Alice@example.org", "active": True})
@@ -132,12 +133,12 @@ async def test_external_token_cannot_revive_after_account_change(
             },
         )
         await directory.replace(account["id"], {"userName": "Alice@example.org", "active": True})
-    assert await directory.resolve_external("Alice@example.org", 100.2) is None
-    assert await directory.resolve_external("Alice@example.org", 100.3) is None
-    assert await directory.resolve_external("Alice@example.org", 100.4) == account["id"]
+    assert await directory.resolve_external("Alice@example.org", 160.2) is None
+    assert await directory.resolve_external("Alice@example.org", 220.3) is None
+    assert await directory.resolve_external("Alice@example.org", 220.4) == account["id"]
     assert "token_valid_after" not in account
     reopened = _directory(tmp_path)
-    assert await reopened.resolve_external("Alice@example.org", 100.2) is None
+    assert await reopened.resolve_external("Alice@example.org", 160.2) is None
 
 
 async def test_external_profile_update_preserves_access(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,9 +147,9 @@ async def test_external_profile_update_preserves_access(tmp_path: Path, monkeypa
     monkeypatch.setattr(accounts_module.time, "time", lambda: now[0])
     directory = _directory(tmp_path)
     account = await directory.create({"userName": "Alice@example.org", "active": True})
-    now[0] = 101.1
+    now[0] = 161.1
     await directory.replace(account["id"], {"userName": "Alice@example.org", "active": True, "displayName": "New Name"})
-    assert await directory.resolve_external("Alice@example.org", 100.2) == account["id"]
+    assert await directory.resolve_external("Alice@example.org", 160.2) == account["id"]
 
 
 async def test_migration_does_not_revive_preexisting_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -160,6 +161,7 @@ async def test_migration_does_not_revive_preexisting_tokens(tmp_path: Path, monk
     monkeypatch.setattr(accounts_module.time, "time", lambda: 200.5)
     migrated = _directory(tmp_path)
     assert await migrated.resolve_external("Alice@example.org", 200.4) is None
-    assert await migrated.resolve_external("Alice@example.org", 200.6) == account["id"]
-    monkeypatch.setattr(accounts_module.time, "time", lambda: 201.5)
-    assert await _directory(tmp_path).resolve_external("Alice@example.org", 200.6) == account["id"]
+    assert await migrated.resolve_external("Alice@example.org", 260.5) is None
+    assert await migrated.resolve_external("Alice@example.org", 260.6) == account["id"]
+    monkeypatch.setattr(accounts_module.time, "time", lambda: 261.5)
+    assert await _directory(tmp_path).resolve_external("Alice@example.org", 260.6) == account["id"]

--- a/tests/test_mcp_gateway_external_auth.py
+++ b/tests/test_mcp_gateway_external_auth.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import time
 from dataclasses import replace
+from json.scanner import py_make_scanner  # ty: ignore[unresolved-import] -- stdlib Python scanner is absent from stubs
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import jwt
@@ -451,15 +454,26 @@ async def test_untrusted_algorithm_never_fetches_keys(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("parser", ["default", "python"])
 async def test_deeply_nested_payload_is_invalid_credential(
     settings: ExternalAuthSettings,
     signing_key: rsa.RSAPrivateKey,
     monkeypatch: pytest.MonkeyPatch,
+    parser: str,
 ) -> None:
     """Bounded but excessively nested signed JSON cannot escape credential rejection."""
     verifier = _verifier(settings, signing_key, monkeypatch)
     payload = b'{"nested":' + b"[" * 1200 + b"0" + b"]" * 1200 + b"}"
     token = PyJWS().encode(payload, signing_key, algorithm="RS256", headers={"kid": "key-1"})
+    assert len(token) <= 16384
+    if parser == "python":
+        decoder = json.JSONDecoder()
+        decoder.scan_once = py_make_scanner(decoder)
+        with pytest.raises(RecursionError):
+            decoder.decode(payload.decode())
+        monkeypatch.setattr(jwt.api_jwt, "json", SimpleNamespace(loads=lambda value: decoder.decode(value.decode())))
     with pytest.raises(HTTPException) as error:
         await verifier.verify(_request(token))
     assert error.value.status_code == 401
+    if parser == "python":
+        assert isinstance(error.value.__cause__, RecursionError)

--- a/tests/test_mcp_gateway_external_auth.py
+++ b/tests/test_mcp_gateway_external_auth.py
@@ -1,0 +1,465 @@
+"""External credentials require signed, audience-bound identity claims."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from fastapi import HTTPException
+from jwt.algorithms import ECAlgorithm, RSAAlgorithm
+from jwt.api_jws import PyJWS
+from starlette.requests import Request
+
+from mindroom.mcp_gateway.external_auth import ExternalAuth, ExternalAuthSettings
+from tests.conftest import test_runtime_paths as make_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+
+
+@pytest.fixture
+def runtime_paths(tmp_path: Path) -> RuntimePaths:
+    """Build isolated external authority settings inputs."""
+    return make_runtime_paths(tmp_path)
+
+
+@pytest.fixture
+def settings() -> ExternalAuthSettings:
+    """Use generic issuer and resource identities."""
+    return ExternalAuthSettings(
+        authorization_server="https://login.example.org/",
+        issuer="https://issuer.example.org/",
+        audience="https://tools.example.org/mcp",
+        jwks_url="https://issuer.example.org/keys",
+        matrix_user_id_claim="matrix_id",
+        required_scopes=("mcp:tools",),
+    )
+
+
+@pytest.fixture
+def signing_key() -> rsa.RSAPrivateKey:
+    """Create issuer signing material for real cryptographic verification."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture
+def claims() -> dict[str, Any]:
+    """Create live audience-bound access claims."""
+    return {
+        "iss": "https://issuer.example.org/",
+        "aud": "https://tools.example.org/mcp",
+        "sub": "user-123",
+        "email": "Alice@example.org",
+        "matrix_id": "@Alice:example.org",
+        "iat": time.time() - 1,
+        "exp": time.time() + 300,
+        "scope": "mcp:tools profile",
+    }
+
+
+def _token(signing_key: rsa.RSAPrivateKey, claims: dict[str, Any]) -> str:
+    return jwt.encode(claims, signing_key, algorithm="RS256", headers={"kid": "key-1"})
+
+
+def _request(token: str, header: str = "authorization") -> Request:
+    value = f"Bearer {token}" if header == "authorization" else token
+    return Request({"type": "http", "headers": [(header.encode(), value.encode())]})
+
+
+def _verifier(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    monkeypatch: pytest.MonkeyPatch,
+) -> ExternalAuth:
+    # Keep JWKS parsing and signature verification real; only replace remote key retrieval.
+    public_jwk = RSAAlgorithm.to_jwk(signing_key.public_key(), as_dict=True)
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _: {"keys": [{**public_jwk, "kid": "key-1"}]})
+    return ExternalAuth(settings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("header", ["authorization", "x-signed-assertion"])
+async def test_signed_identity_and_token_binding(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    header: str,
+) -> None:
+    """Both configured credential forms yield exact signed identity and token digest."""
+    verifier = _verifier(replace(settings, token_header=header), signing_key, monkeypatch)
+    token = _token(signing_key, claims)
+    identity = await verifier.verify(_request(token, header))
+    assert (identity.subject, identity.email, identity.matrix_user_id) == (
+        "user-123",
+        "Alice@example.org",
+        "@Alice:example.org",
+    )
+    assert identity.issued_at == claims["iat"]
+    assert identity.token_digest == hashlib.sha256(token.encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("claim", "value"),
+    [
+        ("iss", "https://other.example.org/"),
+        ("iss", "https://issuer.example.org"),
+        ("aud", "browser-client"),
+        ("exp", 1),
+        ("exp", "2000000000"),
+        ("exp", float("inf")),
+        ("iat", float("nan")),
+        ("iat", True),
+        ("iat", "1"),
+        ("iat", 9000000000),
+        ("nbf", float("inf")),
+        ("nbf", "1"),
+        ("nbf", 9000000000),
+        ("sub", ""),
+        ("sub", ["user-123"]),
+        ("email", "Alice"),
+        ("email", " Alice@example.org"),
+        ("email", "alice@@example.org"),
+        ("matrix_id", "@alice:invalid server"),
+    ],
+)
+async def test_invalid_claims_fail_closed(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    claim: str,
+    value: object,
+) -> None:
+    """Malformed identities and JWT NumericDates cannot bypass cryptographic admission."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(_token(signing_key, {**claims, claim: value})))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("claim", ["iss", "aud", "exp", "iat", "sub", "email", "matrix_id"])
+async def test_missing_required_claim(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    claim: str,
+) -> None:
+    """Every configured identity component must be present in the signed payload."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    claims.pop(claim)
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(_token(signing_key, claims)))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_missing_scope_is_forbidden(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A valid credential without required resource scope is forbidden."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    claims["scope"] = "profile"
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(_token(signing_key, claims)))
+    assert error.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_wrong_key_and_symmetric_signatures_rejected(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the configured asymmetric issuer keys authenticate requests."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    for token in [
+        _token(other, claims),
+        jwt.encode(claims, "untrusted-key-material-for-tests-only", algorithm="HS256"),
+    ]:
+        with pytest.raises(HTTPException) as error:
+            await verifier.verify(_request(token))
+        assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [],
+        [(b"authorization", b"Bearer a.b.c"), (b"authorization", b"Bearer a.b.c")],
+        [(b"authorization", b"Basic a.b.c")],
+        [(b"authorization", b"Bearer a.b.c, Bearer a.b.c")],
+        [(b"authorization", b"Bearer " + b"a" * 17000)],
+        [(b"x-user", b"Alice@example.org")],
+        [(b"authorization", b"Bearer a.b.c ")],
+        [(b"authorization", b"Bearer \xff.b.c")],
+    ],
+)
+async def test_malformed_headers_denied(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    monkeypatch: pytest.MonkeyPatch,
+    headers: list[tuple[bytes, bytes]],
+) -> None:
+    """Duplicate, malformed, missing and unbounded credentials never authenticate."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(Request({"type": "http", "headers": headers}))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("email_domain", ["example.org", "EXAMPLE.ORG"])
+async def test_explicit_email_mapping_and_subject_email(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    email_domain: str,
+) -> None:
+    """An explicitly trusted email subject can map to a Matrix identity."""
+    verifier = _verifier(
+        replace(
+            settings,
+            email_claim="sub",
+            matrix_user_id_claim=None,
+            email_to_matrix_user_id_template="@{localpart}:example.org",
+            email_domain=email_domain,
+        ),
+        signing_key,
+        monkeypatch,
+    )
+    claims["sub"] = "Alice@example.org"
+    claims.pop("email")
+    claims.pop("matrix_id")
+    assert (await verifier.verify(_request(_token(signing_key, claims)))).matrix_user_id == "@Alice:example.org"
+    claims["sub"] = "Alice@other.example.org"
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(_token(signing_key, claims)))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_unknown_keys_share_bounded_fetch(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent attacker-selected key IDs do not trigger per-token network requests."""
+    calls = []
+    public_jwk = RSAAlgorithm.to_jwk(signing_key.public_key(), as_dict=True)
+
+    def fetch(_: jwt.PyJWKClient) -> dict[str, Any]:
+        calls.append(1)
+        return {"keys": [{**public_jwk, "kid": "key-1"}]}
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fetch)
+    verifier = ExternalAuth(settings)
+    tokens = [jwt.encode(claims, signing_key, algorithm="RS256", headers={"kid": str(index)}) for index in range(12)]
+    results = await asyncio.gather(*(verifier.verify(_request(token)) for token in tokens), return_exceptions=True)
+    assert all(isinstance(result, HTTPException) and result.status_code == 401 for result in results)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_key_service_failure_is_cached_denial(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unavailable key service denies requests without repeated network work during backoff."""
+    calls = []
+
+    def fetch(_: jwt.PyJWKClient) -> dict[str, Any]:
+        calls.append(1)
+        msg = "unavailable"
+        raise jwt.PyJWKClientConnectionError(msg)
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fetch)
+    verifier = ExternalAuth(settings)
+    for _ in range(2):
+        with pytest.raises(HTTPException) as error:
+            await verifier.verify(_request(_token(signing_key, claims)))
+        assert error.value.status_code == 401
+    assert len(calls) == 1
+
+
+def _env(**updates: str) -> dict[str, str]:
+    return {
+        "MINDROOM_MCP_AUTH_MODE": "external",
+        **{
+            f"MINDROOM_MCP_EXTERNAL_{name}": value
+            for name, value in {
+                "AUTHORIZATION_SERVER": "https://login.example.org/",
+                "ISSUER": "https://issuer.example.org/",
+                "AUDIENCE": "https://tools.example.org/mcp",
+                "JWKS_URL": "https://issuer.example.org/keys",
+                "MATRIX_USER_ID_CLAIM": "matrix_id",
+                **updates,
+            }.items()
+        },
+    }
+
+
+def test_config_preserves_exact_issuer(runtime_paths: RuntimePaths) -> None:
+    """Issuer slash stays significant and browser credentials configure no MCP auth."""
+    assert ExternalAuthSettings.from_paths(replace(runtime_paths, process_env={}, env_file_values={})) is None
+    configured = ExternalAuthSettings.from_paths(replace(runtime_paths, process_env=_env()))
+    assert configured is not None
+    assert configured.issuer == "https://issuer.example.org/"
+    assert configured.authorization_server == "https://login.example.org/"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client_claim",
+    [
+        {},
+        {"client_id": None},
+        {"client_id": 123},
+        {"client_id": True},
+        {"client_id": ["registered-client"]},
+        {"client_id": {"id": "registered-client"}},
+        {"client_id": "other-client"},
+        {"client_id": "Registered-client"},
+    ],
+)
+async def test_client_pin_rejects_other_signed_clients(
+    runtime_paths: RuntimePaths,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    client_claim: dict[str, object],
+) -> None:
+    """Matching issuer, key, resource and user cannot replace the configured client binding."""
+    configured = ExternalAuthSettings.from_paths(
+        replace(runtime_paths, process_env=_env(CLIENT_ID="registered-client")),
+    )
+    assert configured is not None
+    verifier = _verifier(configured, signing_key, monkeypatch)
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(_token(signing_key, {**claims, **client_claim})))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_client_pin_accepts_exact_signed_client(
+    runtime_paths: RuntimePaths,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An issuer-owned exact client ID can restrict a shared signing authority."""
+    configured = ExternalAuthSettings.from_paths(
+        replace(runtime_paths, process_env=_env(CLIENT_ID="registered-client")),
+    )
+    assert configured is not None
+    verifier = _verifier(configured, signing_key, monkeypatch)
+    identity = await verifier.verify(_request(_token(signing_key, {**claims, "client_id": "registered-client"})))
+    assert identity.email == "Alice@example.org"
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"ISSUER": "http://issuer.example.org"},
+        {"JWKS_URL": "https://user:pass@example.org/keys"},
+        {"AUTHORIZATION_SERVER": "https://example.org/#fragment"},
+        {"AUDIENCE": ""},
+        {"CLIENT_ID": " registered-client"},
+        {"CLIENT_ID": "client\nvalue"},
+        {"CLIENT_ID": "x" * 1025},
+        {"TOKEN_HEADER": "bad header"},
+        {"MATRIX_USER_ID_CLAIM": ""},
+        {"EMAIL_TO_MATRIX_USER_ID_TEMPLATE": "@{localpart}:example.org"},
+        {"MATRIX_USER_ID_CLAIM": "", "EMAIL_TO_MATRIX_USER_ID_TEMPLATE": "@{other}:example.org"},
+    ],
+)
+def test_invalid_config_fails_closed(runtime_paths: RuntimePaths, updates: dict[str, str]) -> None:
+    """Partial or ambiguous external authority configuration cannot become built-in auth."""
+    with pytest.raises(ValueError, match=r"."):
+        ExternalAuthSettings.from_paths(replace(runtime_paths, process_env=_env(**updates)))
+
+
+@pytest.mark.asyncio
+async def test_es256_signing_key(
+    settings: ExternalAuthSettings,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An issuer using the allowed elliptic-curve algorithm also authenticates."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    public_jwk = ECAlgorithm.to_jwk(key.public_key(), as_dict=True)
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _: {"keys": [{**public_jwk, "kid": "ec-key"}]})
+    token = jwt.encode(claims, key, algorithm="ES256", headers={"kid": "ec-key"})
+    assert (await ExternalAuth(settings).verify(_request(token))).subject == "user-123"
+
+
+@pytest.mark.asyncio
+async def test_assertion_mode_has_no_bearer_fallback(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only one unambiguous signed assertion header authenticates in assertion mode."""
+    assertion_settings = replace(settings, token_header="x-signed-assertion")  # noqa: S106 -- header name
+    verifier = _verifier(assertion_settings, signing_key, monkeypatch)
+    token = _token(signing_key, claims)
+    requests = [_request(token), Request({"type": "http", "headers": [(b"x-signed-assertion", token.encode())] * 2})]
+    for request in requests:
+        with pytest.raises(HTTPException) as error:
+            await verifier.verify(request)
+        assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_untrusted_algorithm_never_fetches_keys(
+    settings: ExternalAuthSettings,
+    claims: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Symmetric credentials cannot spend JWKS network work before rejection."""
+
+    def fetch(_: jwt.PyJWKClient) -> dict[str, Any]:
+        pytest.fail("Untrusted algorithm fetched issuer keys")
+
+    monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", fetch)
+    token = jwt.encode(claims, "untrusted-key-material-for-tests-only", algorithm="HS256", headers={"kid": "key-1"})
+    with pytest.raises(HTTPException) as error:
+        await ExternalAuth(settings).verify(_request(token))
+    assert error.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_deeply_nested_payload_is_invalid_credential(
+    settings: ExternalAuthSettings,
+    signing_key: rsa.RSAPrivateKey,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded but excessively nested signed JSON cannot escape credential rejection."""
+    verifier = _verifier(settings, signing_key, monkeypatch)
+    payload = b'{"nested":' + b"[" * 1200 + b"0" + b"]" * 1200 + b"}"
+    token = PyJWS().encode(payload, signing_key, algorithm="RS256", headers={"kid": "key-1"})
+    with pytest.raises(HTTPException) as error:
+        await verifier.verify(_request(token))
+    assert error.value.status_code == 401


### PR DESCRIPTION
MCP clients can use a configured external authorization server instead of MindRoom's built-in OAuth issuer. External mode validates signed bearer tokens or signed proxy assertions, advertises the external server through MCP resource metadata, and checks the user's provisioned account and personal tool permissions on each request. Built-in OAuth remains the default.

SCIM disabling blocks the next request once committed. Creation and account authority changes require JWTs issued more than 60 seconds after the stored event cutoff, under an explicit bounded-clock contract; earlier credentials cannot regain access after reactivation within that contract. An optional pin to the issuer-owned `client_id` claim restricts credentials to the intended OAuth client. The change uses existing JWT dependencies and has no vendor-specific runtime code. Documentation covers signed proxy assertions, tenant isolation, and the boundary between local account disabling and issuer-owned refresh grants.

Validation:

- Full non-Matrix CI suite on the latest commit: 17,770 passed, 12 skipped.
- Targeted gateway regression suite after review fixes: 455 passed. Coverage includes auth-setting changes during asynchronous lookup, another signed client with matching resource and identity, issuer clock skew around reactivation, and nested JWT parser failures.
- `uv run pre-commit run --all-files` and `uv run tach check --dependencies --interfaces` passed.
- All 24 runnable checks passed, including four image builds and Kubernetes/Compose smoke tests. All five automated review findings are resolved; independent review found no remaining blocking issues.

Hosted login and SCIM delivery require acceptance testing with the intended service. Direct JumpCloud tokens are not recommended until the issuer-owned client and access-token identity claims are verified; JumpCloud can instead remain the IdP behind an OAuth-aware proxy. Local tests exercise real JWT signatures and MCP/SCIM HTTP flows using two generic issuer profiles.
