### PR TITLE
Give journal replay one ordering owner per room

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -91,6 +91,7 @@ Successful progress past the failed receipt resets that room's retry delay.
 Room admission and retry history remain alive while downstream responses own unsettled sources, including after the room lane exits.
 Retry handoffs carry their room ID and invalidate that room's current page synchronously, without waiting for a source lookup or affecting another room's progress.
 Fallback liveness checks rotate through a bounded batch; the periodic sweep yields between batches so a large backlog does not multiply probes for every callback or delay the next sweep by a full period per batch.
+Once scheduled, the sweep repeats while deferred owners remain, independently of discovery or lane completion.
 Silent owner loss invalidates room admission when the fallback detects it, through the same room wake used by explicit completion notifications.
 Shutdown cancels lane and retry owners without settling unfinished work, which remains available for startup recovery.
 Visible response paths persist `TurnStore` truth, while pure policy ignores, unmentioned managed senders, blocked deep synthetic relays, and commands owned by another entity settle their journal events directly instead of recording a turn.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -88,8 +88,10 @@ Callback and room-read failures pause only that room with exponential retry dela
 Revisiting an eligible receipt at or before the room's latest admitted receipt also starts a cooldown, preventing immediate downstream handoffs from trapping recovery in a retry loop.
 This receipt marker survives bounded page passes and resets when the cooldown ends, using constant memory per room.
 Successful progress past the failed receipt resets that room's retry delay.
-Downstream handoffs retain live ownership, while lost owners rewind the room's query before later callbacks run.
+Room admission and retry history remain alive while downstream responses own unsettled sources, including after the room lane exits.
 Retry handoffs carry their room ID and invalidate that room's current page synchronously, without waiting for a source lookup or affecting another room's progress.
+Fallback liveness checks rotate through a bounded batch; the periodic sweep yields between batches so a large backlog does not multiply probes for every callback or delay the next sweep by a full period per batch.
+Silent owner loss invalidates room admission when the fallback detects it, through the same room wake used by explicit completion notifications.
 Shutdown cancels lane and retry owners without settling unfinished work, which remains available for startup recovery.
 Visible response paths persist `TurnStore` truth, while pure policy ignores, unmentioned managed senders, blocked deep synthetic relays, and commands owned by another entity settle their journal events directly instead of recording a turn.
 This keeps ignored high-volume traffic out of the handled-turn ledger without weakening exact callback de-duplication.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -81,7 +81,13 @@ Operators can inspect growth by running `SELECT state, COUNT(*) FROM journal_eve
 Terminal rows must not be deleted unless duplicate callback execution after future Matrix redelivery is acceptable.
 Classic Sync tokens are opaque and may be invalidated, forcing a no-`since` sync whose limited timeline backfill can redeliver an older event, so there is no checkpoint-relative pruning frontier that preserves exact de-duplication.
 Successful and intentionally ignored callbacks settle explicitly, while failures and cancellations remain pending for direct startup recovery.
-Callback failures remain autonomously retry-owned with capped exponential backoff until they settle or deterministic corruption parks them for operator repair.
+Global journal scans discover rooms; a reserved room lane reads its own pending pages in receipt order.
+The journal query remains authoritative for replay eligibility, including approval continuations, and the global scan cursor never selects the next callback within a room.
+Each room retains its page position across bounded passes, and its continuation runs independently of global discovery.
+Callback and room-read failures pause only that room with exponential retry delays from one to thirty seconds; other rooms continue, and admissions or recovery drains cannot bypass the cooldown.
+Successful progress past the failed receipt resets that room's retry delay.
+Downstream handoffs retain live ownership, while lost owners and exact retry wakeups rewind the room's query before later callbacks run.
+Shutdown cancels lane and retry owners without settling unfinished work, which remains available for startup recovery.
 Visible response paths persist `TurnStore` truth, while pure policy ignores, unmentioned managed senders, blocked deep synthetic relays, and commands owned by another entity settle their journal events directly instead of recording a turn.
 This keeps ignored high-volume traffic out of the handled-turn ledger without weakening exact callback de-duplication.
 An in-memory claim loser waits for the competing owner, then yields to durable terminal truth or retries ingress when that owner exits without a terminal outcome.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -85,6 +85,8 @@ Global journal scans discover rooms; a reserved room lane reads its own pending 
 The journal query remains authoritative for replay eligibility, including approval continuations, and the global scan cursor never selects the next callback within a room.
 Each room retains its page position across bounded passes, and its continuation runs independently of global discovery.
 Callback and room-read failures pause only that room with exponential retry delays from one to thirty seconds; other rooms continue, and admissions or recovery drains cannot bypass the cooldown.
+Revisiting an eligible receipt at or before the room's latest admitted receipt also starts a cooldown, preventing immediate downstream handoffs from trapping recovery in a retry loop.
+This receipt marker survives bounded page passes and resets when the cooldown ends, using constant memory per room.
 Successful progress past the failed receipt resets that room's retry delay.
 Downstream handoffs retain live ownership, while lost owners rewind the room's query before later callbacks run.
 Retry handoffs carry their room ID and invalidate that room's current page synchronously, without waiting for a source lookup or affecting another room's progress.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -86,7 +86,8 @@ The journal query remains authoritative for replay eligibility, including approv
 Each room retains its page position across bounded passes, and its continuation runs independently of global discovery.
 Callback and room-read failures pause only that room with exponential retry delays from one to thirty seconds; other rooms continue, and admissions or recovery drains cannot bypass the cooldown.
 Successful progress past the failed receipt resets that room's retry delay.
-Downstream handoffs retain live ownership, while lost owners and exact retry wakeups rewind the room's query before later callbacks run.
+Downstream handoffs retain live ownership, while lost owners rewind the room's query before later callbacks run.
+Retry handoffs carry their room ID and invalidate that room's current page synchronously, without waiting for a source lookup or affecting another room's progress.
 Shutdown cancels lane and retry owners without settling unfinished work, which remains available for startup recovery.
 Visible response paths persist `TurnStore` truth, while pure policy ignores, unmentioned managed senders, blocked deep synthetic relays, and commands owned by another entity settle their journal events directly instead of recording a turn.
 This keeps ignored high-volume traffic out of the handled-turn ledger without weakening exact callback de-duplication.

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -42,7 +42,7 @@ _MatrixDeliveryResolver = Callable[[MatrixDelivery], Awaitable[str | None]]
 _ApprovalActionDeliveryResolver = Callable[[str, str], Awaitable[str | None]]
 _TransportSenderProvider = Callable[[], str | None]
 _SendingDeviceProvider = Callable[[], str | None]
-_ContinuationReadyHandler = Callable[[str, tuple[str, ...]], Awaitable[None] | None]
+_ContinuationReadyHandler = Callable[[str, str, tuple[str, ...]], Awaitable[None] | None]
 
 _STARTUP_RECOVERY_SCAN_PAGE = 256
 _DEADLINE_SWEEP_SECONDS = 60.0
@@ -745,9 +745,17 @@ class _ApprovalManager:
         )
 
     async def _wake_continuation(self, recorded: RecordedApprovalDecision) -> None:
-        if recorded.continuation_entity_name is None or self.continuation_ready is None:
+        if (
+            recorded.continuation_entity_name is None
+            or recorded.continuation_room_id is None
+            or self.continuation_ready is None
+        ):
             return
-        wake = self.continuation_ready(recorded.continuation_entity_name, recorded.source_event_ids)
+        wake = self.continuation_ready(
+            recorded.continuation_entity_name,
+            recorded.continuation_room_id,
+            recorded.source_event_ids,
+        )
         if wake is not None:
             await wake
 

--- a/src/mindroom/approval_response.py
+++ b/src/mindroom/approval_response.py
@@ -171,7 +171,7 @@ class ApprovalResponseCoordinator:
     runtime_paths: RuntimePaths
     store: PrincipalStore
     delivery_gateway: DeliveryGateway
-    retry_sources: Callable[[tuple[str, ...]], None]
+    retry_sources: Callable[[str, tuple[str, ...]], None]
 
     async def create(self, continuation: ApprovalContinuation) -> ApprovalContinuation:
         """Persist one born-bound paused run against its original sources."""
@@ -314,7 +314,7 @@ class ApprovalResponseCoordinator:
                 raise RuntimeError(failure_reason)
             continuation = refreshed
         if continuation.state == "ready":
-            self.retry_sources(continuation.source_event_ids)
+            self.retry_sources(continuation.room_id, continuation.source_event_ids)
 
     async def advance_pause(
         self,
@@ -386,7 +386,7 @@ class ApprovalResponseCoordinator:
             expected_runtime_generation=continuation.runtime_generation,
         )
         if failing is not None:
-            self.retry_sources(failing.source_event_ids)
+            self.retry_sources(failing.room_id, failing.source_event_ids)
         return failing
 
     async def fail_publication(self, approval_id: str, *, reason: str) -> ApprovalContinuation | None:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -70,7 +70,7 @@ class _ApprovalTransportBot(Protocol):
         thread_id: str,
     ) -> str | None: ...
 
-    def retry_approval_sources(self, source_event_ids: tuple[str, ...]) -> None: ...
+    def retry_approval_sources(self, room_id: str, source_event_ids: tuple[str, ...]) -> None: ...
 
 
 async def _offload_oversized_full_arguments(
@@ -154,12 +154,13 @@ class ApprovalMatrixTransport:
     async def _wake_continuation_sources(
         self,
         entity_name: str,
+        room_id: str,
         source_event_ids: tuple[str, ...],
     ) -> None:
         """Wake the exact owner after an atomic card decision makes work ready."""
         bot = self.bot_provider(entity_name)
         if bot is not None and bot.running:
-            bot.retry_approval_sources(source_event_ids)
+            bot.retry_approval_sources(room_id, source_event_ids)
 
     def _unavailable_entity_reason(self, entity_name: str) -> str | None:
         permanently_unavailable = (

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1066,9 +1066,9 @@ class AgentBot:
         """Return whether one canonical conversation target currently has an active turn."""
         return self._response_runner.has_active_response_for_target(target)
 
-    def retry_approval_sources(self, source_event_ids: tuple[str, ...]) -> None:
+    def retry_approval_sources(self, room_id: str, source_event_ids: tuple[str, ...]) -> None:
         """Release continuation-owned sources to the normal journal worker."""
-        self._journal_dispatcher.retry_turn_sources(source_event_ids)
+        self._journal_dispatcher.retry_turn_sources(room_id, source_event_ids)
 
     async def _emit_reaction_received_hooks(
         self,
@@ -2456,11 +2456,11 @@ class AgentBot:
     def _retry_failed_coalesced_dispatch(self, pending_events: tuple[PendingEvent, ...]) -> None:
         """Return failed gate sources to their exact durable callback owner."""
         for pending_event in pending_events:
-            self._retry_pending_dispatch_source(pending_event.event.event_id)
+            self._retry_pending_dispatch_source(pending_event.room.room_id, pending_event.event.event_id)
 
-    def _retry_pending_dispatch_source(self, source_event_id: str) -> None:
+    def _retry_pending_dispatch_source(self, room_id: str, source_event_id: str) -> None:
         """Return one undelivered source to its exact durable callback owner."""
-        self._journal_dispatcher.retry_turn_source(source_event_id)
+        self._journal_dispatcher.retry_turn_source(room_id, source_event_id)
 
     async def _settle_ignored_dispatch_source(self, source_event_id: str) -> None:
         """Settle one asynchronously normalized source that produced no dispatch payload."""

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -216,7 +216,7 @@ class CoalescingGate:
         dispatch_allowed_now: Callable[[CoalescingKey], bool] | None = None,
         timestamp_formatter: TimestampFormatter | None = None,
         on_dispatch_failure: Callable[[tuple[PendingEvent, ...]], None] | None = None,
-        on_undelivered_source: Callable[[str], None] | None = None,
+        on_undelivered_source: Callable[[str, str], None] | None = None,
         on_intentionally_ignored_source: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
         self._dispatch_turn = dispatch_turn
@@ -299,12 +299,12 @@ class CoalescingGate:
         """Release one lane slot that will not be admitted."""
         self._lanes.release(slot)
 
-    def _handle_undelivered_lane_source(self, source_event_id: str) -> None:
+    def _handle_undelivered_lane_source(self, room_id: str, source_event_id: str) -> None:
         """Return a source that left its lane without another live gate owner."""
         if self.has_pending_source_event(source_event_id):
             return
         if self._on_undelivered_source is not None:
-            self._on_undelivered_source(source_event_id)
+            self._on_undelivered_source(room_id, source_event_id)
 
     async def _handle_intentionally_ignored_lane_source(self, source_event_id: str) -> None:
         """Settle a source whose asynchronous readiness completed with no payload."""

--- a/src/mindroom/event_journal/approval_card_state.py
+++ b/src/mindroom/event_journal/approval_card_state.py
@@ -54,6 +54,7 @@ class RecordedApprovalDecision:
     recorded: bool
     continuation_ready: bool = False
     continuation_entity_name: str | None = None
+    continuation_room_id: str | None = None
     source_event_ids: tuple[str, ...] = ()
 
 

--- a/src/mindroom/event_journal/approvals.py
+++ b/src/mindroom/event_journal/approvals.py
@@ -390,6 +390,7 @@ def _resolve_continuation(
         recorded=True,
         continuation_ready=state is not None and state["state"] == "ready",
         continuation_entity_name=entity_name,
+        continuation_room_id=str(card["room_id"]),
         source_event_ids=tuple(str(row["event_id"]) for row in source_rows),
     )
 

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -954,6 +954,8 @@ def pending(
     principal_id: str,
     *,
     limit: int,
+    room_id: str | None = None,
+    event_id: str | None = None,
     after_receipt_order: int | None = None,
     runtime_generation: str = "unmanaged",
 ) -> PendingPage:
@@ -975,6 +977,8 @@ def pending(
         transaction,
         principal_id,
         limit=limit,
+        room_id=room_id,
+        event_id=event_id,
         after_receipt_order=after_receipt_order,
         runtime_generation=runtime_generation,
     )
@@ -986,6 +990,8 @@ def _pending_page(
     *,
     limit: int,
     after_receipt_order: int | None,
+    room_id: str | None = None,
+    event_id: str | None = None,
     kind: EventKind | None = None,
     runtime_generation: str = "unmanaged",
 ) -> PendingPage:
@@ -1000,6 +1006,8 @@ def _pending_page(
         transaction,
         principal_id,
         limit=limit,
+        room_id=room_id,
+        event_id=event_id,
         after_receipt_order=after_receipt_order,
         kind=kind,
         runtime_generation=runtime_generation,
@@ -1024,12 +1032,18 @@ def _pending_rows(
     *,
     limit: int,
     after_receipt_order: int | None,
+    room_id: str | None = None,
+    event_id: str | None = None,
     kind: EventKind | None = None,
     runtime_generation: str = "unmanaged",
 ) -> tuple[Row, ...]:
     """Return one raw page of pending rows, in receipt order."""
     cursor_clause = "" if after_receipt_order is None else " AND receipt_order > ?"
     cursor_params: tuple[object, ...] = () if after_receipt_order is None else (after_receipt_order,)
+    room_clause = "" if room_id is None else " AND events.room_id = ?"
+    room_params: tuple[object, ...] = () if room_id is None else (room_id,)
+    event_clause = "" if event_id is None else " AND events.event_id = ?"
+    event_params: tuple[object, ...] = () if event_id is None else (event_id,)
     kind_clause = "" if kind is None else " AND kind = ?"
     kind_params: tuple[object, ...] = () if kind is None else (kind.value,)
     continuation_joins = """
@@ -1075,11 +1089,11 @@ def _pending_rows(
         SELECT {_EVENT_JOURNAL_COLUMNS} FROM journal_events AS events
         {continuation_joins}
         WHERE events.principal_id = ? AND events.state = 'pending'
-          {continuation_clause}{kind_clause}{cursor_clause}
+          {continuation_clause}{kind_clause}{room_clause}{event_clause}{cursor_clause}
         ORDER BY events.receipt_order
         LIMIT ?
         """,  # noqa: S608 - a fixed column list and fixed clauses, not input
-        (principal_id, *continuation_params, *kind_params, *cursor_params, limit),
+        (principal_id, *continuation_params, *kind_params, *room_params, *event_params, *cursor_params, limit),
     )
 
 

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -955,7 +955,6 @@ def pending(
     *,
     limit: int,
     room_id: str | None = None,
-    event_id: str | None = None,
     after_receipt_order: int | None = None,
     runtime_generation: str = "unmanaged",
 ) -> PendingPage:
@@ -978,7 +977,6 @@ def pending(
         principal_id,
         limit=limit,
         room_id=room_id,
-        event_id=event_id,
         after_receipt_order=after_receipt_order,
         runtime_generation=runtime_generation,
     )
@@ -991,7 +989,6 @@ def _pending_page(
     limit: int,
     after_receipt_order: int | None,
     room_id: str | None = None,
-    event_id: str | None = None,
     kind: EventKind | None = None,
     runtime_generation: str = "unmanaged",
 ) -> PendingPage:
@@ -1007,7 +1004,6 @@ def _pending_page(
         principal_id,
         limit=limit,
         room_id=room_id,
-        event_id=event_id,
         after_receipt_order=after_receipt_order,
         kind=kind,
         runtime_generation=runtime_generation,
@@ -1033,7 +1029,6 @@ def _pending_rows(
     limit: int,
     after_receipt_order: int | None,
     room_id: str | None = None,
-    event_id: str | None = None,
     kind: EventKind | None = None,
     runtime_generation: str = "unmanaged",
 ) -> tuple[Row, ...]:
@@ -1042,8 +1037,6 @@ def _pending_rows(
     cursor_params: tuple[object, ...] = () if after_receipt_order is None else (after_receipt_order,)
     room_clause = "" if room_id is None else " AND events.room_id = ?"
     room_params: tuple[object, ...] = () if room_id is None else (room_id,)
-    event_clause = "" if event_id is None else " AND events.event_id = ?"
-    event_params: tuple[object, ...] = () if event_id is None else (event_id,)
     kind_clause = "" if kind is None else " AND kind = ?"
     kind_params: tuple[object, ...] = () if kind is None else (kind.value,)
     continuation_joins = """
@@ -1089,11 +1082,11 @@ def _pending_rows(
         SELECT {_EVENT_JOURNAL_COLUMNS} FROM journal_events AS events
         {continuation_joins}
         WHERE events.principal_id = ? AND events.state = 'pending'
-          {continuation_clause}{kind_clause}{room_clause}{event_clause}{cursor_clause}
+          {continuation_clause}{kind_clause}{room_clause}{cursor_clause}
         ORDER BY events.receipt_order
         LIMIT ?
         """,  # noqa: S608 - a fixed column list and fixed clauses, not input
-        (principal_id, *continuation_params, *kind_params, *room_params, *event_params, *cursor_params, limit),
+        (principal_id, *continuation_params, *kind_params, *room_params, *cursor_params, limit),
     )
 
 

--- a/src/mindroom/event_journal/schema.py
+++ b/src/mindroom/event_journal/schema.py
@@ -375,6 +375,11 @@ _INDEXES = (
     WHERE state = 'pending'
     """,
     """
+    CREATE INDEX IF NOT EXISTS journal_events_pending_room
+    ON journal_events (principal_id, room_id, receipt_order)
+    WHERE state = 'pending'
+    """,
+    """
     -- The replay guard asks whether one conversation holds newer unfinished
     -- work. `journal_events_pending` orders the principal's whole pending set
     -- by receipt, so answering from it means filtering every pending row in

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -196,6 +196,8 @@ class PrincipalStore:
         self,
         *,
         limit: int = _DEFAULT_PENDING_LIMIT,
+        room_id: str | None = None,
+        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
@@ -205,6 +207,8 @@ class PrincipalStore:
                 transaction,
                 self._principal_id,
                 limit=limit,
+                room_id=room_id,
+                event_id=event_id,
                 after_receipt_order=after_receipt_order,
                 runtime_generation=runtime_generation,
             ),

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -197,7 +197,6 @@ class PrincipalStore:
         *,
         limit: int = _DEFAULT_PENDING_LIMIT,
         room_id: str | None = None,
-        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
@@ -208,7 +207,6 @@ class PrincipalStore:
                 self._principal_id,
                 limit=limit,
                 room_id=room_id,
-                event_id=event_id,
                 after_receipt_order=after_receipt_order,
                 runtime_generation=runtime_generation,
             ),

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -83,6 +83,8 @@ class ReplayView(Protocol):
         self,
         *,
         limit: int = ...,
+        room_id: str | None = None,
+        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -84,7 +84,6 @@ class ReplayView(Protocol):
         *,
         limit: int = ...,
         room_id: str | None = None,
-        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:

--- a/src/mindroom/ingress_lanes.py
+++ b/src/mindroom/ingress_lanes.py
@@ -103,7 +103,7 @@ class IngressLanes:
         self,
         *,
         deliver: Callable[[LaneSlot, LaneDelivery, ReadyPendingEvent], Awaitable[None]],
-        on_undelivered_source: Callable[[str], None] | None = None,
+        on_undelivered_source: Callable[[str, str], None] | None = None,
         on_intentionally_ignored_source: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
         self._deliver = deliver
@@ -364,7 +364,7 @@ class IngressLanes:
         if callback is None or delivery.source_event_id is None:
             return
         try:
-            callback(delivery.source_event_id)
+            callback(delivery.key.room_id, delivery.source_event_id)
         except Exception:
             logger.exception(
                 "ingress_lane_undelivered_source_notification_failed",

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -364,14 +364,14 @@ class JournalDispatcher:
             raise RuntimeError(msg)
         await self.settle_intentionally_ignored_turn_sources((event.event_id,))
 
-    def retry_turn_source(self, event_id: str) -> None:
+    def retry_turn_source(self, room_id: str, event_id: str) -> None:
         """Return one undelivered turn source to the worker."""
-        self.retry_turn_sources((event_id,))
+        self.retry_turn_sources(room_id, (event_id,))
 
-    def retry_turn_sources(self, event_ids: tuple[str, ...]) -> None:
+    def retry_turn_sources(self, room_id: str, event_ids: tuple[str, ...]) -> None:
         """Return several undelivered turn sources to the worker."""
         self._release_sources(event_ids)
-        self._worker.wake(event_ids=event_ids)
+        self._worker.wake(room_id=room_id)
 
     def _release_sources(self, event_ids: tuple[str, ...]) -> None:
         """Release worker ownership and forget any deferred-reaction markers."""

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -371,7 +371,7 @@ class JournalDispatcher:
     def retry_turn_sources(self, event_ids: tuple[str, ...]) -> None:
         """Return several undelivered turn sources to the worker."""
         self._release_sources(event_ids)
-        self._worker.wake()
+        self._worker.wake(event_ids=event_ids)
 
     def _release_sources(self, event_ids: tuple[str, ...]) -> None:
         """Release worker ownership and forget any deferred-reaction markers."""

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -148,7 +148,7 @@ class JournalDispatcher:
         return await self._worker.wait_stopped(timeout_seconds=timeout_seconds)
 
     async def drain_once(self) -> int:
-        """Run everything currently pending to completion.
+        """Run currently eligible pending work, respecting room retry cooldowns.
 
         This is the explicit recovery entry point, so it releases turn replay.
         What it deliberately does not do is forget which sources are in flight.

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -398,14 +398,14 @@ class PendingEventWorker:
 
     def _schedule_room_retry(self, event: JournalEvent) -> None:
         """Keep each room's cooldown independent of admissions and other rooms."""
-        if self._stopped:
-            return
         logger.exception(
             "pending_event_failed",
             event_id=event.event_id,
             kind=event.kind.value,
             room_id=event.room_id,
         )
+        if self._stopped:
+            return
         room_id = event.room_id
         previous = self._room_retries.get(room_id)
         delay = (

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -1,14 +1,8 @@
-"""Turns committed journal events into semantic work.
+"""Discover rooms globally; let each reserved room lane own ordered replay.
 
-The journal decides what MindRoom owes. This decides when it runs. Nothing
-here is durable: a crash leaves every unsettled event exactly as pending as it
-was, which is why there is no ``running`` state to get stuck in.
-
-Every bound here is paired with a signal that more work remains. A pass that
-stops early — because a room is busy, because the scan hit its page budget, or
-because a lane failed — arranges to be woken again. A bound that silently drops
-the remainder is how durable work ends up abandoned while the process looks
-healthy.
+The journal owns durable work and replay eligibility. Discovery only finds
+rooms: its rotating cursor never decides which event in a room runs next.
+Each room keeps its own page position across bounded passes and cooldowns.
 """
 
 from __future__ import annotations
@@ -31,117 +25,72 @@ logger = get_logger(__name__)
 _INITIAL_RETRY_DELAY_SECONDS = 1.0
 _MAX_RETRY_DELAY_SECONDS = 30.0
 _BATCH_SIZE = 128
-# How long a deferral may sit before the worker looks at its owner again.
-#
-# This is a cadence, not a deadline. Nothing is declared dead because this
-# elapsed; the probe decides, and it is exact. So the value does not have to
-# exceed the longest legitimate turn the way a death timeout would — it only
-# bounds how long a lost owner goes unnoticed in a bot quiet enough that no
-# admission wakes the pump on its own.
-_DEFERRAL_SCAN_SECONDS = 30.0
-# How many pages one pass will read looking for events it can act on. Each is
-# bounded in rows by the store, so this bounds the pass in rows too. Reached
-# only when a very large backlog is in flight, or when a long stretch of it
-# cannot be read; either way the pass reports that more remains.
 _MAX_SCAN_PAGES = 16
+_DEFERRAL_SCAN_SECONDS = 30.0
 
-# Returning ``False`` means the handler started work that outlives it — a turn
-# that is still running — so the event stays pending and whoever owns that work
-# releases it. Returning ``True`` means the work is finished.
 type _EventHandler = Callable[[JournalEvent], Awaitable[bool]]
-
-# Whether the owner a deferring handler handed one event to still exists.
 type _DeferralLivenessProbe = Callable[[JournalEvent], bool]
 
 
-def _in_receipt_order(by_room: dict[str, list[JournalEvent]]) -> dict[str, list[JournalEvent]]:
-    """Put each room's collected events back into receipt order.
-
-    A lane runs its list verbatim, so the list is where a room's order is
-    decided -- and a collected list is segments concatenated, none of which is
-    placed by receipt order. Reclaimed deferrals are seeded before any page is
-    read, whatever their position in the backlog, and a wrapped pass reads the
-    events after its resume point before the ones in front of it. Either one
-    hands a lane a later message to answer before an earlier one, which is the
-    single thing a lane exists to prevent.
-
-    Sorted rather than merged, because there are not two ordered runs to merge.
-    Only the pages carry the store's ``ORDER BY``; the reclaim walks the
-    deferral map in insertion order, and an event released and deferred again
-    moves to the back of it, behind one that never moved. Sorting also costs
-    nothing to state: these lists are near-sorted and bounded by the page
-    budget, which is the case a sort is cheapest on.
-    """
-    for events in by_room.values():
-        events.sort(key=lambda event: event.receipt_order)
-    return by_room
-
-
 def _assume_owner_is_live(event: JournalEvent) -> bool:
-    """Treat every deferral as owned, which is all a worker alone can know.
-
-    ``pending`` conflates "never started" with "started, someone else owns it",
-    and only the caller that handed the event off can tell them apart. A worker
-    built without a probe therefore has to believe the handoff, exactly as it
-    did before probes existed. The opposite default would re-dispatch every
-    deferral on every scan.
-    """
+    """A worker without an owner probe must honor every deferred handoff."""
     del event
     return True
 
 
 @dataclass
+class _RoomProgress:
+    """The lane advances its cursor; outside notifications only request rewinds."""
+
+    cursor: int | None = None
+    rewind_before: int | None = None
+
+
+@dataclass
 class _RoomRetry:
-    """One room's failure history and independently owned cooldown."""
+    """Cooldown history; the failed receipt controls reset, never admission."""
 
     delay_seconds: float
     task: asyncio.Task[None]
-    event: JournalEvent
+    failed_receipt_order: int | None
+
+
+@dataclass(frozen=True)
+class _RoomPass:
+    """A drain observes this completed pass without borrowing its lane."""
+
+    attempted: int
+    more: bool = False
+    failed: bool = False
 
 
 @dataclass
 class PendingEventWorker:
-    """Drain pending journal events, in receipt order within each room.
-
-    Order is preserved per room rather than globally. A room's events are a
-    conversation and must be answered in the order they were received; two
-    different rooms are unrelated, and making one wait for the other would let
-    a single slow turn stall every other conversation the bot is in.
-    """
+    """Run one ordered lane per room while keeping unsettled work durable."""
 
     store: ReplayView
     handle: _EventHandler
     runtime_generation: str = "unmanaged"
-    # Asked about every deferred event on every scan. A deferral whose owner is
-    # gone is durable work nobody is left to release, so the scan takes it back
-    # rather than waiting for a restart to notice.
     deferral_is_live: _DeferralLivenessProbe = _assume_owner_is_live
     deferral_scan_seconds: float = _DEFERRAL_SCAN_SECONDS
-    _lanes: dict[str, asyncio.Task[None]] = field(default_factory=dict, init=False, repr=False)
+    _lanes: dict[str, asyncio.Task[_RoomPass]] = field(default_factory=dict, init=False, repr=False)
+    _rooms: dict[str, _RoomProgress] = field(default_factory=dict, init=False, repr=False)
+    _ready_rooms: set[str] = field(default_factory=set, init=False, repr=False)
+    _retry_sources: set[str] = field(default_factory=set, init=False, repr=False)
+    _room_retries: dict[str, _RoomRetry] = field(default_factory=dict, init=False, repr=False)
+    _deferred: dict[str, JournalEvent] = field(default_factory=dict, init=False, repr=False)
     _wake: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
     _pump: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _retry: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _deferral_scan: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    _retry_delay_seconds: float = field(default=_INITIAL_RETRY_DELAY_SECONDS, init=False, repr=False)
+    _scan_cursor: int | None = field(default=None, init=False, repr=False)
     _stopped: bool = field(default=False, init=False, repr=False)
     _process_shutdown: bool = field(default=False, init=False, repr=False)
     _stop_generation: int = field(default=0, init=False, repr=False)
-    _retry_delay_seconds: float = field(default=_INITIAL_RETRY_DELAY_SECONDS, init=False, repr=False)
-    _room_retries: dict[str, _RoomRetry] = field(default_factory=dict, init=False, repr=False)
-    # Events handed to a turn that is still running, kept whole rather than by
-    # id. They stay pending durably so a crash replays them, but dispatching
-    # one again while its turn is alive would answer the same message twice --
-    # and asking whether that turn still exists is a question about this set,
-    # not about wherever the scan's window currently sits.
-    _deferred: dict[str, JournalEvent] = field(default_factory=dict, init=False, repr=False)
-    # Rooms a pass found work for but could not dispatch, because their lane
-    # was still busy. Their lane wakes the pump when it finishes.
-    _rooms_with_more: set[str] = field(default_factory=set, init=False, repr=False)
-    # Where the next bounded scan resumes, so a prefix of events this worker
-    # cannot act on cannot spend the whole page budget on every pass.
-    _scan_cursor: int | None = field(default=None, init=False, repr=False)
 
     def start(self) -> None:
-        """Begin draining, including anything a previous process left behind."""
+        """Start discovery, including work left pending by a previous process."""
         if self._pump is not None and not self._pump.done():
             return
         self._stopped = False
@@ -149,20 +98,22 @@ class PendingEventWorker:
         self._wake.set()
         self._pump = asyncio.create_task(self._run(), name="pending_event_worker")
 
-    def wake(self) -> None:
-        """Signal that new work was admitted."""
+    def wake(self, *, event_ids: tuple[str, ...] = ()) -> None:
+        """Signal admissions or exact sources made replayable by an owner handoff."""
+        self._retry_sources.update(event_ids)
         self._wake.set()
 
     def release(self, event_ids: Iterable[str]) -> None:
-        """Let events be dispatched again: their turn ended or is being retried.
+        """Forget downstream ownership after its durable handoff.
 
-        Callable from any thread, because a turn can become terminal on one.
-        It only mutates memory; the pump does the I/O on its own loop.
+        This remains an in-memory operation callable from terminal handoffs.
+        A retry additionally calls wake with the exact source IDs, allowing
+        replay to rewind even after an approval source left this cache.
         """
         for event_id in event_ids:
             self._deferred.pop(event_id, None)
 
-    def _owned_tasks(self) -> tuple[asyncio.Task[None], ...]:
+    def _owned_tasks(self) -> tuple[asyncio.Task[object], ...]:
         return tuple(
             task
             for task in (
@@ -177,11 +128,11 @@ class PendingEventWorker:
 
     @property
     def pending_task_count(self) -> int:
-        """Count callback and pump owners that still require runtime resources."""
+        """Count owners that still require runtime resources."""
         return sum(not task.done() for task in self._owned_tasks())
 
     def begin_shutdown(self, *, shutdown_intent: RuntimeShutdownIntent = GENERIC_SHUTDOWN) -> None:
-        """Close admission and mark every cancellation before teardown can yield."""
+        """Close admission and mark cancellations before teardown can yield."""
         process_shutdown = shutdown_intent.stop_reason == "shutdown"
         if self._stopped and (not process_shutdown or self._process_shutdown):
             return
@@ -198,7 +149,7 @@ class PendingEventWorker:
                 )
 
     async def wait_stopped(self, *, timeout_seconds: float | None) -> bool:
-        """Wait within the caller's budget, retaining any unfinished owners."""
+        """Retain unfinished owners when the caller's shutdown budget expires."""
         tasks = self._owned_tasks()
         if tasks:
             done, pending = await asyncio.wait(tasks, timeout=timeout_seconds)
@@ -211,89 +162,133 @@ class PendingEventWorker:
         self._retry = None
         self._deferral_scan = None
         self._lanes.clear()
+        self._rooms.clear()
+        self._ready_rooms.clear()
+        self._retry_sources.clear()
         self._room_retries.clear()
-        self._rooms_with_more.clear()
+        self._scan_cursor = None
         return True
 
     async def stop(self) -> None:
-        """Stop draining, leaving unfinished events pending for the next start."""
+        """Stop owners without settling their unfinished journal work."""
         self.begin_shutdown()
         await self.wait_stopped(timeout_seconds=None)
 
-    async def drain_once(self) -> int:
-        """Run currently eligible events and return the count, skipping room cooldowns.
+    def _queue_room(self, room_id: str, *, rewind_before: int | None = None) -> None:
+        progress = self._rooms.setdefault(room_id, _RoomProgress())
+        if rewind_before is not None:
+            previous = progress.rewind_before
+            progress.rewind_before = rewind_before if previous is None else min(previous, rewind_before)
+        self._ready_rooms.add(room_id)
 
-        Exists for startup recovery and for tests, where "the queue is empty"
-        has to be observable rather than eventually true. Unlike a pump pass,
-        this keeps scanning until nothing dispatchable is left, so its return
-        value is the whole backlog rather than one bounded slice of it.
+    async def _resolve_retry_sources(self) -> None:
+        """Resolve exact handoffs through the same replay policy as room reads."""
+        generation = self._stop_generation
+        failed = False
+        for event_id in tuple(self._retry_sources)[:_BATCH_SIZE]:
+            # Remove before awaiting: another wake for this ID during the read
+            # is a new obligation, including when this snapshot still says waiting.
+            self._retry_sources.discard(event_id)
+            try:
+                page = await self.store.pending(
+                    event_id=event_id,
+                    limit=1,
+                    runtime_generation=self.runtime_generation,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if self._stopped or generation != self._stop_generation:
+                    return
+                logger.exception("pending_event_retry_source_read_failed", event_id=event_id)
+                self._retry_sources.add(event_id)
+                failed = True
+                continue
+            if self._stopped or generation != self._stop_generation:
+                return
+            for event in page:
+                self._queue_room(event.room_id, rewind_before=event.receipt_order - 1)
+        if failed:
+            self._schedule_retry()
+        elif self._retry_sources:
+            self._wake.set()
 
-        Recovery runs while the pump is live rather than only before it starts,
-        so this drains through the room's lane instead of beside it. A second
-        lane over one room is not a faster drain: it puts two handlers inside
-        one event and lets event three overtake event two, which are the two
-        things a lane exists to make impossible.
+    def _queue_lost_owners(self) -> None:
+        """Probe globally, but leave reclamation to the room's reserved owner."""
+        for event in tuple(self._deferred.values()):
+            if not self.deferral_is_live(event):
+                self._queue_room(event.room_id)
 
-        It scans the whole backlog from the front and owns no resume point, and
-        both halves of that matter. Borrowing the pump's bounded, rotating
-        window gave consecutive passes different slices, so the comparison that
-        ends this loop -- the same events came back untouched -- could not
-        converge on a backlog larger than one pass with anything in it that
-        keeps failing: the drain never returned, and every later recovery for
-        every bot queued behind the one that was still going. Borrowing the
-        pump's cursor also moved it, so a drain rewound the pump's position or
-        skipped it forward past work the pump had not looked at yet.
-        """
-        drained = 0
-        attempted: frozenset[str] = frozenset()
-        stop_generation = self._stop_generation
-        while not self._stopped and stop_generation == self._stop_generation:
-            by_room = await self._collect_whole_backlog()
-            if self._stopped or stop_generation != self._stop_generation:
-                return drained
-            if not by_room:
-                return drained
-            ids = frozenset(event.event_id for events in by_room.values() for event in events)
-            if ids == attempted:
-                # Nothing moved: every remaining event failed or was refused.
-                # Looping again would only repeat the same failures forever.
-                return drained
-            attempted = ids
-            drained += len(ids)
-            await asyncio.gather(
-                *(
-                    self._drain_room(room_id, events, stop_generation=stop_generation)
-                    for room_id, events in by_room.items()
-                ),
+    async def _discover_rooms(self, *, whole_backlog: bool = False) -> tuple[set[str], bool]:
+        """Find rooms without passing global scan slices to their lanes."""
+        rooms: set[str] = set()
+        origin = None if whole_backlog else self._scan_cursor
+        cursor = origin
+        wrapped = origin is None
+        pages = 0
+        while whole_backlog or pages < _MAX_SCAN_PAGES:
+            page = await self.store.pending(
+                limit=_BATCH_SIZE,
+                after_receipt_order=cursor,
+                runtime_generation=self.runtime_generation,
             )
-        return drained
+            pages += 1
+            reached_origin = False
+            for event in page:
+                if wrapped and origin is not None and event.receipt_order > origin:
+                    reached_origin = True
+                    break
+                if event.event_id not in self._deferred:
+                    rooms.add(event.room_id)
+            if reached_origin or (page.reached_end and wrapped):
+                if not whole_backlog:
+                    self._scan_cursor = None
+                return rooms, False
+            if page.reached_end:
+                cursor, wrapped = None, True
+            else:
+                cursor = page.resume_after
+        self._scan_cursor = cursor
+        return rooms, True
 
-    async def _drain_room(
-        self,
-        room_id: str,
-        events: list[JournalEvent],
-        *,
-        stop_generation: int,
-    ) -> None:
-        """Run one room's events, once whatever lane owns that room is done.
+    async def drain_once(self) -> int:
+        """Drain eligible room work through the same owners, without waiting out cooldowns."""
+        generation = self._stop_generation
+        if self._stopped:
+            return 0
+        await self._resolve_retry_sources()
+        if self._stopped or generation != self._stop_generation:
+            return 0
+        rooms, _more = await self._discover_rooms(whole_backlog=True)
+        if self._stopped or generation != self._stop_generation:
+            return 0
+        self._queue_lost_owners()
+        rooms.update(self._ready_rooms)
+        return sum(
+            await asyncio.gather(
+                *(self._drain_room(room_id, stop_generation=generation) for room_id in rooms),
+            ),
+        )
 
-        Rechecked after each wait because the pump wakes on the same lane
-        completion, so the room can be claimed again before this resumes.
-        Someone else's lane is waited on rather than awaited: whether that one
-        was cancelled is the pump's business, and a drain must not inherit it.
-        """
-        while (active := self._lanes.get(room_id)) is not None and not active.done():
-            await asyncio.wait([active])
-        if self._stopped or stop_generation != self._stop_generation:
-            return
-        lane = self._start_lane(room_id, events)
-        if lane is None:
-            return
-        await asyncio.wait([lane])
-        # This lane is the drain's own, so whatever ended it is the drain's to
-        # report. A cancelled turn is not a failed one: it leaves its event
-        # pending and hands the cancellation to whoever asked for the drain.
-        lane.result()
+    async def _drain_room(self, room_id: str, *, stop_generation: int) -> int:
+        attempted = 0
+        while not self._stopped and stop_generation == self._stop_generation:
+            active = self._lanes.get(room_id)
+            if active is not None and not active.done():
+                await asyncio.wait([active])
+                continue
+            if self._room_is_backing_off(room_id):
+                return attempted
+            self._queue_room(room_id)
+            lane = self._start_lane(room_id)
+            if lane is None:
+                return attempted
+            await asyncio.wait([lane])
+            outcome = lane.result()
+            attempted += outcome.attempted
+            if outcome.failed or (not outcome.more and room_id not in self._ready_rooms):
+                return attempted
+        return attempted
 
     async def _run(self) -> None:
         while True:
@@ -308,157 +303,204 @@ class PendingEventWorker:
                 self._schedule_retry()
 
     async def _dispatch_ready_rooms(self) -> None:
-        by_room, more_remains = await self._collect_dispatchable()
+        started = self._start_ready_rooms()
+        await self._resolve_retry_sources()
+        started = self._start_ready_rooms() or started
+        rooms, more_remains = await self._discover_rooms()
         if self._stopped:
             return
-        started = False
-        for room_id, events in by_room.items():
-            if self._room_is_backing_off(room_id):
-                continue
-            active = self._lanes.get(room_id)
-            if active is not None and not active.done():
-                # Nothing else will look at this room again on its own, so its
-                # lane has to wake the pump when it finishes.
-                self._rooms_with_more.add(room_id)
-                continue
-            if self._start_lane(room_id, events) is not None:
-                started = True
+        self._queue_lost_owners()
+        for room_id in rooms:
+            self._queue_room(room_id)
+        started = self._start_ready_rooms() or started
         if more_remains:
-            self._continue_scanning(dispatched=started)
+            if started:
+                self._wake.set()
+            else:
+                self._schedule_retry()
         else:
             self._retry_delay_seconds = _INITIAL_RETRY_DELAY_SECONDS
-        if any(retry.task.done() and room_id not in self._lanes for room_id, retry in self._room_retries.items()):
-            # The scan may not have reached a ready room's failed head yet.
-            self._schedule_retry()
-        # A pass that found every deferral still owned starts no lane, so the
-        # lane-finished path cannot be the only thing that arms the next look.
         self._schedule_deferral_scan()
 
-    def _continue_scanning(self, *, dispatched: bool) -> None:
-        """Arm the pass that resumes where this one stopped short.
+    def _start_ready_rooms(self) -> bool:
+        started = False
+        for room_id in tuple(self._ready_rooms):
+            if self._start_lane(room_id) is not None:
+                started = True
+        return started
 
-        Where a pass stopped is the scan's own position, so the scan is what
-        has to carry it. Hung off the rooms a pass dispatched to instead, it
-        was simply lost whenever a pass dispatched to none -- and a window of
-        nothing but rows the store could not decode is exactly that. Those rows
-        yield no event and belong to no owner, so nothing would wake the pump
-        on their behalf and everything queued behind them stayed pending until
-        unrelated traffic happened to arrive, which in a quiet room is never.
-
-        A pass that dispatched something left the cursor past what it
-        dispatched, so the next one reads a different window and may run at
-        once. A pass that dispatched nothing would read the same window
-        immediately and spin on it, so that one waits out the backoff instead.
-        """
-        if dispatched:
-            self._wake.set()
-        else:
-            self._schedule_retry()
-
-    def _start_lane(self, room_id: str, events: list[JournalEvent]) -> asyncio.Task[None] | None:
-        """Admit a lane against current retry state after any scan or lane wait."""
-        if self._room_is_backing_off(room_id):
+    def _start_lane(self, room_id: str) -> asyncio.Task[_RoomPass] | None:
+        """Reserve before reading; every caller shares this admission boundary."""
+        active = self._lanes.get(room_id)
+        if self._stopped or self._room_is_backing_off(room_id) or (active is not None and not active.done()):
             return None
-        retry = self._room_retries.get(room_id)
-        if retry is not None and not any(event.event_id == retry.event.event_id for event in events):
-            events = [event for event in events if event.receipt_order < retry.event.receipt_order]
-        if not events:
-            return None
-        # Cooldown expiry or owner loss while a scan awaited I/O can expose
-        # an earlier deferral after its initial reclaim. Admission owns order.
-        event_ids = {event.event_id for event in events}
-        last_receipt = events[-1].receipt_order
-        reclaimed = (
-            event
-            for event in tuple(self._deferred.values())
-            if event.room_id == room_id
-            and event.receipt_order < last_receipt
-            and event.event_id not in event_ids
-            and not self.deferral_is_live(event)
-        )
-        events = sorted([*events, *reclaimed], key=lambda event: event.receipt_order)
-        self._rooms_with_more.discard(room_id)
-        lane = asyncio.create_task(self._run_lane(events), name=f"pending_event_lane_{room_id}")
+        self._rooms.setdefault(room_id, _RoomProgress())
+        self._ready_rooms.discard(room_id)
+        lane = asyncio.create_task(self._run_room(room_id), name=f"pending_event_lane_{room_id}")
         self._lanes[room_id] = lane
         lane.add_done_callback(lambda task: self._lane_finished(room_id, task))
         return lane
 
-    def _lane_finished(self, room_id: str, lane: asyncio.Task[None]) -> None:
-        if self._lanes.get(room_id) is lane:
-            del self._lanes[room_id]
+    def _lane_finished(self, room_id: str, lane: asyncio.Task[_RoomPass]) -> None:
+        if self._lanes.get(room_id) is not lane:
+            return
+        del self._lanes[room_id]
         if self._stopped or lane.cancelled():
             return
-        if room_id in self._rooms_with_more and not self._room_is_backing_off(room_id):
-            self._wake.set()
+        outcome = lane.result()
+        if outcome.more:
+            self._ready_rooms.add(room_id)
+        if room_id in self._ready_rooms:
+            if self._pump is not None and not self._pump.done():
+                self._start_lane(room_id)
+        elif room_id not in self._room_retries:
+            # An exhausted room starts a fresh scan on its next admission.
+            self._rooms.pop(room_id, None)
         self._schedule_deferral_scan()
 
     def _room_is_backing_off(self, room_id: str) -> bool:
         retry = self._room_retries.get(room_id)
         return retry is not None and not retry.task.done()
 
-    def _schedule_room_retry(self, event: JournalEvent) -> None:
-        """Keep each room's cooldown independent of admissions and other rooms."""
+    def _schedule_room_retry(self, room_id: str, event: JournalEvent | None) -> None:
         logger.exception(
             "pending_event_failed",
-            event_id=event.event_id,
-            kind=event.kind.value,
-            room_id=event.room_id,
+            room_id=room_id,
+            event_id=None if event is None else event.event_id,
+            kind=None if event is None else event.kind.value,
         )
         if self._stopped:
             return
-        room_id = event.room_id
         previous = self._room_retries.get(room_id)
         delay = (
             _INITIAL_RETRY_DELAY_SECONDS
             if previous is None
             else min(previous.delay_seconds * 2, _MAX_RETRY_DELAY_SECONDS)
         )
-        task = asyncio.create_task(self._retry_room_after_delay(delay), name=f"pending_event_room_retry_{room_id}")
-        self._room_retries[room_id] = _RoomRetry(delay, task, event)
+        failed_receipt = None if previous is None else previous.failed_receipt_order
+        if event is not None:
+            failed_receipt = event.receipt_order
+        task = asyncio.create_task(
+            asyncio.sleep(delay),
+            name=f"pending_event_room_retry_{room_id}",
+        )
+        self._room_retries[room_id] = _RoomRetry(delay, task, failed_receipt)
+        task.add_done_callback(lambda done: self._room_retry_finished(room_id, done))
 
-    async def _retry_room_after_delay(self, delay: float) -> None:
-        await asyncio.sleep(delay)
-        self._wake.set()
+    def _room_retry_finished(self, room_id: str, task: asyncio.Task[None]) -> None:
+        retry = self._room_retries.get(room_id)
+        if self._stopped or task.cancelled() or retry is None or retry.task is not task:
+            return
+        task.result()
+        self._queue_room(room_id)
+        if self._pump is not None and not self._pump.done():
+            self._start_lane(room_id)
 
-    def _clear_room_retry(self, event: JournalEvent) -> None:
-        """Only recovery of the failed event removes its room's ordering fence."""
-        retry = self._room_retries.get(event.room_id)
-        if retry is not None and retry.event.event_id == event.event_id:
-            del self._room_retries[event.room_id]
-            # A wrapped scan may have skipped the tail before finding this head.
-            self._wake.set()
+    def _record_room_progress(self, room_id: str, receipt_order: int | None) -> None:
+        retry = self._room_retries.get(room_id)
+        if retry is not None and (
+            retry.failed_receipt_order is None or receipt_order is None or receipt_order >= retry.failed_receipt_order
+        ):
+            del self._room_retries[room_id]
 
-    async def _forget_ineligible_room_retries(self) -> None:
-        """A settled or approval-owned failed head no longer fences replay."""
-        for room_id, retry in tuple(self._room_retries.items()):
-            if not retry.task.done() or room_id in self._lanes:
+    def _reclaim_room_deferrals(self, room_id: str, seen: set[str]) -> None:
+        """Only the reserved lane can replace a dead owner with room replay."""
+        progress = self._rooms[room_id]
+        for event in tuple(self._deferred.values()):
+            if event.room_id != room_id or event.event_id in seen or self.deferral_is_live(event):
                 continue
-            try:
-                # Use the journal's replay eligibility, which excludes sources
-                # transferred to approvals even while they remain unsettled.
+            rewind = event.receipt_order - 1
+            previous = progress.rewind_before
+            progress.rewind_before = rewind if previous is None else min(previous, rewind)
+            self._deferred.pop(event.event_id, None)
+            logger.warning(
+                "pending_event_deferral_owner_lost",
+                event_id=event.event_id,
+                kind=event.kind.value,
+                room_id=room_id,
+            )
+
+    @staticmethod
+    def _apply_rewind(progress: _RoomProgress) -> bool:
+        requested = progress.rewind_before
+        progress.rewind_before = None
+        if requested is None:
+            return False
+        if progress.cursor is not None:
+            progress.cursor = min(progress.cursor, requested)
+        # A request during an awaited read invalidates its snapshot even when
+        # the cursor was already before the newly eligible source.
+        return True
+
+    async def _run_room_event(self, event: JournalEvent, seen: set[str]) -> bool:
+        """Admit against current ownership; False requires a fresh room page."""
+        room_id = event.room_id
+        progress = self._rooms[room_id]
+        self._reclaim_room_deferrals(room_id, seen)
+        if self._apply_rewind(progress):
+            return False
+        if event.event_id in self._deferred:
+            progress.cursor = event.receipt_order
+            return True
+        self._record_room_progress(room_id, event.receipt_order - 1)
+        seen.add(event.event_id)
+        pending = await self.store.is_pending(event.event_id)
+        self._reclaim_room_deferrals(room_id, seen)
+        if self._apply_rewind(progress):
+            return False
+        if not pending:
+            self._deferred.pop(event.event_id, None)
+        elif not await self.handle(event):
+            self._deferred[event.event_id] = event
+        else:
+            self._deferred.pop(event.event_id, None)
+            await self.store.settle(event.event_id)
+        progress.cursor = event.receipt_order
+        self._record_room_progress(room_id, event.receipt_order)
+        return True
+
+    async def _run_room(self, room_id: str) -> _RoomPass:
+        """Own selection, callback order, and the continuation of one room."""
+        progress = self._rooms[room_id]
+        seen: set[str] = set()
+        event: JournalEvent | None = None
+        try:
+            for _ in range(_MAX_SCAN_PAGES):
+                event = None
+                self._reclaim_room_deferrals(room_id, seen)
+                self._apply_rewind(progress)
                 page = await self.store.pending(
-                    limit=1,
-                    after_receipt_order=retry.event.receipt_order - 1,
+                    room_id=room_id,
+                    limit=_BATCH_SIZE,
+                    after_receipt_order=progress.cursor,
                     runtime_generation=self.runtime_generation,
                 )
-            except Exception:
-                if self._room_retries.get(room_id) is retry and room_id not in self._lanes:
-                    self._schedule_room_retry(retry.event)
-                continue
-            pending = any(event.event_id == retry.event.event_id for event in page)
-            if not pending and self._room_retries.get(room_id) is retry and room_id not in self._lanes:
-                del self._room_retries[room_id]
+                if self._stopped:
+                    return _RoomPass(len(seen))
+                self._reclaim_room_deferrals(room_id, seen)
+                if self._apply_rewind(progress):
+                    continue
+                for event in page:
+                    if not await self._run_room_event(event, seen):
+                        return _RoomPass(len(seen), more=True)
+                progress.cursor = page.resume_after
+                self._reclaim_room_deferrals(room_id, seen)
+                if self._apply_rewind(progress):
+                    continue
+                if page.reached_end:
+                    progress.cursor = None
+                    self._record_room_progress(room_id, None)
+                    return _RoomPass(len(seen))
+            return _RoomPass(len(seen), more=True)
+        except Exception:
+            if event is not None:
+                self._deferred.pop(event.event_id, None)
+                progress.cursor = event.receipt_order - 1
+            self._schedule_room_retry(room_id, event)
+            return _RoomPass(len(seen), failed=True)
 
     def _schedule_deferral_scan(self) -> None:
-        """Arrange one later look while anything is deferred.
-
-        Every other wakeup here is caused by something: an admission, a lane
-        finishing, a failure backing off. An owner dying causes none of them,
-        so without this the reclaim would only run when unrelated traffic
-        happened to wake the pump — which is no bound at all in a quiet room.
-        The timer exists only while a deferral does.
-        """
-        if not self._deferred or (self._deferral_scan is not None and not self._deferral_scan.done()):
+        if self._stopped or not self._deferred or (self._deferral_scan is not None and not self._deferral_scan.done()):
             return
         self._deferral_scan = asyncio.create_task(
             self._scan_after_deferral_delay(),
@@ -470,8 +512,7 @@ class PendingEventWorker:
         self._wake.set()
 
     def _schedule_retry(self) -> None:
-        """Re-run a failed pass later, since nothing else will trigger one."""
-        if self._retry is not None and not self._retry.done():
+        if self._stopped or (self._retry is not None and not self._retry.done()):
             return
         self._retry = asyncio.create_task(self._retry_after_delay(), name="pending_event_worker_retry")
 
@@ -479,194 +520,3 @@ class PendingEventWorker:
         await asyncio.sleep(self._retry_delay_seconds)
         self._retry_delay_seconds = min(self._retry_delay_seconds * 2, _MAX_RETRY_DELAY_SECONDS)
         self._wake.set()
-
-    async def _collect_dispatchable(self) -> tuple[dict[str, list[JournalEvent]], bool]:
-        """Group pending events this worker may act on now, by room.
-
-        Returns the grouping and whether the scan stopped before the end of the
-        backlog. Events whose turn is still running are skipped rather than
-        stopping the scan, so a room full of in-flight turns cannot hide the
-        events queued behind it.
-
-        A pass that runs out of page budget leaves its position behind for the
-        next one, and a pass that reaches the end of the backlog starts again
-        from the front. Restarting at receipt order zero every time is what
-        made the budget a ceiling rather than a bound: enough events the worker
-        cannot act on -- a busy bot's in-flight turns, a room whose lane keeps
-        failing -- and every pass spends the whole budget on the same prefix
-        while the dispatchable events behind it are never reached at all.
-
-        Rows the store could not read are the same kind of prefix and get the
-        same treatment. They yield no event, so the resume point comes from the
-        page rather than from the last event on it: taken from the events, a
-        page that decoded nothing would leave the cursor where it was and every
-        later pass would spend its whole budget re-reading the same corruption.
-
-        Wrapping to the front is a revolution, not a fresh start, so the pass
-        ends where it began. Without that stop it kept spending budget past its
-        own origin and collected the events it had already collected a few
-        pages earlier -- and a room's lane is handed that list verbatim, so a
-        handler that defers rather than settling runs twice on one source.
-        """
-        await self._forget_ineligible_room_retries()
-        by_room = self._reclaim_lost_deferrals()
-        reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
-        origin = self._scan_cursor
-        cursor = origin
-        wrapped = origin is None
-        for _ in range(_MAX_SCAN_PAGES):
-            page = await self.store.pending(
-                limit=_BATCH_SIZE,
-                after_receipt_order=cursor,
-                runtime_generation=self.runtime_generation,
-            )
-            reached_origin = self._collect_page(
-                page,
-                by_room,
-                already_taken=reclaimed,
-                stop_after=origin if wrapped else None,
-            )
-            if reached_origin or (page.reached_end and wrapped):
-                self._scan_cursor = None
-                return _in_receipt_order(by_room), False
-            if not page.reached_end:
-                cursor = page.resume_after
-                continue
-            # The end of the backlog, reached from part way through it. What
-            # came before the resume point has not been looked at, so the rest
-            # of the budget goes on it rather than on another pass.
-            cursor, wrapped = None, True
-        self._scan_cursor = cursor
-        return _in_receipt_order(by_room), True
-
-    async def _collect_whole_backlog(self) -> dict[str, list[JournalEvent]]:
-        """Group every pending event this worker may act on, front to back.
-
-        What a drain asks for, and the reason it cannot borrow the pump's scan.
-        A page budget exists to bound how long one pump pass keeps the loop,
-        and a drain has no such need -- it already loops until the backlog
-        stops moving, and it is that loop, not one pass of it, that has to see
-        every event.
-        """
-        await self._forget_ineligible_room_retries()
-        by_room = self._reclaim_lost_deferrals()
-        reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
-        cursor: int | None = None
-        while True:
-            page = await self.store.pending(
-                limit=_BATCH_SIZE,
-                after_receipt_order=cursor,
-                runtime_generation=self.runtime_generation,
-            )
-            self._collect_page(page, by_room, already_taken=reclaimed, stop_after=None)
-            if page.reached_end:
-                return _in_receipt_order(by_room)
-            cursor = page.resume_after
-
-    def _collect_page(
-        self,
-        page: Iterable[JournalEvent],
-        by_room: dict[str, list[JournalEvent]],
-        *,
-        already_taken: frozenset[str],
-        stop_after: int | None,
-    ) -> bool:
-        """Group one page's dispatchable events by room, stopping at ``stop_after``.
-
-        Returns whether the page ran into that stop, which is how a wrapped
-        pass recognises the position it set out from.
-        """
-        for event in page:
-            if stop_after is not None and event.receipt_order > stop_after:
-                return True
-            if self._room_is_backing_off(event.room_id):
-                continue
-            retry = self._room_retries.get(event.room_id)
-            if (
-                retry is not None
-                and event.receipt_order > retry.event.receipt_order
-                and not any(prior.event_id == retry.event.event_id for prior in by_room.get(event.room_id, ()))
-            ):
-                # A rotating scan can reach the tail before the failed head.
-                # Wait for the contiguous segment starting at that head.
-                continue
-            if event.event_id in already_taken:
-                # The reclaim at the top of this pass already took it back.
-                continue
-            if event.event_id in self._deferred:
-                # Handed to an owner the reclaim found still alive.
-                continue
-            by_room.setdefault(event.room_id, []).append(event)
-        return False
-
-    def _reclaim_lost_deferrals(self) -> dict[str, list[JournalEvent]]:
-        """Take back every deferral whose owner is gone, wherever it sits.
-
-        Deferral is a promise that some owner will call ``release``. Nothing
-        makes that owner keep the promise, and the event is durably pending the
-        whole time, so an owner that dies quietly leaves work that no later
-        admission and no retry will ever reveal. Asking whether the owner still
-        exists turns that into a bounded outage instead of one that lasts until
-        the process restarts.
-
-        Asked of the deferrals themselves rather than of whatever the scan's
-        window happens to cover, because those are different sets. A backlog
-        too large for one pass keeps the window ahead of a deferral sitting
-        behind it for as long as the overload lasts, and the outage this is
-        supposed to bound then lasts exactly as long as the one it replaced.
-        """
-        by_room: dict[str, list[JournalEvent]] = {}
-        for event in tuple(self._deferred.values()):
-            if self._room_is_backing_off(event.room_id) or self.deferral_is_live(event):
-                continue
-            # Keep ownership until a lane actually handles the reclaimed event.
-            # A scan can still lose admission to a busy or newly cooling room.
-            logger.warning(
-                "pending_event_deferral_owner_lost",
-                event_id=event.event_id,
-                kind=event.kind.value,
-                room_id=event.room_id,
-            )
-            retry = self._room_retries.get(event.room_id)
-            if retry is None or event.receipt_order <= retry.event.receipt_order:
-                by_room.setdefault(event.room_id, []).append(event)
-        return by_room
-
-    async def _run_lane(self, events: list[JournalEvent]) -> None:
-        """Run one room's events in receipt order, stopping at the first failure.
-
-        Stopping matters: if event two fails and event three still ran, the
-        room's conversation would be answered out of order, and the retry of
-        event two would then arrive after its own reply.
-
-        The store reads and writes around the handler are inside the same
-        failure, because they fail for the same reasons it does and leave the
-        same work owed. Left outside, they would instead fault the lane task
-        itself: nothing retrieves that exception, no room is recorded as
-        failed, and no retry is scheduled -- so a failed settlement would sit
-        until some unrelated event woke the pump, and then run its handler a
-        second time.
-        """
-        for event in events:
-            if self._stopped:
-                return
-            try:
-                if not await self.store.is_pending(event.event_id):
-                    self._deferred.pop(event.event_id, None)
-                    self._clear_room_retry(event)
-                    continue
-                if not await self.handle(event):
-                    self._deferred[event.event_id] = event
-                    self._clear_room_retry(event)
-                    continue
-                self._deferred.pop(event.event_id, None)
-                await self.store.settle(event.event_id)
-                self._clear_room_retry(event)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # Retry ownership replaces deferral; the ordered journal scan
-                # must encounter this failed head before admitting its tail.
-                self._deferred.pop(event.event_id, None)
-                self._schedule_room_retry(event)
-                return

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -8,6 +8,7 @@ Each room keeps its own page position across bounded passes and cooldowns.
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -45,6 +46,7 @@ class _RoomProgress:
     cursor: int | None = None
     rewind_before: int | None = None
     admitted_through: int = 0
+    deferred_count: int = 0
 
 
 @dataclass
@@ -78,7 +80,7 @@ class PendingEventWorker:
     _rooms: dict[str, _RoomProgress] = field(default_factory=dict, init=False, repr=False)
     _ready_rooms: set[str] = field(default_factory=set, init=False, repr=False)
     _room_retries: dict[str, _RoomRetry] = field(default_factory=dict, init=False, repr=False)
-    _deferred: dict[str, JournalEvent] = field(default_factory=dict, init=False, repr=False)
+    _deferred: OrderedDict[str, JournalEvent] = field(default_factory=OrderedDict, init=False, repr=False)
     _wake: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
     _pump: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _retry: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
@@ -116,7 +118,16 @@ class PendingEventWorker:
         even after an approval source has left this cache.
         """
         for event_id in event_ids:
-            self._deferred.pop(event_id, None)
+            event = self._deferred.pop(event_id, None)
+            if event is not None:
+                self._rooms[event.room_id].deferred_count -= 1
+                self._queue_room(event.room_id)
+                self._wake.set()
+
+    def _defer(self, event: JournalEvent) -> None:
+        if event.event_id not in self._deferred:
+            self._rooms.setdefault(event.room_id, _RoomProgress()).deferred_count += 1
+        self._deferred[event.event_id] = event
 
     def _owned_tasks(self) -> tuple[asyncio.Task[object], ...]:
         return tuple(
@@ -167,7 +178,11 @@ class PendingEventWorker:
         self._retry = None
         self._deferral_scan = None
         self._lanes.clear()
-        self._rooms.clear()
+        self._rooms = {
+            room_id: _RoomProgress(deferred_count=progress.deferred_count)
+            for room_id, progress in self._rooms.items()
+            if progress.deferred_count
+        }
         self._ready_rooms.clear()
         self._room_retries.clear()
         self._scan_cursor = None
@@ -186,10 +201,12 @@ class PendingEventWorker:
         self._ready_rooms.add(room_id)
 
     def _queue_lost_owners(self) -> None:
-        """Probe globally, but leave reclamation to the room's reserved owner."""
-        for event in tuple(self._deferred.values()):
+        """Rotate a bounded fallback probe; detected loss invalidates room admission."""
+        for _ in range(min(_BATCH_SIZE, len(self._deferred))):
+            event_id, event = self._deferred.popitem(last=False)
+            self._deferred[event_id] = event
             if not self.deferral_is_live(event):
-                self._queue_room(event.room_id)
+                self._reclaim_deferral(event)
 
     async def _discover_rooms(self, *, whole_backlog: bool = False) -> tuple[set[str], bool]:
         """Find rooms without passing global scan slices to their lanes."""
@@ -315,12 +332,14 @@ class PendingEventWorker:
         if self._stopped or lane.cancelled():
             return
         outcome = lane.result()
+        if not outcome.failed and not outcome.more and self._rooms[room_id].deferred_count == 0:
+            self._record_room_progress(room_id, None)
         if outcome.more:
             self._ready_rooms.add(room_id)
         if room_id in self._ready_rooms:
             if self._pump is not None and not self._pump.done():
                 self._start_lane(room_id)
-        elif room_id not in self._room_retries:
+        elif room_id not in self._room_retries and self._rooms[room_id].deferred_count == 0:
             # An exhausted room starts a fresh scan on its next admission.
             self._rooms.pop(room_id, None)
         self._schedule_deferral_scan()
@@ -365,22 +384,16 @@ class PendingEventWorker:
         ):
             del self._room_retries[room_id]
 
-    def _reclaim_room_deferrals(self, room_id: str) -> None:
-        """Only the reserved lane can replace a dead owner with room replay."""
-        progress = self._rooms[room_id]
-        for event in tuple(self._deferred.values()):
-            if event.room_id != room_id or self.deferral_is_live(event):
-                continue
-            rewind = event.receipt_order - 1
-            previous = progress.rewind_before
-            progress.rewind_before = rewind if previous is None else min(previous, rewind)
-            self._deferred.pop(event.event_id, None)
-            logger.warning(
-                "pending_event_deferral_owner_lost",
-                event_id=event.event_id,
-                kind=event.kind.value,
-                room_id=room_id,
-            )
+    def _reclaim_deferral(self, event: JournalEvent) -> None:
+        """Return one lost handoff through the same room boundary as explicit retries."""
+        self.release((event.event_id,))
+        self.wake(room_id=event.room_id)
+        logger.warning(
+            "pending_event_deferral_owner_lost",
+            event_id=event.event_id,
+            kind=event.kind.value,
+            room_id=event.room_id,
+        )
 
     @staticmethod
     def _apply_rewind(progress: _RoomProgress) -> bool:
@@ -398,7 +411,6 @@ class PendingEventWorker:
         """Admit against current ownership; False stops the current page."""
         room_id = event.room_id
         progress = self._rooms[room_id]
-        self._reclaim_room_deferrals(room_id)
         if self._stopped or self._apply_rewind(progress):
             return False
         if event.event_id in self._deferred:
@@ -408,11 +420,10 @@ class PendingEventWorker:
         pending = await self.store.is_pending(event.event_id)
         if self._stopped:
             return False
-        self._reclaim_room_deferrals(room_id)
         if self._apply_rewind(progress):
             return False
         if not pending:
-            self._deferred.pop(event.event_id, None)
+            self.release((event.event_id,))
         else:
             if event.receipt_order <= progress.admitted_through:
                 # A rewind revisits eligible work. Pace the next traversal even
@@ -422,9 +433,11 @@ class PendingEventWorker:
             seen.add(event.event_id)
             progress.admitted_through = event.receipt_order
             if not await self.handle(event):
-                self._deferred[event.event_id] = event
+                self._defer(event)
+                if not self.deferral_is_live(event):
+                    self._reclaim_deferral(event)
             else:
-                self._deferred.pop(event.event_id, None)
+                self.release((event.event_id,))
                 await self.store.settle(event.event_id)
                 self._record_room_progress(room_id, event.receipt_order)
         progress.cursor = event.receipt_order
@@ -438,7 +451,6 @@ class PendingEventWorker:
         try:
             for _ in range(_MAX_SCAN_PAGES):
                 event = None
-                self._reclaim_room_deferrals(room_id)
                 self._apply_rewind(progress)
                 page = await self.store.pending(
                     room_id=room_id,
@@ -448,7 +460,6 @@ class PendingEventWorker:
                 )
                 if self._stopped:
                     return _RoomPass(len(seen))
-                self._reclaim_room_deferrals(room_id)
                 if self._apply_rewind(progress):
                     continue
                 for event in page:
@@ -456,12 +467,10 @@ class PendingEventWorker:
                         failed = self._room_is_backing_off(room_id)
                         return _RoomPass(len(seen), more=not self._stopped and not failed, failed=failed)
                 progress.cursor = page.resume_after
-                self._reclaim_room_deferrals(room_id)
                 if self._apply_rewind(progress):
                     continue
                 if page.reached_end:
                     progress.cursor = None
-                    self._record_room_progress(room_id, None)
                     return _RoomPass(len(seen))
             return _RoomPass(len(seen), more=True)
         except Exception:
@@ -472,7 +481,7 @@ class PendingEventWorker:
                 kind=None if event is None else event.kind.value,
             )
             if event is not None:
-                self._deferred.pop(event.event_id, None)
+                self.release((event.event_id,))
                 progress.cursor = event.receipt_order - 1
             self._schedule_room_retry(room_id, event)
             return _RoomPass(len(seen), failed=True)
@@ -487,6 +496,9 @@ class PendingEventWorker:
 
     async def _scan_after_deferral_delay(self) -> None:
         await asyncio.sleep(self.deferral_scan_seconds)
+        for _ in range(0, len(self._deferred), _BATCH_SIZE):
+            self._queue_lost_owners()
+            await asyncio.sleep(0)
         self._wake.set()
 
     def _schedule_retry(self) -> None:

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -656,5 +656,8 @@ class PendingEventWorker:
             except asyncio.CancelledError:
                 raise
             except Exception:
+                # Retry ownership replaces deferral; the ordered journal scan
+                # must encounter this failed head before admitting its tail.
+                self._deferred.pop(event.event_id, None)
                 self._schedule_room_retry(event)
                 return

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -44,6 +44,7 @@ class _RoomProgress:
 
     cursor: int | None = None
     rewind_before: int | None = None
+    admitted_through: int = 0
 
 
 @dataclass
@@ -329,12 +330,6 @@ class PendingEventWorker:
         return retry is not None and not retry.task.done()
 
     def _schedule_room_retry(self, room_id: str, event: JournalEvent | None) -> None:
-        logger.exception(
-            "pending_event_failed",
-            room_id=room_id,
-            event_id=None if event is None else event.event_id,
-            kind=None if event is None else event.kind.value,
-        )
         if self._stopped:
             return
         previous = self._room_retries.get(room_id)
@@ -358,6 +353,7 @@ class PendingEventWorker:
         if self._stopped or task.cancelled() or retry is None or retry.task is not task:
             return
         task.result()
+        self._rooms[room_id].admitted_through = 0
         self._queue_room(room_id)
         if self._pump is not None and not self._pump.done():
             self._start_lane(room_id)
@@ -369,11 +365,11 @@ class PendingEventWorker:
         ):
             del self._room_retries[room_id]
 
-    def _reclaim_room_deferrals(self, room_id: str, newly_unowned: set[str]) -> None:
+    def _reclaim_room_deferrals(self, room_id: str) -> None:
         """Only the reserved lane can replace a dead owner with room replay."""
         progress = self._rooms[room_id]
         for event in tuple(self._deferred.values()):
-            if event.room_id != room_id or event.event_id in newly_unowned or self.deferral_is_live(event):
+            if event.room_id != room_id or self.deferral_is_live(event):
                 continue
             rewind = event.receipt_order - 1
             previous = progress.rewind_before
@@ -398,52 +394,51 @@ class PendingEventWorker:
         # the cursor was already before the newly eligible source.
         return True
 
-    async def _run_room_event(self, event: JournalEvent, seen: set[str], newly_unowned: set[str]) -> bool:
+    async def _run_room_event(self, event: JournalEvent, seen: set[str]) -> bool:
         """Admit against current ownership; False stops the current page."""
-        if self._stopped:
-            return False
         room_id = event.room_id
         progress = self._rooms[room_id]
-        self._reclaim_room_deferrals(room_id, newly_unowned)
-        if self._apply_rewind(progress):
+        self._reclaim_room_deferrals(room_id)
+        if self._stopped or self._apply_rewind(progress):
             return False
         if event.event_id in self._deferred:
             progress.cursor = event.receipt_order
             return True
         self._record_room_progress(room_id, event.receipt_order - 1)
-        seen.add(event.event_id)
         pending = await self.store.is_pending(event.event_id)
         if self._stopped:
             return False
-        self._reclaim_room_deferrals(room_id, newly_unowned)
+        self._reclaim_room_deferrals(room_id)
         if self._apply_rewind(progress):
             return False
         if not pending:
             self._deferred.pop(event.event_id, None)
-        elif not await self.handle(event):
-            self._deferred[event.event_id] = event
-            if not self.deferral_is_live(event):
-                # The downstream owner can finish before the callback returns.
-                # Leave an already ownerless handoff to the next probe, avoiding
-                # repeated dispatch within this pass.
-                newly_unowned.add(event.event_id)
         else:
-            self._deferred.pop(event.event_id, None)
-            await self.store.settle(event.event_id)
+            if event.receipt_order <= progress.admitted_through:
+                # A rewind revisits eligible work. Pace the next traversal even
+                # when callbacks alternate owners or span several page passes.
+                self._schedule_room_retry(room_id, event)
+                return False
+            seen.add(event.event_id)
+            progress.admitted_through = event.receipt_order
+            if not await self.handle(event):
+                self._deferred[event.event_id] = event
+            else:
+                self._deferred.pop(event.event_id, None)
+                await self.store.settle(event.event_id)
+                self._record_room_progress(room_id, event.receipt_order)
         progress.cursor = event.receipt_order
-        self._record_room_progress(room_id, event.receipt_order)
         return True
 
     async def _run_room(self, room_id: str) -> _RoomPass:
         """Own selection, callback order, and the continuation of one room."""
         progress = self._rooms[room_id]
         seen: set[str] = set()
-        newly_unowned: set[str] = set()
         event: JournalEvent | None = None
         try:
             for _ in range(_MAX_SCAN_PAGES):
                 event = None
-                self._reclaim_room_deferrals(room_id, newly_unowned)
+                self._reclaim_room_deferrals(room_id)
                 self._apply_rewind(progress)
                 page = await self.store.pending(
                     room_id=room_id,
@@ -453,14 +448,15 @@ class PendingEventWorker:
                 )
                 if self._stopped:
                     return _RoomPass(len(seen))
-                self._reclaim_room_deferrals(room_id, newly_unowned)
+                self._reclaim_room_deferrals(room_id)
                 if self._apply_rewind(progress):
                     continue
                 for event in page:
-                    if not await self._run_room_event(event, seen, newly_unowned):
-                        return _RoomPass(len(seen), more=not self._stopped)
+                    if not await self._run_room_event(event, seen):
+                        failed = self._room_is_backing_off(room_id)
+                        return _RoomPass(len(seen), more=not self._stopped and not failed, failed=failed)
                 progress.cursor = page.resume_after
-                self._reclaim_room_deferrals(room_id, newly_unowned)
+                self._reclaim_room_deferrals(room_id)
                 if self._apply_rewind(progress):
                     continue
                 if page.reached_end:
@@ -469,6 +465,12 @@ class PendingEventWorker:
                     return _RoomPass(len(seen))
             return _RoomPass(len(seen), more=True)
         except Exception:
+            logger.exception(
+                "pending_event_failed",
+                room_id=room_id,
+                event_id=None if event is None else event.event_id,
+                kind=None if event is None else event.kind.value,
+            )
             if event is not None:
                 self._deferred.pop(event.event_id, None)
                 progress.cursor = event.receipt_order - 1

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -76,7 +76,6 @@ class PendingEventWorker:
     _lanes: dict[str, asyncio.Task[_RoomPass]] = field(default_factory=dict, init=False, repr=False)
     _rooms: dict[str, _RoomProgress] = field(default_factory=dict, init=False, repr=False)
     _ready_rooms: set[str] = field(default_factory=set, init=False, repr=False)
-    _retry_sources: set[str] = field(default_factory=set, init=False, repr=False)
     _room_retries: dict[str, _RoomRetry] = field(default_factory=dict, init=False, repr=False)
     _deferred: dict[str, JournalEvent] = field(default_factory=dict, init=False, repr=False)
     _wake: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
@@ -98,17 +97,22 @@ class PendingEventWorker:
         self._wake.set()
         self._pump = asyncio.create_task(self._run(), name="pending_event_worker")
 
-    def wake(self, *, event_ids: tuple[str, ...] = ()) -> None:
-        """Signal admissions or exact sources made replayable by an owner handoff."""
-        self._retry_sources.update(event_ids)
+    def wake(self, *, room_id: str | None = None) -> None:
+        """Signal admission, or synchronously rewind a room after a retry handoff."""
+        if self._stopped:
+            return
+        if room_id is not None:
+            self._queue_room(room_id, rewind_before=0)
+            if self._pump is not None and not self._pump.done():
+                self._start_lane(room_id)
         self._wake.set()
 
     def release(self, event_ids: Iterable[str]) -> None:
         """Forget downstream ownership after its durable handoff.
 
         This remains an in-memory operation callable from terminal handoffs.
-        A retry additionally calls wake with the exact source IDs, allowing
-        replay to rewind even after an approval source left this cache.
+        A retry additionally wakes its room, invalidating the current page
+        even after an approval source has left this cache.
         """
         for event_id in event_ids:
             self._deferred.pop(event_id, None)
@@ -164,7 +168,6 @@ class PendingEventWorker:
         self._lanes.clear()
         self._rooms.clear()
         self._ready_rooms.clear()
-        self._retry_sources.clear()
         self._room_retries.clear()
         self._scan_cursor = None
         return True
@@ -180,38 +183,6 @@ class PendingEventWorker:
             previous = progress.rewind_before
             progress.rewind_before = rewind_before if previous is None else min(previous, rewind_before)
         self._ready_rooms.add(room_id)
-
-    async def _resolve_retry_sources(self) -> None:
-        """Resolve exact handoffs through the same replay policy as room reads."""
-        generation = self._stop_generation
-        failed = False
-        for event_id in tuple(self._retry_sources)[:_BATCH_SIZE]:
-            # Remove before awaiting: another wake for this ID during the read
-            # is a new obligation, including when this snapshot still says waiting.
-            self._retry_sources.discard(event_id)
-            try:
-                page = await self.store.pending(
-                    event_id=event_id,
-                    limit=1,
-                    runtime_generation=self.runtime_generation,
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                if self._stopped or generation != self._stop_generation:
-                    return
-                logger.exception("pending_event_retry_source_read_failed", event_id=event_id)
-                self._retry_sources.add(event_id)
-                failed = True
-                continue
-            if self._stopped or generation != self._stop_generation:
-                return
-            for event in page:
-                self._queue_room(event.room_id, rewind_before=event.receipt_order - 1)
-        if failed:
-            self._schedule_retry()
-        elif self._retry_sources:
-            self._wake.set()
 
     def _queue_lost_owners(self) -> None:
         """Probe globally, but leave reclamation to the room's reserved owner."""
@@ -255,9 +226,6 @@ class PendingEventWorker:
         """Drain eligible room work through the same owners, without waiting out cooldowns."""
         generation = self._stop_generation
         if self._stopped:
-            return 0
-        await self._resolve_retry_sources()
-        if self._stopped or generation != self._stop_generation:
             return 0
         rooms, _more = await self._discover_rooms(whole_backlog=True)
         if self._stopped or generation != self._stop_generation:
@@ -304,8 +272,6 @@ class PendingEventWorker:
 
     async def _dispatch_ready_rooms(self) -> None:
         started = self._start_ready_rooms()
-        await self._resolve_retry_sources()
-        started = self._start_ready_rooms() or started
         rooms, more_remains = await self._discover_rooms()
         if self._stopped:
             return

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -399,7 +399,9 @@ class PendingEventWorker:
         return True
 
     async def _run_room_event(self, event: JournalEvent, seen: set[str]) -> bool:
-        """Admit against current ownership; False requires a fresh room page."""
+        """Admit against current ownership; False stops the current page."""
+        if self._stopped:
+            return False
         room_id = event.room_id
         progress = self._rooms[room_id]
         self._reclaim_room_deferrals(room_id, seen)
@@ -411,6 +413,8 @@ class PendingEventWorker:
         self._record_room_progress(room_id, event.receipt_order - 1)
         seen.add(event.event_id)
         pending = await self.store.is_pending(event.event_id)
+        if self._stopped:
+            return False
         self._reclaim_room_deferrals(room_id, seen)
         if self._apply_rewind(progress):
             return False
@@ -448,7 +452,7 @@ class PendingEventWorker:
                     continue
                 for event in page:
                     if not await self._run_room_event(event, seen):
-                        return _RoomPass(len(seen), more=True)
+                        return _RoomPass(len(seen), more=not self._stopped)
                 progress.cursor = page.resume_after
                 self._reclaim_room_deferrals(room_id, seen)
                 if self._apply_rewind(progress):

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -425,18 +425,27 @@ class PendingEventWorker:
         retry = self._room_retries.get(event.room_id)
         if retry is not None and retry.event.event_id == event.event_id:
             del self._room_retries[event.room_id]
+            # A wrapped scan may have skipped the tail before finding this head.
+            self._wake.set()
 
-    async def _forget_settled_room_retries(self) -> None:
-        """An externally settled failed head must not block its room forever."""
+    async def _forget_ineligible_room_retries(self) -> None:
+        """A settled or approval-owned failed head no longer fences replay."""
         for room_id, retry in tuple(self._room_retries.items()):
             if not retry.task.done() or room_id in self._lanes:
                 continue
             try:
-                pending = await self.store.is_pending(retry.event.event_id)
+                # Use the journal's replay eligibility, which excludes sources
+                # transferred to approvals even while they remain unsettled.
+                page = await self.store.pending(
+                    limit=1,
+                    after_receipt_order=retry.event.receipt_order - 1,
+                    runtime_generation=self.runtime_generation,
+                )
             except Exception:
                 if self._room_retries.get(room_id) is retry and room_id not in self._lanes:
                     self._schedule_room_retry(retry.event)
                 continue
+            pending = any(event.event_id == retry.event.event_id for event in page)
             if not pending and self._room_retries.get(room_id) is retry and room_id not in self._lanes:
                 del self._room_retries[room_id]
 
@@ -499,7 +508,7 @@ class PendingEventWorker:
         pages earlier -- and a room's lane is handed that list verbatim, so a
         handler that defers rather than settling runs twice on one source.
         """
-        await self._forget_settled_room_retries()
+        await self._forget_ineligible_room_retries()
         by_room = self._reclaim_lost_deferrals()
         reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
         origin = self._scan_cursor
@@ -539,7 +548,7 @@ class PendingEventWorker:
         stops moving, and it is that loop, not one pass of it, that has to see
         every event.
         """
-        await self._forget_settled_room_retries()
+        await self._forget_ineligible_room_retries()
         by_room = self._reclaim_lost_deferrals()
         reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
         cursor: int | None = None

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -495,11 +495,12 @@ class PendingEventWorker:
         )
 
     async def _scan_after_deferral_delay(self) -> None:
-        await asyncio.sleep(self.deferral_scan_seconds)
-        for _ in range(0, len(self._deferred), _BATCH_SIZE):
-            self._queue_lost_owners()
-            await asyncio.sleep(0)
-        self._wake.set()
+        while self._deferred:
+            await asyncio.sleep(self.deferral_scan_seconds)
+            for _ in range(0, len(self._deferred), _BATCH_SIZE):
+                self._queue_lost_owners()
+                await asyncio.sleep(0)
+            self._wake.set()
 
     def _schedule_retry(self) -> None:
         if self._stopped or (self._retry is not None and not self._retry.done()):

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -369,11 +369,11 @@ class PendingEventWorker:
         ):
             del self._room_retries[room_id]
 
-    def _reclaim_room_deferrals(self, room_id: str, seen: set[str]) -> None:
+    def _reclaim_room_deferrals(self, room_id: str, newly_unowned: set[str]) -> None:
         """Only the reserved lane can replace a dead owner with room replay."""
         progress = self._rooms[room_id]
         for event in tuple(self._deferred.values()):
-            if event.room_id != room_id or event.event_id in seen or self.deferral_is_live(event):
+            if event.room_id != room_id or event.event_id in newly_unowned or self.deferral_is_live(event):
                 continue
             rewind = event.receipt_order - 1
             previous = progress.rewind_before
@@ -398,13 +398,13 @@ class PendingEventWorker:
         # the cursor was already before the newly eligible source.
         return True
 
-    async def _run_room_event(self, event: JournalEvent, seen: set[str]) -> bool:
+    async def _run_room_event(self, event: JournalEvent, seen: set[str], newly_unowned: set[str]) -> bool:
         """Admit against current ownership; False stops the current page."""
         if self._stopped:
             return False
         room_id = event.room_id
         progress = self._rooms[room_id]
-        self._reclaim_room_deferrals(room_id, seen)
+        self._reclaim_room_deferrals(room_id, newly_unowned)
         if self._apply_rewind(progress):
             return False
         if event.event_id in self._deferred:
@@ -415,13 +415,18 @@ class PendingEventWorker:
         pending = await self.store.is_pending(event.event_id)
         if self._stopped:
             return False
-        self._reclaim_room_deferrals(room_id, seen)
+        self._reclaim_room_deferrals(room_id, newly_unowned)
         if self._apply_rewind(progress):
             return False
         if not pending:
             self._deferred.pop(event.event_id, None)
         elif not await self.handle(event):
             self._deferred[event.event_id] = event
+            if not self.deferral_is_live(event):
+                # The downstream owner can finish before the callback returns.
+                # Leave an already ownerless handoff to the next probe, avoiding
+                # repeated dispatch within this pass.
+                newly_unowned.add(event.event_id)
         else:
             self._deferred.pop(event.event_id, None)
             await self.store.settle(event.event_id)
@@ -433,11 +438,12 @@ class PendingEventWorker:
         """Own selection, callback order, and the continuation of one room."""
         progress = self._rooms[room_id]
         seen: set[str] = set()
+        newly_unowned: set[str] = set()
         event: JournalEvent | None = None
         try:
             for _ in range(_MAX_SCAN_PAGES):
                 event = None
-                self._reclaim_room_deferrals(room_id, seen)
+                self._reclaim_room_deferrals(room_id, newly_unowned)
                 self._apply_rewind(progress)
                 page = await self.store.pending(
                     room_id=room_id,
@@ -447,14 +453,14 @@ class PendingEventWorker:
                 )
                 if self._stopped:
                     return _RoomPass(len(seen))
-                self._reclaim_room_deferrals(room_id, seen)
+                self._reclaim_room_deferrals(room_id, newly_unowned)
                 if self._apply_rewind(progress):
                     continue
                 for event in page:
-                    if not await self._run_room_event(event, seen):
+                    if not await self._run_room_event(event, seen, newly_unowned):
                         return _RoomPass(len(seen), more=not self._stopped)
                 progress.cursor = page.resume_after
-                self._reclaim_room_deferrals(room_id, seen)
+                self._reclaim_room_deferrals(room_id, newly_unowned)
                 if self._apply_rewind(progress):
                     continue
                 if page.reached_end:

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -91,6 +91,15 @@ def _assume_owner_is_live(event: JournalEvent) -> bool:
 
 
 @dataclass
+class _RoomRetry:
+    """One room's failure history and independently owned cooldown."""
+
+    delay_seconds: float
+    task: asyncio.Task[None]
+    event: JournalEvent
+
+
+@dataclass
 class PendingEventWorker:
     """Drain pending journal events, in receipt order within each room.
 
@@ -117,7 +126,7 @@ class PendingEventWorker:
     _process_shutdown: bool = field(default=False, init=False, repr=False)
     _stop_generation: int = field(default=0, init=False, repr=False)
     _retry_delay_seconds: float = field(default=_INITIAL_RETRY_DELAY_SECONDS, init=False, repr=False)
-    _failed_rooms: set[str] = field(default_factory=set, init=False, repr=False)
+    _room_retries: dict[str, _RoomRetry] = field(default_factory=dict, init=False, repr=False)
     # Events handed to a turn that is still running, kept whole rather than by
     # id. They stay pending durably so a crash replays them, but dispatching
     # one again while its turn is alive would answer the same message twice --
@@ -155,7 +164,15 @@ class PendingEventWorker:
 
     def _owned_tasks(self) -> tuple[asyncio.Task[None], ...]:
         return tuple(
-            task for task in (self._pump, self._retry, self._deferral_scan, *self._lanes.values()) if task is not None
+            task
+            for task in (
+                self._pump,
+                self._retry,
+                self._deferral_scan,
+                *self._lanes.values(),
+                *(retry.task for retry in self._room_retries.values()),
+            )
+            if task is not None
         )
 
     @property
@@ -194,6 +211,7 @@ class PendingEventWorker:
         self._retry = None
         self._deferral_scan = None
         self._lanes.clear()
+        self._room_retries.clear()
         self._rooms_with_more.clear()
         return True
 
@@ -203,7 +221,7 @@ class PendingEventWorker:
         await self.wait_stopped(timeout_seconds=None)
 
     async def drain_once(self) -> int:
-        """Run every currently pending event to completion and return the count.
+        """Run currently eligible events and return the count, skipping room cooldowns.
 
         Exists for startup recovery and for tests, where "the queue is empty"
         has to be observable rather than eventually true. Unlike a pump pass,
@@ -269,6 +287,8 @@ class PendingEventWorker:
         if self._stopped or stop_generation != self._stop_generation:
             return
         lane = self._start_lane(room_id, events)
+        if lane is None:
+            return
         await asyncio.wait([lane])
         # This lane is the drain's own, so whatever ended it is the drain's to
         # report. A cancelled turn is not a failed one: it leaves its event
@@ -293,18 +313,23 @@ class PendingEventWorker:
             return
         started = False
         for room_id, events in by_room.items():
+            if self._room_is_backing_off(room_id):
+                continue
             active = self._lanes.get(room_id)
             if active is not None and not active.done():
                 # Nothing else will look at this room again on its own, so its
                 # lane has to wake the pump when it finishes.
                 self._rooms_with_more.add(room_id)
                 continue
-            started = True
-            self._start_lane(room_id, events)
-        if started:
-            self._retry_delay_seconds = _INITIAL_RETRY_DELAY_SECONDS
+            if self._start_lane(room_id, events) is not None:
+                started = True
         if more_remains:
             self._continue_scanning(dispatched=started)
+        else:
+            self._retry_delay_seconds = _INITIAL_RETRY_DELAY_SECONDS
+        if any(retry.task.done() and room_id not in self._lanes for room_id, retry in self._room_retries.items()):
+            # The scan may not have reached a ready room's failed head yet.
+            self._schedule_retry()
         # A pass that found every deferral still owned starts no lane, so the
         # lane-finished path cannot be the only thing that arms the next look.
         self._schedule_deferral_scan()
@@ -330,8 +355,28 @@ class PendingEventWorker:
         else:
             self._schedule_retry()
 
-    def _start_lane(self, room_id: str, events: list[JournalEvent]) -> asyncio.Task[None]:
-        """Make one room's lane, which is the only one that room may have."""
+    def _start_lane(self, room_id: str, events: list[JournalEvent]) -> asyncio.Task[None] | None:
+        """Admit a lane against current retry state after any scan or lane wait."""
+        if self._room_is_backing_off(room_id):
+            return None
+        retry = self._room_retries.get(room_id)
+        if retry is not None and not any(event.event_id == retry.event.event_id for event in events):
+            events = [event for event in events if event.receipt_order < retry.event.receipt_order]
+        if not events:
+            return None
+        # Cooldown expiry or owner loss while a scan awaited I/O can expose
+        # an earlier deferral after its initial reclaim. Admission owns order.
+        event_ids = {event.event_id for event in events}
+        last_receipt = events[-1].receipt_order
+        reclaimed = (
+            event
+            for event in tuple(self._deferred.values())
+            if event.room_id == room_id
+            and event.receipt_order < last_receipt
+            and event.event_id not in event_ids
+            and not self.deferral_is_live(event)
+        )
+        events = sorted([*events, *reclaimed], key=lambda event: event.receipt_order)
         self._rooms_with_more.discard(room_id)
         lane = asyncio.create_task(self._run_lane(events), name=f"pending_event_lane_{room_id}")
         self._lanes[room_id] = lane
@@ -343,11 +388,57 @@ class PendingEventWorker:
             del self._lanes[room_id]
         if self._stopped or lane.cancelled():
             return
-        if room_id in self._failed_rooms:
-            self._schedule_retry()
-        elif room_id in self._rooms_with_more:
+        if room_id in self._rooms_with_more and not self._room_is_backing_off(room_id):
             self._wake.set()
         self._schedule_deferral_scan()
+
+    def _room_is_backing_off(self, room_id: str) -> bool:
+        retry = self._room_retries.get(room_id)
+        return retry is not None and not retry.task.done()
+
+    def _schedule_room_retry(self, event: JournalEvent) -> None:
+        """Keep each room's cooldown independent of admissions and other rooms."""
+        if self._stopped:
+            return
+        logger.exception(
+            "pending_event_failed",
+            event_id=event.event_id,
+            kind=event.kind.value,
+            room_id=event.room_id,
+        )
+        room_id = event.room_id
+        previous = self._room_retries.get(room_id)
+        delay = (
+            _INITIAL_RETRY_DELAY_SECONDS
+            if previous is None
+            else min(previous.delay_seconds * 2, _MAX_RETRY_DELAY_SECONDS)
+        )
+        task = asyncio.create_task(self._retry_room_after_delay(delay), name=f"pending_event_room_retry_{room_id}")
+        self._room_retries[room_id] = _RoomRetry(delay, task, event)
+
+    async def _retry_room_after_delay(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+        self._wake.set()
+
+    def _clear_room_retry(self, event: JournalEvent) -> None:
+        """Only recovery of the failed event removes its room's ordering fence."""
+        retry = self._room_retries.get(event.room_id)
+        if retry is not None and retry.event.event_id == event.event_id:
+            del self._room_retries[event.room_id]
+
+    async def _forget_settled_room_retries(self) -> None:
+        """An externally settled failed head must not block its room forever."""
+        for room_id, retry in tuple(self._room_retries.items()):
+            if not retry.task.done() or room_id in self._lanes:
+                continue
+            try:
+                pending = await self.store.is_pending(retry.event.event_id)
+            except Exception:
+                if self._room_retries.get(room_id) is retry and room_id not in self._lanes:
+                    self._schedule_room_retry(retry.event)
+                continue
+            if not pending and self._room_retries.get(room_id) is retry and room_id not in self._lanes:
+                del self._room_retries[room_id]
 
     def _schedule_deferral_scan(self) -> None:
         """Arrange one later look while anything is deferred.
@@ -408,6 +499,7 @@ class PendingEventWorker:
         pages earlier -- and a room's lane is handed that list verbatim, so a
         handler that defers rather than settling runs twice on one source.
         """
+        await self._forget_settled_room_retries()
         by_room = self._reclaim_lost_deferrals()
         reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
         origin = self._scan_cursor
@@ -447,6 +539,7 @@ class PendingEventWorker:
         stops moving, and it is that loop, not one pass of it, that has to see
         every event.
         """
+        await self._forget_settled_room_retries()
         by_room = self._reclaim_lost_deferrals()
         reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
         cursor: int | None = None
@@ -477,6 +570,17 @@ class PendingEventWorker:
         for event in page:
             if stop_after is not None and event.receipt_order > stop_after:
                 return True
+            if self._room_is_backing_off(event.room_id):
+                continue
+            retry = self._room_retries.get(event.room_id)
+            if (
+                retry is not None
+                and event.receipt_order > retry.event.receipt_order
+                and not any(prior.event_id == retry.event.event_id for prior in by_room.get(event.room_id, ()))
+            ):
+                # A rotating scan can reach the tail before the failed head.
+                # Wait for the contiguous segment starting at that head.
+                continue
             if event.event_id in already_taken:
                 # The reclaim at the top of this pass already took it back.
                 continue
@@ -504,16 +608,19 @@ class PendingEventWorker:
         """
         by_room: dict[str, list[JournalEvent]] = {}
         for event in tuple(self._deferred.values()):
-            if self.deferral_is_live(event):
+            if self._room_is_backing_off(event.room_id) or self.deferral_is_live(event):
                 continue
-            self._deferred.pop(event.event_id, None)
+            # Keep ownership until a lane actually handles the reclaimed event.
+            # A scan can still lose admission to a busy or newly cooling room.
             logger.warning(
                 "pending_event_deferral_owner_lost",
                 event_id=event.event_id,
                 kind=event.kind.value,
                 room_id=event.room_id,
             )
-            by_room.setdefault(event.room_id, []).append(event)
+            retry = self._room_retries.get(event.room_id)
+            if retry is None or event.receipt_order <= retry.event.receipt_order:
+                by_room.setdefault(event.room_id, []).append(event)
         return by_room
 
     async def _run_lane(self, events: list[JournalEvent]) -> None:
@@ -531,28 +638,23 @@ class PendingEventWorker:
         until some unrelated event woke the pump, and then run its handler a
         second time.
         """
-        room_id = events[0].room_id if events else ""
         for event in events:
             if self._stopped:
                 return
             try:
                 if not await self.store.is_pending(event.event_id):
                     self._deferred.pop(event.event_id, None)
+                    self._clear_room_retry(event)
                     continue
                 if not await self.handle(event):
                     self._deferred[event.event_id] = event
+                    self._clear_room_retry(event)
                     continue
                 self._deferred.pop(event.event_id, None)
                 await self.store.settle(event.event_id)
+                self._clear_room_retry(event)
             except asyncio.CancelledError:
                 raise
             except Exception:
-                logger.exception(
-                    "pending_event_failed",
-                    event_id=event.event_id,
-                    kind=event.kind.value,
-                    room_id=event.room_id,
-                )
-                self._failed_rooms.add(room_id)
+                self._schedule_room_retry(event)
                 return
-        self._failed_rooms.discard(room_id)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -697,7 +697,7 @@ class ResponseRunnerDeps:
     state_writer: ConversationStateWriter
     request_preparer: ResponsePayloadPreparer
     approval_store: PrincipalStore
-    retry_approval_sources: Callable[[tuple[str, ...]], None]
+    retry_approval_sources: Callable[[str, tuple[str, ...]], None]
     approval_runtime_generation: str
 
 
@@ -723,6 +723,7 @@ class _InboxResponseOwnership:
     on_failure: Callable[[], None] | None
     shutdown_phase_trace: ResponseShutdownPhaseTrace
     source_event_ids: frozenset[str]
+    room_id: str
     drain_intent: RuntimeShutdownIntent | None = None
     proof_task: asyncio.Task[bool] | None = None
 
@@ -775,6 +776,7 @@ class ResponseRunner:
         response: Coroutine[Any, Any, None],
         *,
         name: str,
+        room_id: str,
         recovery_proof_ready: Callable[[], bool | Awaitable[bool]],
         on_failure: Callable[[], None] | None = None,
         on_terminal: Callable[[], None] | None = None,
@@ -795,6 +797,7 @@ class ResponseRunner:
             on_failure=on_failure,
             shutdown_phase_trace=shutdown_phase_trace,
             source_event_ids=frozenset(source_event_ids),
+            room_id=room_id,
         )
         if on_terminal is not None:
             task.add_done_callback(lambda _finished: on_terminal())
@@ -842,7 +845,7 @@ class ResponseRunner:
         if ownership is not None and ownership.drain_intent is None:
             self._inbox_response_tasks.pop(task)
         if ownership is not None and ownership.source_event_ids:
-            self.deps.retry_approval_sources(tuple(ownership.source_event_ids))
+            self.deps.retry_approval_sources(ownership.room_id, tuple(ownership.source_event_ids))
         if task.cancelled():
             return
         error = task.exception()
@@ -2565,6 +2568,7 @@ class ResponseRunner:
                 resume,
                 name=f"approval_resume:{continuation.approval_id}:{continuation.generation}",
                 recovery_proof_ready=lambda: True,
+                room_id=continuation.room_id,
                 source_event_ids=continuation.source_event_ids,
             )
         except BaseException:

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -436,9 +436,12 @@ async def _apply_turn_plan(  # noqa: C901
             release_response_claim,
         ),
         name=f"inbox_response:{prepared.event.event_id}",
+        room_id=room.room_id,
         recovery_proof_ready=response_recovery_ready,
         on_failure=lambda: (
-            controller.deps.retry_dispatch_sources(handled_turn.source_event_ids) if response_started.is_set() else None
+            controller.deps.retry_dispatch_sources(room.room_id, handled_turn.source_event_ids)
+            if response_started.is_set()
+            else None
         ),
         on_terminal=release_response_claim,
         source_event_ids=handled_turn.source_event_ids,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -349,7 +349,7 @@ class TurnControllerDeps:
     interrupted_turn_rooms: InterruptedTurnRooms
     visible_voice_echo: VisibleVoiceEchoLifecycle
     visible_responses: VisibleResponseReconciler
-    retry_dispatch_sources: Callable[[tuple[str, ...]], None]
+    retry_dispatch_sources: Callable[[str, tuple[str, ...]], None]
     response_recovery_ready: Callable[[TurnRecord], Awaitable[bool]]
     settle_dispatch_sources: Callable[[tuple[str, ...]], Awaitable[None]]
     dispatch_source_is_terminal: Callable[[str], Awaitable[bool]]
@@ -1367,7 +1367,7 @@ class TurnController:
         try:
             reservation = await self.deps.response_runner.reserve_response_lifecycle(response_envelope)
         except BaseException:
-            self.deps.retry_dispatch_sources((source_event_id,))
+            self.deps.retry_dispatch_sources(response_target.room_id, (source_event_id,))
             raise
 
         async def run_owned_response() -> None:
@@ -1385,7 +1385,7 @@ class TurnController:
                     await self.deps.settle_dispatch_sources((source_event_id,))
             except BaseException:
                 if not response_claim_transferred:
-                    self.deps.retry_dispatch_sources((source_event_id,))
+                    self.deps.retry_dispatch_sources(response_target.room_id, (source_event_id,))
                 raise
             finally:
                 await reservation.release()
@@ -1395,17 +1395,18 @@ class TurnController:
             self.deps.response_runner.track_inbox_response(
                 owned_response,
                 name=f"interactive_selection_response:{source_event_id}",
+                room_id=response_target.room_id,
                 recovery_proof_ready=lambda: (
                     response_target.source_thread_id is not None
                     and self.deps.interrupted_turn_rooms.contains(source_event_id)
                 ),
-                on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
+                on_failure=lambda: self.deps.retry_dispatch_sources(response_target.room_id, (source_event_id,)),
                 source_event_ids=(source_event_id,),
             )
         except BaseException:
             owned_response.close()
             await reservation.release()
-            self.deps.retry_dispatch_sources((source_event_id,))
+            self.deps.retry_dispatch_sources(response_target.room_id, (source_event_id,))
             raise
         # Ownership registration is synchronous, and the task cannot execute
         # until this callback yields after reporting its deferred handoff.

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -529,7 +529,7 @@ def _build_response_runner(
                 logger=bot.logger,
             ),
             approval_store=approval_store,
-            retry_approval_sources=lambda _source_event_ids: None,
+            retry_approval_sources=lambda _room_id, _source_event_ids: None,
             approval_runtime_generation="test-runtime",
         ),
     )

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -1183,7 +1183,7 @@ class TestAgentBot(AgentBotTestBase):
         assert response_completed.is_set()
         settle_dispatch_sources.assert_awaited_once_with(("$reaction",))
         # The failed settlement must hand the exact journal source back for retry.
-        retry_dispatch_sources.assert_called_once_with(("$reaction",))
+        retry_dispatch_sources.assert_called_once_with(target.room_id, ("$reaction",))
 
     @pytest.mark.asyncio
     async def test_interactive_approval_handoff_skips_fallback_source_settlement(
@@ -1335,11 +1335,13 @@ class TestAgentBot(AgentBotTestBase):
             name="test_interactive_claim_owner",
             recovery_proof_ready=lambda: False,
             source_event_ids=("$reaction",),
+            room_id="!room:example.org",
         )
         ordinary_response_task = bot._response_runner.track_inbox_response(
             ordinary_response(),
             name="test_ordinary_response",
             recovery_proof_ready=lambda: False,
+            room_id="!room:example.org",
         )
         await response_started.wait()
         await ordinary_response_started.wait()
@@ -1442,7 +1444,8 @@ class TestAgentBot(AgentBotTestBase):
                 assert deferred is not None
                 bot._journal_dispatcher._worker._deferred[deferred.event_id] = deferred
                 assert bot._journal_dispatcher._deferral_is_live(deferred)
-                assert bot._journal_dispatcher._worker._reclaim_lost_deferrals() == {}
+                assert await bot._journal_dispatcher._worker.drain_once() == 0
+                assert bot._journal_dispatcher._worker._deferred[deferred.event_id] == deferred
             finally:
                 release_resume.set()
                 await asyncio.gather(handoff, return_exceptions=True)
@@ -1645,7 +1648,10 @@ class TestAgentBot(AgentBotTestBase):
                     cards=restarted._journal_store.principal(router_principal_id),
                     transport_sender=lambda: "@mindroom_router:localhost",
                     sending_device=lambda: "DEVICE",
-                    continuation_ready=lambda _entity_name, source_ids: restarted.retry_approval_sources(source_ids),
+                    continuation_ready=lambda _entity_name, room_id, source_ids: restarted.retry_approval_sources(
+                        room_id,
+                        source_ids,
+                    ),
                 )
                 restarted._journal_dispatcher.release_turn_replay()
                 try:
@@ -1694,6 +1700,7 @@ class TestAgentBot(AgentBotTestBase):
                     name="test_late_interactive_claim_owner",
                     recovery_proof_ready=lambda: False,
                     source_event_ids=("$reaction",),
+                    room_id="!room:example.org",
                 ),
             )
             await response_started.wait()
@@ -1775,7 +1782,7 @@ class TestAgentBot(AgentBotTestBase):
                     await bot._response_runner.drain_inbox_responses()
 
             assert not response_entered.is_set()
-            retry_dispatch_sources.assert_called_with(("$reaction",))
+            retry_dispatch_sources.assert_called_with(target.room_id, ("$reaction",))
             if lock_owned_by_test:
                 lifecycle_lock.release()
                 lock_owned_by_test = False

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -761,6 +761,14 @@ class TestAgentBot(AgentBotTestBase):
 
             await bot._journal_dispatcher.drain_once()
             await bot._response_runner.drain_inbox_responses()
+            bot._journal_dispatcher.start()
+            try:
+                async with asyncio.timeout(5):
+                    # Journal settlement has no event signal to await.
+                    while event.event_id in await bot._journal_dispatcher.unsettled_event_ids():  # noqa: ASYNC110
+                        await asyncio.sleep(0.01)
+            finally:
+                await bot._journal_dispatcher.stop()
 
         assert event.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
         assert execute.await_count == 2
@@ -1442,7 +1450,7 @@ class TestAgentBot(AgentBotTestBase):
                 assert bot._response_runner.has_live_inbox_response("$coalesced")
                 deferred = await store.load_event("$source")
                 assert deferred is not None
-                bot._journal_dispatcher._worker._deferred[deferred.event_id] = deferred
+                bot._journal_dispatcher._worker._defer(deferred)
                 assert bot._journal_dispatcher._deferral_is_live(deferred)
                 assert await bot._journal_dispatcher._worker.drain_once() == 0
                 assert bot._journal_dispatcher._worker._deferred[deferred.event_id] == deferred

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -3378,6 +3378,7 @@ async def test_replaced_runtime_refuses_deferred_response_without_matrix_io(
         ),
         name="test_reload_admission_race",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     try:
         await asyncio.sleep(0)

--- a/tests/test_durable_ingestion_admission.py
+++ b/tests/test_durable_ingestion_admission.py
@@ -116,14 +116,13 @@ async def test_acknowledged_retry_wakes_an_idle_semantic_worker(
         return True
 
     worker = PendingEventWorker(store=principal, handle=handle)
-    collect = worker._collect_dispatchable
+    dispatch = worker._dispatch_ready_rooms
 
-    async def collect_and_signal() -> tuple[dict[str, list[JournalEvent]], bool]:
-        result = await collect()
+    async def dispatch_and_signal() -> None:
+        await dispatch()
         worker_idle.set()
-        return result
 
-    monkeypatch.setattr(worker, "_collect_dispatchable", collect_and_signal)
+    monkeypatch.setattr(worker, "_dispatch_ready_rooms", dispatch_and_signal)
 
     async def interrupt_after_commit(
         _record: IngestionRecordAdmission,

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -1377,6 +1377,45 @@ async def corrupt(store: PrincipalStore, *event_ids: str) -> None:
 class TestUnreadableRowsDoNotEndTheBacklog:
     """A short page of pending work has to mean one thing, or paging is a lie."""
 
+    async def test_room_pages_keep_order_and_unreadable_cursor(
+        self,
+        alice: PrincipalStore,
+        journal_store: EventJournalStore,
+    ) -> None:
+        """Room selection must seek past its own corrupt row without mixing owners."""
+        await admit(alice, "$first", ts=9_000)
+        await admit(alice, "$other", room_id="!other:example.org")
+        await admit(journal_store.principal("agent@bob"), "$foreign")
+        await admit(alice, "$corrupt")
+        await admit(alice, "$last", ts=1_000)
+        await corrupt(alice, "$corrupt")
+
+        page = await alice.pending(room_id=ROOM, limit=2)
+
+        assert [event.event_id for event in page] == ["$first"]
+        assert page.unreadable_rows == 1
+        assert not page.reached_end
+        tail = await alice.pending(room_id=ROOM, limit=2, after_receipt_order=page.resume_after)
+        assert [event.event_id for event in tail] == ["$last"]
+        assert tail.reached_end
+        assert [event.event_id for event in await alice.pending(room_id="!other:example.org")] == ["$other"]
+
+    async def test_exact_replay_source_keeps_room_and_principal_scope(
+        self,
+        alice: PrincipalStore,
+        journal_store: EventJournalStore,
+    ) -> None:
+        """A targeted wake resolves only its own eligible source, not nearby rows."""
+        await admit(alice, "$first")
+        await admit(alice, "$target")
+        await admit(journal_store.principal("agent@bob"), "$foreign")
+
+        assert [event.event_id for event in await alice.pending(event_id="$target")] == ["$target"]
+        assert await alice.pending(event_id="$foreign") == ()
+        assert await alice.pending(room_id="!other:example.org", event_id="$target") == ()
+        await alice.settle("$target")
+        assert await alice.pending(event_id="$target") == ()
+
     async def test_a_corrupt_row_shortens_its_page_without_ending_the_backlog(
         self,
         alice: PrincipalStore,
@@ -6383,20 +6422,27 @@ class TestApprovalContinuations:
         assert winner.runtime_generation == "runtime-a"
         assert loser is None
 
-    async def test_pending_page_exposes_only_runnable_primary_source(self, alice: PrincipalStore) -> None:
+    @pytest.mark.parametrize("room_id", [None, ROOM])
+    @pytest.mark.parametrize("event_id", [None, "$source-1"])
+    async def test_pending_page_exposes_only_runnable_primary_source(
+        self,
+        alice: PrincipalStore,
+        room_id: str | None,
+        event_id: str | None,
+    ) -> None:
         """Waiting and live claims stay hidden while ready and old claims re-enter once."""
         await self.admit_sources(alice)
         waiting = self.continuation(state="waiting")
         await alice.create_approval_continuation(waiting)
 
-        assert list(await alice.pending(runtime_generation="runtime-a")) == []
+        assert list(await alice.pending(room_id=room_id, event_id=event_id, runtime_generation="runtime-a")) == []
 
         await alice.request_approval_failure(
             waiting.approval_id,
             "make it runnable",
             expected_state="waiting",
         )
-        failing = await alice.pending(runtime_generation="runtime-a")
+        failing = await alice.pending(room_id=room_id, event_id=event_id, runtime_generation="runtime-a")
         assert [event.event_id for event in failing] == ["$source-1"]
 
     async def test_pending_card_page_exposes_unreadable_durable_debt(self, alice: PrincipalStore) -> None:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -1400,22 +1400,6 @@ class TestUnreadableRowsDoNotEndTheBacklog:
         assert tail.reached_end
         assert [event.event_id for event in await alice.pending(room_id="!other:example.org")] == ["$other"]
 
-    async def test_exact_replay_source_keeps_room_and_principal_scope(
-        self,
-        alice: PrincipalStore,
-        journal_store: EventJournalStore,
-    ) -> None:
-        """A targeted wake resolves only its own eligible source, not nearby rows."""
-        await admit(alice, "$first")
-        await admit(alice, "$target")
-        await admit(journal_store.principal("agent@bob"), "$foreign")
-
-        assert [event.event_id for event in await alice.pending(event_id="$target")] == ["$target"]
-        assert await alice.pending(event_id="$foreign") == ()
-        assert await alice.pending(room_id="!other:example.org", event_id="$target") == ()
-        await alice.settle("$target")
-        assert await alice.pending(event_id="$target") == ()
-
     async def test_a_corrupt_row_shortens_its_page_without_ending_the_backlog(
         self,
         alice: PrincipalStore,
@@ -6423,26 +6407,24 @@ class TestApprovalContinuations:
         assert loser is None
 
     @pytest.mark.parametrize("room_id", [None, ROOM])
-    @pytest.mark.parametrize("event_id", [None, "$source-1"])
     async def test_pending_page_exposes_only_runnable_primary_source(
         self,
         alice: PrincipalStore,
         room_id: str | None,
-        event_id: str | None,
     ) -> None:
         """Waiting and live claims stay hidden while ready and old claims re-enter once."""
         await self.admit_sources(alice)
         waiting = self.continuation(state="waiting")
         await alice.create_approval_continuation(waiting)
 
-        assert list(await alice.pending(room_id=room_id, event_id=event_id, runtime_generation="runtime-a")) == []
+        assert list(await alice.pending(room_id=room_id, runtime_generation="runtime-a")) == []
 
         await alice.request_approval_failure(
             waiting.approval_id,
             "make it runnable",
             expected_state="waiting",
         )
-        failing = await alice.pending(room_id=room_id, event_id=event_id, runtime_generation="runtime-a")
+        failing = await alice.pending(room_id=room_id, runtime_generation="runtime-a")
         assert [event.event_id for event in failing] == ["$source-1"]
 
     async def test_pending_card_page_exposes_unreadable_durable_debt(self, alice: PrincipalStore) -> None:

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -101,7 +101,7 @@ def _gate(
     room_scope_is_single_conversation: bool | None = None,
     dispatch_allowed_now: Callable[[CoalescingKey], bool] | bool | None = None,
     wait_until_dispatch_allowed: Callable[[CoalescingKey], Awaitable[None]] | None = None,
-    on_undelivered_source: Callable[[str], None] | None = None,
+    on_undelivered_source: Callable[[str, str], None] | None = None,
     on_intentionally_ignored_source: Callable[[str], Awaitable[None]] | None = None,
 ) -> tuple[CoalescingGate, list[PreparedTurn]]:
     batches: list[PreparedTurn] = []
@@ -656,7 +656,7 @@ async def test_ignored_source_remains_owned_during_durable_settlement(
 @pytest.mark.asyncio
 async def test_failed_ignored_source_settlement_returns_source_to_retry_owner() -> None:
     """A failed terminal write must not suppress its own durable retry handoff."""
-    undelivered_sources: list[str] = []
+    undelivered_sources: list[tuple[str, str]] = []
 
     async def fail_settlement(_event_id: str) -> None:
         msg = "tracking store unavailable"
@@ -664,7 +664,7 @@ async def test_failed_ignored_source_settlement_returns_source_to_retry_owner() 
 
     gate, _batches = _gate(
         debounce_seconds=0.0,
-        on_undelivered_source=undelivered_sources.append,
+        on_undelivered_source=lambda room_id, source_id: undelivered_sources.append((room_id, source_id)),
         on_intentionally_ignored_source=fail_settlement,
     )
 
@@ -681,7 +681,7 @@ async def test_failed_ignored_source_settlement_returns_source_to_retry_owner() 
     )
 
     await slot.settled.wait()
-    assert undelivered_sources == ["$ignored-media"]
+    assert undelivered_sources == [("!room:localhost", "$ignored-media")]
 
 
 @pytest.mark.asyncio
@@ -1296,6 +1296,7 @@ async def test_response_cancellation_drains_follow_up_queue(tmp_path: Path) -> N
         blocked_response(),
         name="test_blocked_response",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(response_running.wait(), timeout=1.0)
     with patch("mindroom.turn_controller.dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)):
@@ -1504,6 +1505,7 @@ async def test_bounded_inbox_drain_cancels_stuck_response(tmp_path: Path) -> Non
         stuck_response(),
         name="test_stuck_response",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(started.wait(), timeout=1.0)
 
@@ -1539,6 +1541,7 @@ async def test_bounded_inbox_drain_rejects_indefinitely_resistant_response(tmp_p
         cancellation_resistant_response(),
         name="test_cancellation_resistant_response",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(started.wait(), timeout=1.0)
     drain_task = asyncio.create_task(
@@ -1578,6 +1581,7 @@ async def test_bounded_inbox_drain_preserves_cancel_message(tmp_path: Path) -> N
         stuck_response(),
         name="test_sync_restart_cancelled_response",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(started.wait(), timeout=1.0)
 
@@ -1612,6 +1616,7 @@ async def test_failed_inbox_response_is_contained_and_unregistered(tmp_path: Pat
         failing_response(),
         name="test_failing_response",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.gather(task, return_exceptions=True)
     await asyncio.sleep(0)

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -49,6 +49,7 @@ from mindroom.matrix.journal_ingress import (
 )
 from mindroom.pending_event_worker import _BATCH_SIZE, PendingEventWorker
 from tests.journal_helpers import admit_dispatch_event
+from tests.test_event_journal_store import TestApprovalContinuations as _ApprovalContinuations
 from tests.test_event_journal_store import corrupt
 
 if TYPE_CHECKING:
@@ -1926,6 +1927,96 @@ async def _dispatch_worker_pass(worker: PendingEventWorker) -> None:
 class TestRoomRetryBackoff:
     """Only a room's own successful work resets its bounded retry delay."""
 
+    async def test_wrapped_retry_wakes_the_skipped_tail(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Recovering the head must wake work skipped before the scan wrapped."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 4)
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$head" and attempts.count("$head") == 1:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        for event_id, room_id in (
+            ("$head", ROOM),
+            ("$filler1", "!healthy1:example.org"),
+            ("$filler2", "!healthy2:example.org"),
+            ("$filler3", "!healthy3:example.org"),
+            ("$tail", ROOM),
+        ):
+            await TestPendingEventWorker._admit(alice, text_event(event_id), room_id)
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            retry_sleeps[0][1].set()
+            await worker._room_retries[ROOM].task
+            worker.start()
+            await _eventually_async(alice.pending)
+            assert [event_id for event_id in attempts if event_id in {"$head", "$tail"}] == ["$head", "$head", "$tail"]
+        finally:
+            await worker.stop()
+
+    async def test_approval_owned_failed_source_releases_its_room(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """A source transferred to an approval must not fence later room work."""
+        for event_id in ("$source-1", "$source-2", "$later"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        approval_created = False
+
+        class ApprovalDuringScan(_FlakyReplayView):
+            async def pending(
+                self,
+                *,
+                limit: int = 256,
+                after_receipt_order: int | None = None,
+                runtime_generation: str = "unmanaged",
+            ) -> PendingPage:
+                nonlocal approval_created
+                page = await super().pending(
+                    limit=limit,
+                    after_receipt_order=after_receipt_order,
+                    runtime_generation=runtime_generation,
+                )
+                if not approval_created:
+                    approval_created = True
+                    await alice.create_approval_continuation(_ApprovalContinuations.continuation(state="waiting"))
+                return page
+
+        handled: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            return True
+
+        worker = PendingEventWorker(
+            store=ApprovalDuringScan(alice, fail_is_pending={"$source-1"}),
+            handle=handle,
+        )
+        try:
+            await _dispatch_worker_pass(worker)
+            assert handled == []
+            assert [event.event_id for event in await alice.pending()] == ["$later"]
+            retry_sleeps[0][1].set()
+            await worker._room_retries[ROOM].task
+            worker.start()
+            await _eventually_async(alice.pending)
+            assert handled == ["$later"]
+            assert await alice.is_pending("$source-1")
+            assert await alice.is_pending("$source-2")
+        finally:
+            await worker.stop()
+
     @pytest.mark.parametrize("drain", [False, True])
     async def test_admissions_do_not_bypass_a_failed_rooms_cooldown(
         self,
@@ -2168,7 +2259,8 @@ class TestRoomRetryBackoff:
             await _dispatch_worker_pass(worker)
             retry_sleeps[0][1].set()
             await asyncio.sleep(0)
-            store.fail_is_pending.add("$failed")
+            failed = (await alice.pending())[0]
+            store.fail_pending_after.add(failed.receipt_order - 1)
             await TestPendingEventWorker._admit(alice, text_event("$healthy"), "!healthy:example.org")
             await _dispatch_worker_pass(worker)
             assert handled == ["$healthy"]
@@ -2930,6 +3022,7 @@ class _FlakyReplayView:
     inner: PrincipalStore
     fail_is_pending: set[str] = field(default_factory=set)
     fail_settle: set[str] = field(default_factory=set)
+    fail_pending_after: set[int] = field(default_factory=set)
 
     async def pending(
         self,
@@ -2938,6 +3031,10 @@ class _FlakyReplayView:
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
+        if after_receipt_order is not None and after_receipt_order in self.fail_pending_after:
+            self.fail_pending_after.remove(after_receipt_order)
+            msg = "the journal is unreadable"
+            raise RuntimeError(msg)
         return await self.inner.pending(
             limit=limit,
             after_receipt_order=after_receipt_order,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -2096,12 +2096,15 @@ class TestRoomRetryBackoff:
             await worker.stop()
 
     @pytest.mark.parametrize("cooldown_passes", [0, 4])
+    @pytest.mark.parametrize("earlier_fails", [False, True])
     async def test_reclaimed_earlier_event_does_not_release_later_slice_before_failed_head(
         self,
         alice: PrincipalStore,
         retry_sleeps: list[tuple[float, asyncio.Event]],
         monkeypatch: pytest.MonkeyPatch,
         cooldown_passes: int,
+        *,
+        earlier_fails: bool,
     ) -> None:
         """Reclaimed work before the failure cannot make a later scan slice safe."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
@@ -2112,6 +2115,9 @@ class TestRoomRetryBackoff:
         async def handle(event: JournalEvent) -> bool:
             attempts.append(event.event_id)
             if event.event_id == "$earlier":
+                if earlier_fails and not owner_live and attempts.count("$earlier") == 2:
+                    msg = "earlier callback unavailable"
+                    raise RuntimeError(msg)
                 return not owner_live
             if event.event_id == "$failed" and attempts.count("$failed") == 1:
                 msg = "callback unavailable"
@@ -2129,9 +2135,17 @@ class TestRoomRetryBackoff:
                 await _dispatch_worker_pass(worker)
             retry_sleeps[0][1].set()
             await asyncio.sleep(0)
+            if earlier_fails:
+                await _dispatch_worker_pass(worker)
+                assert attempts == ["$earlier", "$failed", "$earlier"]
+                retry_sleeps[-1][1].set()
+                await asyncio.sleep(0)
             for _ in range(8):
                 await _dispatch_worker_pass(worker)
-            assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
+            if earlier_fails:
+                assert attempts == ["$earlier", "$failed", "$earlier", "$earlier", "$failed", "$later", "$last"]
+            else:
+                assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
         finally:
             await worker.stop()
 

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1339,6 +1339,7 @@ class TestPendingEventWorker:
     async def test_owner_lost_within_one_page_rewinds_before_later_callback(
         self,
         alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
     ) -> None:
         """An earlier handoff can die while the same page checks its next source."""
         owner_live = True
@@ -1364,6 +1365,11 @@ class TestPendingEventWorker:
         )
         try:
             await asyncio.wait_for(worker.drain_once(), timeout=5)
+            assert handled == ["$earlier"]
+            await _eventually(lambda: len(retry_sleeps) == 1)
+            worker.start()
+            retry_sleeps[0][1].set()
+            await _eventually_async(alice.pending)
             assert handled == ["$earlier", "$earlier", "$later"]
             assert await alice.unsettled_event_ids() == frozenset()
         finally:
@@ -1884,7 +1890,7 @@ class TestPendingEventWorker:
 
         async def handle(event: JournalEvent) -> bool:
             handled.append(event.event_id)
-            return False
+            return True
 
         await self._admit(alice, text_event("$early", ts=1_000))
         await self._admit(alice, text_event("$late", ts=2_000))
@@ -1993,6 +1999,88 @@ async def _dispatch_worker_pass(worker: PendingEventWorker) -> None:
 
 class TestRoomRetryBackoff:
     """Only a room's own successful work resets its bounded retry delay."""
+
+    async def test_alternating_failed_owners_cannot_keep_a_drain_running(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A lifecycle lock handoff may lose the previous source's owner each time."""
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        attempts: list[str] = []
+        live: set[str] = set()
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            live.clear()
+            live.add(event.event_id)
+            return False
+
+        for event_id in ("$first", "$second"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda event: event.event_id in live)
+        try:
+            await asyncio.wait_for(worker.drain_once(), timeout=1)
+            assert attempts == ["$first", "$second"]
+            await _eventually(lambda: len(retry_sleeps) == 1)
+            assert retry_sleeps[0][0] == 1
+            assert await alice.unsettled_event_ids() == frozenset({"$first", "$second"})
+        finally:
+            await worker.stop()
+
+    @pytest.mark.parametrize("max_pages", [1, 16])
+    @pytest.mark.parametrize("wake_on_return", [False, True])
+    async def test_ownerless_handoffs_pause_the_room_without_trapping_a_drain(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        max_pages: int,
+        *,
+        wake_on_return: bool,
+    ) -> None:
+        """A promptly failed downstream owner cannot spin or let later work pass."""
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", max_pages)
+        attempts: list[str] = []
+        failing = True
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id != "$earlier" or not failing:
+                return True
+            if wake_on_return:
+                worker.release((event.event_id,))
+                worker.wake(room_id=event.room_id)
+            return False
+
+        for event_id in ("$earlier", "$later"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        await TestPendingEventWorker._admit(alice, text_event("$healthy"), "!healthy:example.org")
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: False)
+        try:
+            await asyncio.wait_for(worker.drain_once(), timeout=1)
+            assert sorted(attempts) == ["$earlier", "$healthy"]
+            await _eventually(lambda: len(retry_sleeps) == 1)
+            assert retry_sleeps[0][0] == 1
+            worker.start()
+            worker.wake(room_id=ROOM)
+            await worker.drain_once()
+            assert attempts.count("$earlier") == 1
+
+            retry_sleeps[0][1].set()
+            await _eventually(lambda: len(retry_sleeps) == 2)
+            assert attempts.count("$earlier") == 2
+            assert "$later" not in attempts
+            assert retry_sleeps[1][0] == 2
+
+            failing = False
+            retry_sleeps[1][1].set()
+            await _eventually_async(alice.pending)
+            assert attempts.count("$earlier") == 3
+            assert attempts[-1] == "$later"
+        finally:
+            await worker.stop()
 
     async def test_busy_room_keeps_work_skipped_by_discovery_in_order(
         self,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1449,9 +1449,14 @@ class TestPendingEventWorker:
                 tracked_lane.cancel()
             await asyncio.gather(stopping, draining, *worker._lanes.values(), return_exceptions=True)
 
+    @pytest.mark.parametrize("retry_source", [False, True])
+    @pytest.mark.parametrize("read_fails", [False, True])
     async def test_a_pre_stop_recovery_drain_cannot_dispatch_after_restart(
         self,
         alice: PrincipalStore,
+        *,
+        retry_source: bool,
+        read_fails: bool,
     ) -> None:
         """Restarting does not make an old drain current again."""
         first_read_started = asyncio.Event()
@@ -1467,6 +1472,8 @@ class TestPendingEventWorker:
                 self,
                 *,
                 limit: int = 256,
+                room_id: str | None = None,
+                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
@@ -1474,11 +1481,16 @@ class TestPendingEventWorker:
                 if self.pending_calls == 1:
                     page = await self.inner.pending(
                         limit=limit,
+                        room_id=room_id,
+                        event_id=event_id,
                         after_receipt_order=after_receipt_order,
                         runtime_generation=runtime_generation,
                     )
                     first_read_started.set()
                     await release_first_read.wait()
+                    if read_fails:
+                        msg = "stale read failed"
+                        raise RuntimeError(msg)
                     return page
                 return PendingPage((), resume_after=None, reached_end=True, unreadable_rows=0)
 
@@ -1495,6 +1507,8 @@ class TestPendingEventWorker:
 
         await self._admit(alice, text_event("$message"))
         worker = PendingEventWorker(store=BlockingFirstRead(alice), handle=handle)
+        if retry_source:
+            worker.wake(event_ids=("$message",))
         stale_drain = asyncio.create_task(worker.drain_once())
         await first_read_started.wait()
 
@@ -1502,10 +1516,16 @@ class TestPendingEventWorker:
         worker.start()
         try:
             release_first_read.set()
-            await asyncio.wait_for(stale_drain, timeout=1.0)
+            if read_fails and not retry_source:
+                with pytest.raises(RuntimeError, match="stale read failed"):
+                    await asyncio.wait_for(stale_drain, timeout=1.0)
+            else:
+                await asyncio.wait_for(stale_drain, timeout=1.0)
             await asyncio.sleep(0)
 
             assert not handled.is_set()
+            assert worker._rooms == {}
+            assert worker._retry_sources == set()
         finally:
             release_first_read.set()
             await worker.stop()
@@ -1653,7 +1673,7 @@ class TestPendingEventWorker:
         # because that note is the only thing that arranges the second look. A
         # bare yield cannot fail -- a second lane over one room is impossible
         # either way -- so it proved the wakeup without exercising it.
-        await _eventually(lambda: worker._rooms_with_more == {ROOM})
+        await _eventually(lambda: worker._ready_rooms == {ROOM})
         released.set()
 
         await _eventually(lambda: handled == ["$slow", "$late"])
@@ -1799,14 +1819,7 @@ class TestPendingEventWorker:
         self,
         alice: PrincipalStore,
     ) -> None:
-        """A lane runs its list verbatim, so the list has to be in receipt order.
-
-        Reclaimed deferrals seed the grouping before any page is read, and the
-        reclaim knows nothing about where they sit in the backlog. So a later
-        message taken back from a dead owner was handed to the room's lane
-        ahead of an earlier one that had simply never run -- the room answered
-        out of order, which is the one thing a lane exists to prevent.
-        """
+        """Reclaiming a later deferral still starts with the room's earliest work."""
         handled: list[str] = []
         owner_alive = True
 
@@ -1822,8 +1835,7 @@ class TestPendingEventWorker:
             deferral_is_live=lambda _event: owner_alive,
         )
 
-        # Seed a later deferred source, then reclaim it alongside the earlier
-        # pending row. The lane must merge both in receipt order.
+        # A lost owner requests replay; the room query determines its order.
         late = await alice.load_event("$late")
         assert late is not None
         worker._deferred["$late"] = late
@@ -1833,34 +1845,30 @@ class TestPendingEventWorker:
 
         assert handled == ["$early", "$late"]
 
-    async def test_a_wrapped_pass_does_not_run_its_tail_before_its_head(
+    async def test_a_wrapped_discovery_keeps_room_callbacks_in_receipt_order(
         self,
         alice: PrincipalStore,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The other way one room's list comes out inverted.
-
-        A pass that ran out of page budget resumes at its cursor, reads to the
-        end of the backlog, and only then wraps to the front. Those two blocks
-        arrive in the opposite order to the one they were received in, and the
-        room's lane is handed the concatenation.
-        """
+        """Discovery can start at the tail without handing that tail to the lane."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 2)
         monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 3)
         for index in range(8):
             await self._admit(alice, text_event(f"$m{index}", ts=1_000 + index))
+        handled: list[str] = []
 
         async def handle(event: JournalEvent) -> bool:
-            del event
+            handled.append(event.event_id)
             return True
 
         worker = PendingEventWorker(store=alice, handle=handle)
-        # One budget-limited pass parks the cursor part way through the
-        # backlog; the next reads the tail, hits the end, and wraps.
-        await worker._collect_dispatchable()
-        by_room, _more = await worker._collect_dispatchable()
-
-        assert [event.event_id for event in by_room[ROOM]] == ["$m0", "$m1", "$m6", "$m7"]
+        worker._scan_cursor = (await alice.pending(limit=6))[-1].receipt_order
+        worker.start()
+        try:
+            await _eventually_async(alice.pending)
+            assert handled == ["$m0", "$m1", "$m2", "$m3", "$m4", "$m5", "$m6", "$m7"]
+        finally:
+            await worker.stop()
 
     async def test_a_lost_owner_is_noticed_without_any_further_admission(
         self,
@@ -1927,6 +1935,77 @@ async def _dispatch_worker_pass(worker: PendingEventWorker) -> None:
 class TestRoomRetryBackoff:
     """Only a room's own successful work resets its bounded retry delay."""
 
+    async def test_busy_room_keeps_work_skipped_by_discovery_in_order(
+        self,
+        alice: PrincipalStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A busy lane cannot lose its earlier messages as discovery moves on."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$first":
+                entered.set()
+                await release.wait()
+            return True
+
+        for event_id in ("$first", "$second", "$third", "$fourth"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await worker._dispatch_ready_rooms()
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            await worker._dispatch_ready_rooms()
+            await worker._dispatch_ready_rooms()
+            release.set()
+            await asyncio.gather(*worker._lanes.values())
+            await asyncio.sleep(0)
+            await _dispatch_worker_pass(worker)
+            assert attempts[:2] == ["$first", "$second"]
+            for _ in range(4):
+                await _dispatch_worker_pass(worker)
+            assert attempts == ["$first", "$second", "$third", "$fourth"]
+        finally:
+            release.set()
+            await worker.stop()
+
+    async def test_ready_retry_runs_while_new_admissions_keep_discovery_advancing(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Recovery must not depend on reaching the end of a growing global scan."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if attempts == ["$head"]:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$head"))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            retry_sleeps[0][1].set()
+            await worker._room_retries[ROOM].task
+            for index in range(8):
+                await TestPendingEventWorker._admit(alice, text_event(f"$later-{index}"))
+                await _dispatch_worker_pass(worker)
+            assert attempts[:2] == ["$head", "$head"]
+            assert not await alice.is_pending("$head")
+        finally:
+            await worker.stop()
+
     async def test_wrapped_retry_wakes_the_skipped_tail(
         self,
         alice: PrincipalStore,
@@ -1964,10 +2043,9 @@ class TestRoomRetryBackoff:
         finally:
             await worker.stop()
 
-    async def test_approval_owned_failed_source_releases_its_room(
+    async def test_room_read_respects_approval_handoff_after_discovery(
         self,
         alice: PrincipalStore,
-        retry_sleeps: list[tuple[float, asyncio.Event]],
     ) -> None:
         """A source transferred to an approval must not fence later room work."""
         for event_id in ("$source-1", "$source-2", "$later"):
@@ -1979,12 +2057,16 @@ class TestRoomRetryBackoff:
                 self,
                 *,
                 limit: int = 256,
+                room_id: str | None = None,
+                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
                 nonlocal approval_created
                 page = await super().pending(
                     limit=limit,
+                    room_id=room_id,
+                    event_id=event_id,
                     after_receipt_order=after_receipt_order,
                     runtime_generation=runtime_generation,
                 )
@@ -2000,21 +2082,86 @@ class TestRoomRetryBackoff:
             return True
 
         worker = PendingEventWorker(
-            store=ApprovalDuringScan(alice, fail_is_pending={"$source-1"}),
+            store=ApprovalDuringScan(alice),
             handle=handle,
         )
         try:
-            await _dispatch_worker_pass(worker)
-            assert handled == []
-            assert [event.event_id for event in await alice.pending()] == ["$later"]
-            retry_sleeps[0][1].set()
-            await worker._room_retries[ROOM].task
             worker.start()
             await _eventually_async(alice.pending)
             assert handled == ["$later"]
             assert await alice.is_pending("$source-1")
             assert await alice.is_pending("$source-2")
         finally:
+            await worker.stop()
+
+    @pytest.mark.parametrize("lookup_race", ["ready", "stale", "failed"])
+    async def test_exact_approval_wake_rewinds_before_unstarted_tail(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        lookup_race: str,
+    ) -> None:
+        """Exact wakes survive stale or failed reads after approval ownership moves."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        generation = "runtime-a"
+        store = _ApprovalWakeReplayView(alice, lookup_race=lookup_race)
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id != "$source-1":
+                return True
+            if attempts.count("$source-1") == 1:
+                created = await alice.create_approval_continuation(
+                    replace(_ApprovalContinuations.continuation(state="waiting"), runtime_generation=generation),
+                )
+                assert created is not None
+                await _ApprovalContinuations.remember_card(alice)
+            else:
+                claimed = await alice.claim_approval_continuation("approval-1", runtime_generation=generation)
+                assert claimed is not None
+                assert claimed.state == "claimed"
+            return False
+
+        for event_id in ("$source-1", "$source-2", "$middle", "$tail"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        middle = (await alice.pending(event_id="$middle"))[0]
+        worker = PendingEventWorker(store=store, handle=handle, runtime_generation=generation)
+        try:
+            worker.start()
+            await asyncio.wait_for(store.tail_read_entered.wait(), timeout=5)
+            assert attempts == ["$source-1", "$middle"]
+            assert store.tail_read_after == middle.receipt_order
+            worker.release(("$source-1",))
+            assert await alice.pending(event_id="$source-1", runtime_generation=generation) == ()
+            if lookup_race == "stale":
+                worker.wake(event_ids=("$source-1",))
+                await asyncio.wait_for(store.empty_lookup_entered.wait(), timeout=5)
+            recorded = await alice.resolve_continuation_approval_card(
+                card_event_id="$approval",
+                requested_status="approved",
+                reason=None,
+                resolution={"status": "approved"},
+            )
+            assert recorded.continuation_ready
+            worker.wake(event_ids=("$source-1",))
+            store.release_empty_lookup.set()
+            if lookup_race == "failed":
+                await _eventually(lambda: len(retry_sleeps) == 1)
+                retry_sleeps[0][1].set()
+            await asyncio.wait_for(store.fresh_lookup_returned.wait(), timeout=5)
+            assert store.exact_reads == (1 if lookup_race == "ready" else 2)
+            assert attempts == ["$source-1", "$middle"]
+            store.release_tail_read.set()
+            await _eventually_async(lambda: alice.pending(runtime_generation=generation))
+            assert attempts == ["$source-1", "$middle", "$source-1", "$tail"]
+            assert await alice.is_pending("$source-1")
+            assert await alice.is_pending("$source-2")
+            assert not await alice.is_pending("$tail")
+        finally:
+            store.release_empty_lookup.set()
+            store.release_tail_read.set()
             await worker.stop()
 
     @pytest.mark.parametrize("drain", [False, True])
@@ -2277,32 +2424,37 @@ class TestRoomRetryBackoff:
         *,
         owner_dies_during_scan: bool,
     ) -> None:
-        """Cooldown expiry or owner death during I/O cannot hide an earlier deferral."""
+        """Owner loss before or during a room read preserves earlier work."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
         monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
         owner_live = True
-        block_page = False
+        block_next_room_page = False
         page_entered = asyncio.Event()
         release_page = asyncio.Event()
+        blocked_event_ids: list[str] = []
         attempts: list[str] = []
-        for event_id in ("$earlier", "$failed", "$later", "$last"):
-            await TestPendingEventWorker._admit(alice, text_event(event_id))
-        earlier = (await alice.pending())[0]
 
-        class BlockingRetryPage(_FlakyReplayView):
+        class BlockingRoomRead(_FlakyReplayView):
             async def pending(
                 self,
                 *,
                 limit: int = 256,
+                room_id: str | None = None,
+                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
+                nonlocal block_next_room_page
                 page = await super().pending(
                     limit=limit,
+                    room_id=room_id,
+                    event_id=event_id,
                     after_receipt_order=after_receipt_order,
                     runtime_generation=runtime_generation,
                 )
-                if block_page and after_receipt_order == earlier.receipt_order:
+                if room_id == ROOM and block_next_room_page:
+                    block_next_room_page = False
+                    blocked_event_ids.extend(event.event_id for event in page)
                     page_entered.set()
                     await release_page.wait()
                 return page
@@ -2316,39 +2468,35 @@ class TestRoomRetryBackoff:
                 raise RuntimeError(msg)
             return True
 
+        for event_id in ("$earlier", "$failed", "$later", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
         worker = PendingEventWorker(
-            store=BlockingRetryPage(alice),
+            store=BlockingRoomRead(alice),
             handle=handle,
             deferral_is_live=lambda _event: owner_live,
         )
-        await _dispatch_worker_pass(worker)
-        await _dispatch_worker_pass(worker)
-        owner_live = owner_dies_during_scan
-        for _ in range(4):
-            await _dispatch_worker_pass(worker)
-        assert worker._scan_cursor == earlier.receipt_order
-        block_page = True
-        scanning = asyncio.create_task(_dispatch_worker_pass(worker))
         try:
-            await page_entered.wait()
-            owner_live = False
+            await asyncio.wait_for(worker.drain_once(), timeout=5)
+            await _eventually(lambda: len(retry_sleeps) == 1)
+            assert attempts == ["$earlier", "$failed"]
+            owner_live = owner_dies_during_scan
+            block_next_room_page = True
+            worker.start()
             retry_sleeps[0][1].set()
-            await asyncio.sleep(0)
+            await asyncio.wait_for(page_entered.wait(), timeout=5)
+            assert blocked_event_ids == ["$failed" if owner_dies_during_scan else "$earlier"]
+            assert attempts == ["$earlier", "$failed"]
+            owner_live = False
             release_page.set()
-            await scanning
-            assert attempts == ["$earlier", "$failed", "$earlier", "$failed"]
-            for _ in range(4):
-                await _dispatch_worker_pass(worker)
+            await _eventually_async(alice.pending)
             assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
             assert await alice.unsettled_event_ids() == frozenset()
         finally:
             release_page.set()
-            scanning.cancel()
-            await asyncio.gather(scanning, return_exceptions=True)
             await worker.stop()
 
     @pytest.mark.parametrize("drain", [False, True])
-    async def test_stale_tail_cannot_overtake_head_that_failed_during_scan(
+    async def test_concurrent_drain_respects_room_read_ownership_and_failure(
         self,
         alice: PrincipalStore,
         retry_sleeps: list[tuple[float, asyncio.Event]],
@@ -2356,74 +2504,122 @@ class TestRoomRetryBackoff:
         *,
         drain: bool,
     ) -> None:
-        """Final lane admission rechecks failures that appeared during an awaited scan."""
+        """A reserved room read excludes another drain through head failure."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
-        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
-        entered_head = asyncio.Event()
-        fail_head = asyncio.Event()
-        entered_last_page = asyncio.Event()
-        release_last_page = asyncio.Event()
+        store = _ReservedRoomReplayView(alice)
         attempts: list[str] = []
-        for event_id in ("$head", "$tail", "$last"):
-            await TestPendingEventWorker._admit(alice, text_event(event_id))
-        admitted = await alice.pending()
-        tail = admitted[1]
-
-        class BlockingLastPage(_FlakyReplayView):
-            async def pending(
-                self,
-                *,
-                limit: int = 256,
-                after_receipt_order: int | None = None,
-                runtime_generation: str = "unmanaged",
-            ) -> PendingPage:
-                page = await super().pending(
-                    limit=limit,
-                    after_receipt_order=after_receipt_order,
-                    runtime_generation=runtime_generation,
-                )
-                if after_receipt_order == tail.receipt_order:
-                    entered_last_page.set()
-                    await release_last_page.wait()
-                return page
+        first_drain: asyncio.Task[int] | None = None
 
         async def handle(event: JournalEvent) -> bool:
             attempts.append(event.event_id)
-            if attempts == ["$head"]:
-                entered_head.set()
-                await fail_head.wait()
+            if event.event_id == "$head" and attempts.count("$head") == 1:
                 msg = "callback unavailable"
                 raise RuntimeError(msg)
             return True
 
-        worker = PendingEventWorker(store=BlockingLastPage(alice), handle=handle)
-        await worker._dispatch_ready_rooms()
-        await entered_head.wait()
-        head_lane = worker._lanes[ROOM]
-        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 2)
-        scanning = asyncio.create_task(worker._collect_dispatchable() if drain else worker._dispatch_ready_rooms())
+        for event_id in ("$head", "$tail", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=store, handle=handle)
         try:
-            await entered_last_page.wait()
-            fail_head.set()
-            await head_lane
-            await asyncio.sleep(0)
-            retry_sleeps[0][1].set()
-            await asyncio.sleep(0)
-            release_last_page.set()
-            await scanning
             if drain:
-                await worker._drain_room(ROOM, [tail], stop_generation=worker._stop_generation)
-            await asyncio.gather(*worker._lanes.values())
+                first_drain = asyncio.create_task(worker.drain_once())
+            else:
+                worker.start()
+            await asyncio.wait_for(store.page_entered.wait(), timeout=5)
+            store.competing_drain = asyncio.create_task(worker.drain_once())
+            await asyncio.wait_for(store.competing_discovered.wait(), timeout=5)
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(store.overlapping_reads.wait(), timeout=0.1)
+            assert not store.overlapping_reads.is_set()
+            assert store.room_reads == 1
+            assert attempts == []
+            store.release_page.set()
+            await asyncio.wait_for(store.competing_drain, timeout=5)
+            if first_drain is not None:
+                await asyncio.wait_for(first_drain, timeout=5)
+            await _eventually(lambda: len(retry_sleeps) == 1)
             assert attempts == ["$head"]
-            for _ in range(4):
-                await _dispatch_worker_pass(worker)
+            assert store.room_reads == 1
+            assert await alice.unsettled_event_ids() == frozenset({"$head", "$tail", "$last"})
+            worker.start()
+            retry_sleeps[0][1].set()
+            await _eventually_async(alice.pending)
             assert attempts == ["$head", "$head", "$tail", "$last"]
-            assert await alice.unsettled_event_ids() == frozenset()
         finally:
-            fail_head.set()
-            release_last_page.set()
-            scanning.cancel()
-            await asyncio.gather(scanning, return_exceptions=True)
+            store.release_page.set()
+            drains = [task for task in (first_drain, store.competing_drain) if task is not None]
+            for task in drains:
+                task.cancel()
+            await asyncio.gather(*drains, return_exceptions=True)
+            await worker.stop()
+
+    @pytest.mark.parametrize("fails_first", [False, True])
+    async def test_room_progress_does_not_wait_for_stalled_discovery(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        fails_first: bool,
+    ) -> None:
+        """A discovered room owns page continuation and retry despite slow discovery."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        discovery_started = asyncio.Event()
+        release_discovery = asyncio.Event()
+        release_head = asyncio.Event()
+        attempts: list[str] = []
+        global_reads = 0
+
+        class SlowDiscovery(_FlakyReplayView):
+            async def pending(
+                self,
+                *,
+                limit: int = 256,
+                room_id: str | None = None,
+                event_id: str | None = None,
+                after_receipt_order: int | None = None,
+                runtime_generation: str = "unmanaged",
+            ) -> PendingPage:
+                nonlocal global_reads
+                if room_id is None and event_id is None:
+                    global_reads += 1
+                    if global_reads > 1:
+                        discovery_started.set()
+                        await release_discovery.wait()
+                return await super().pending(
+                    limit=limit,
+                    room_id=room_id,
+                    event_id=event_id,
+                    after_receipt_order=after_receipt_order,
+                    runtime_generation=runtime_generation,
+                )
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if len(attempts) == 1:
+                if fails_first:
+                    msg = "callback unavailable"
+                    raise RuntimeError(msg)
+                await release_head.wait()
+            return True
+
+        for event_id in ("$head", "$tail", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=SlowDiscovery(alice), handle=handle)
+        worker.start()
+        try:
+            await asyncio.wait_for(discovery_started.wait(), timeout=5)
+            if fails_first:
+                await _eventually(lambda: len(retry_sleeps) == 1)
+                retry_sleeps[0][1].set()
+            else:
+                release_head.set()
+            await _eventually_async(alice.pending)
+            assert attempts == (["$head", "$head"] if fails_first else ["$head"]) + ["$tail", "$last"]
+        finally:
+            release_head.set()
+            release_discovery.set()
             await worker.stop()
 
     async def test_shutdown_cancels_room_cooldown_and_restart_replays_pending_work(
@@ -2888,65 +3084,32 @@ class TestABoundedScanIsFair:
         finally:
             await worker.stop()
 
-    async def test_a_wrapped_pass_stops_at_the_position_it_set_out_from(
-        self,
-        alice: PrincipalStore,
-    ) -> None:
-        """One revolution, not an unbounded lap of a circle.
-
-        A pass resumed part way through the backlog runs to the end and then
-        starts again at the front, and nothing stopped it running past its own
-        origin and collecting what it had already collected pages earlier. The
-        room's lane is handed that list as it stands, and a handler that defers
-        rather than settling is not saved by the pending recheck in front of
-        it: it runs a second time on one source.
-
-        Asked of the scan rather than of a lane, because the duplicate is in
-        the list the scan produces and reading it there is exact -- through a
-        lane it is a race between two dispatches of one event.
-
-        Five events, each once, is what the stop proves: a pass that ran past
-        its origin collects ``$e3`` and ``$e4`` twice, which no ordering of the
-        result can hide.
-        """
-        for index in range(5):
-            await self._admit(alice, text_event(f"$e{index}", ts=1_000 + index), ROOM)
-        admitted = await alice.pending(limit=5)
-        worker = PendingEventWorker(store=alice, handle=_never_called)
-        worker._scan_cursor = admitted[2].receipt_order
-
-        by_room, more_remains = await worker._collect_dispatchable()
-
-        assert [event.event_id for event in by_room[ROOM]] == ["$e0", "$e1", "$e2", "$e3", "$e4"]
-        assert not more_remains
-        assert worker._scan_cursor is None
-
-    async def test_a_lost_owner_behind_the_window_is_still_taken_back(
+    async def test_a_lost_owner_behind_discovery_still_runs_first(
         self,
         alice: PrincipalStore,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The reclaim's question is about the deferrals, not about the window.
-
-        A backlog too large for one pass keeps the scan's window ahead of a
-        deferral sitting behind it -- the pages stay full, so the pass never
-        reaches the end and never wraps to the front. Reclaiming only what the
-        window happens to cover then leaves that deferral's dead owner
-        unnoticed for as long as the overload lasts, which is the unbounded
-        outage the reclaim exists to replace.
-        """
+        """An abandoned source is reclaimed through its room, before later work."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
         monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
         for index in range(3):
             await self._admit(alice, text_event(f"$e{index}", ts=1_000 + index), ROOM)
         admitted = await alice.pending(limit=3)
-        worker = PendingEventWorker(store=alice, handle=_never_called, deferral_is_live=lambda _event: False)
+        handled: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            return True
+
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: False)
         worker._deferred[admitted[0].event_id] = admitted[0]
         worker._scan_cursor = admitted[0].receipt_order
-
-        by_room, _ = await worker._collect_dispatchable()
-
-        assert [event.event_id for event in by_room[ROOM]] == ["$e0", "$e1"]
+        worker.start()
+        try:
+            await _eventually_async(alice.pending)
+            assert handled == ["$e0", "$e1", "$e2"]
+        finally:
+            await worker.stop()
 
 
 class TestADrainSeesTheWholeBacklog:
@@ -3028,6 +3191,8 @@ class _FlakyReplayView:
         self,
         *,
         limit: int = 256,
+        room_id: str | None = None,
+        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
@@ -3037,6 +3202,8 @@ class _FlakyReplayView:
             raise RuntimeError(msg)
         return await self.inner.pending(
             limit=limit,
+            room_id=room_id,
+            event_id=event_id,
             after_receipt_order=after_receipt_order,
             runtime_generation=runtime_generation,
         )
@@ -3054,6 +3221,94 @@ class _FlakyReplayView:
             msg = "the journal is unwritable"
             raise RuntimeError(msg)
         await self.inner.settle(event_id)
+
+
+@dataclass
+class _ReservedRoomReplayView(_FlakyReplayView):
+    """Hold the first room read while another drain finishes discovering it."""
+
+    page_entered: asyncio.Event = field(default_factory=asyncio.Event)
+    release_page: asyncio.Event = field(default_factory=asyncio.Event)
+    competing_discovered: asyncio.Event = field(default_factory=asyncio.Event)
+    overlapping_reads: asyncio.Event = field(default_factory=asyncio.Event)
+    room_reads: int = 0
+    competing_drain: asyncio.Task[int] | None = None
+
+    async def pending(
+        self,
+        *,
+        limit: int = 256,
+        room_id: str | None = None,
+        event_id: str | None = None,
+        after_receipt_order: int | None = None,
+        runtime_generation: str = "unmanaged",
+    ) -> PendingPage:
+        reading_room = room_id == ROOM
+        if reading_room:
+            self.room_reads += 1
+            if self.room_reads == 2:
+                self.overlapping_reads.set()
+        hold_this_read = reading_room and self.room_reads == 1
+        page = await super().pending(
+            limit=limit,
+            room_id=room_id,
+            event_id=event_id,
+            after_receipt_order=after_receipt_order,
+            runtime_generation=runtime_generation,
+        )
+        if room_id is None and event_id is None and asyncio.current_task() is self.competing_drain and page.reached_end:
+            self.competing_discovered.set()
+        if hold_this_read:
+            self.page_entered.set()
+            await self.release_page.wait()
+        return page
+
+
+@dataclass
+class _ApprovalWakeReplayView(_FlakyReplayView):
+    """Hold one room snapshot while approval wake lookups race its eligibility."""
+
+    lookup_race: str = "ready"
+    tail_read_entered: asyncio.Event = field(default_factory=asyncio.Event)
+    release_tail_read: asyncio.Event = field(default_factory=asyncio.Event)
+    empty_lookup_entered: asyncio.Event = field(default_factory=asyncio.Event)
+    release_empty_lookup: asyncio.Event = field(default_factory=asyncio.Event)
+    fresh_lookup_returned: asyncio.Event = field(default_factory=asyncio.Event)
+    tail_read_after: int | None = None
+    exact_reads: int = 0
+
+    async def pending(
+        self,
+        *,
+        limit: int = 256,
+        room_id: str | None = None,
+        event_id: str | None = None,
+        after_receipt_order: int | None = None,
+        runtime_generation: str = "unmanaged",
+    ) -> PendingPage:
+        page = await super().pending(
+            limit=limit,
+            room_id=room_id,
+            event_id=event_id,
+            after_receipt_order=after_receipt_order,
+            runtime_generation=runtime_generation,
+        )
+        if event_id == "$source-1":
+            self.exact_reads += 1
+            if self.lookup_race == "failed" and self.exact_reads == 1:
+                msg = "retry source lookup failed"
+                raise RuntimeError(msg)
+            if self.lookup_race == "stale" and self.exact_reads == 1:
+                assert page == ()
+                self.empty_lookup_entered.set()
+                await self.release_empty_lookup.wait()
+            elif page:
+                self.fresh_lookup_returned.set()
+        if room_id == ROOM and not self.tail_read_entered.is_set() and any(event.event_id == "$tail" for event in page):
+            self.tail_read_after = after_receipt_order
+            self.tail_read_entered.set()
+            await self.release_tail_read.wait()
+        return page
 
 
 class TestStoreFailuresBelongToTheLane:

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -2057,10 +2057,13 @@ class TestRoomRetryBackoff:
         finally:
             await worker.stop()
 
+    @pytest.mark.parametrize("lose_after_first_sweep", [False, True])
     async def test_fallback_sweep_reaches_owners_beyond_one_probe_batch(
         self,
         alice: PrincipalStore,
         monkeypatch: pytest.MonkeyPatch,
+        *,
+        lose_after_first_sweep: bool,
     ) -> None:
         """A quiet backlog is swept in yielding batches without waiting extra periods."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 2)
@@ -2070,6 +2073,7 @@ class TestRoomRetryBackoff:
         block_discovery = False
         discovery_blocked = asyncio.Event()
         release_discovery = asyncio.Event()
+        last_owner_probed = asyncio.Event()
 
         class SlowDiscovery(_FlakyReplayView):
             async def pending(
@@ -2094,12 +2098,17 @@ class TestRoomRetryBackoff:
             attempts.append(event.event_id)
             return event.event_id in lost
 
+        def owner_is_live(event: JournalEvent) -> bool:
+            if discovery_blocked.is_set() and event.event_id == sources[-1]:
+                last_owner_probed.set()
+            return event.event_id not in lost
+
         for event_id in sources:
             await TestPendingEventWorker._admit(alice, text_event(event_id))
         worker = PendingEventWorker(
             store=SlowDiscovery(alice),
             handle=handle,
-            deferral_is_live=lambda event: event.event_id not in lost,
+            deferral_is_live=owner_is_live,
             deferral_scan_seconds=0.01,
         )
         worker.start()
@@ -2108,6 +2117,8 @@ class TestRoomRetryBackoff:
             block_discovery = True
             worker.wake()
             await asyncio.wait_for(discovery_blocked.wait(), timeout=5)
+            if lose_after_first_sweep:
+                await asyncio.wait_for(last_owner_probed.wait(), timeout=5)
             lost.add(sources[-1])
             await _eventually(lambda: attempts.count(sources[-1]) == 2, seconds=5)
             assert attempts == [*sources, sources[-1]]

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1897,6 +1897,460 @@ class TestPendingEventWorker:
         await worker.stop()
 
 
+@pytest.fixture
+def retry_sleeps(monkeypatch: pytest.MonkeyPatch) -> list[tuple[float, asyncio.Event]]:
+    """Hold only worker retry timers, leaving real journal I/O and loop scheduling intact."""
+    sleeping: list[tuple[float, asyncio.Event]] = []
+    original_sleep = asyncio.sleep
+
+    async def sleep(delay: float) -> None:
+        task = asyncio.current_task()
+        if task is not None and "retry" in task.get_name():
+            release = asyncio.Event()
+            sleeping.append((delay, release))
+            await release.wait()
+        else:
+            await original_sleep(delay)
+
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+    return sleeping
+
+
+async def _dispatch_worker_pass(worker: PendingEventWorker) -> None:
+    """Finish one real scan and its room lanes without running the background pump."""
+    await worker._dispatch_ready_rooms()
+    await asyncio.gather(*worker._lanes.values())
+    await asyncio.sleep(0)
+
+
+class TestRoomRetryBackoff:
+    """Only a room's own successful work resets its bounded retry delay."""
+
+    @pytest.mark.parametrize("drain", [False, True])
+    async def test_admissions_do_not_bypass_a_failed_rooms_cooldown(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        *,
+        drain: bool,
+    ) -> None:
+        """An unrelated wake runs healthy rooms without retrying a failed head early."""
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$failed":
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$failed"))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            assert len(retry_sleeps) == 1
+            await TestPendingEventWorker._admit(alice, text_event("$later"))
+            await TestPendingEventWorker._admit(alice, text_event("$healthy"), "!healthy:example.org")
+            if drain:
+                await asyncio.wait_for(worker.drain_once(), timeout=1)
+            else:
+                await _dispatch_worker_pass(worker)
+
+            assert attempts == ["$failed", "$healthy"]
+            assert await alice.unsettled_event_ids() == frozenset({"$failed", "$later"})
+        finally:
+            await worker.stop()
+
+    async def test_consecutive_room_failures_back_off_to_cap_and_success_resets(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """Lane starts and successful work in another room cannot reset failure history."""
+        attempts: list[str] = []
+        failing = True
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.room_id == ROOM and failing:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$failed"))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            for index, expected_delay in enumerate((1, 2, 4, 8, 16, 30, 30)):
+                await _dispatch_worker_pass(worker)
+                assert retry_sleeps[-1][0] == expected_delay
+                assert attempts.count("$failed") == index + 1
+                await TestPendingEventWorker._admit(alice, text_event(f"$healthy{index}"), "!healthy:example.org")
+                await _dispatch_worker_pass(worker)
+                assert attempts[-1] == f"$healthy{index}"
+                retry_sleeps[-1][1].set()
+                await asyncio.sleep(0)
+
+            failing = False
+            await _dispatch_worker_pass(worker)
+            assert not await alice.is_pending("$failed")
+            failing = True
+            await TestPendingEventWorker._admit(alice, text_event("$new-failure"))
+            await _dispatch_worker_pass(worker)
+            assert retry_sleeps[-1][0] == 1
+        finally:
+            await worker.stop()
+
+    async def test_each_room_wakes_at_its_own_retry_without_new_admission(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """One timer cannot release another failing room or strand its pending event."""
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if attempts.count(event.event_id) == 1:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        worker = PendingEventWorker(store=alice, handle=handle)
+        await TestPendingEventWorker._admit(alice, text_event("$first"))
+        worker.start()
+        try:
+            await _eventually(lambda: len(retry_sleeps) == 1)
+            await TestPendingEventWorker._admit(alice, text_event("$second"), "!second:example.org")
+            worker.wake()
+            await _eventually(lambda: len(retry_sleeps) == 2)
+            retry_sleeps[1][1].set()
+            await _eventually(lambda: attempts.count("$second") == 2)
+            assert attempts.count("$first") == 1
+            retry_sleeps[0][1].set()
+            await _eventually_async(alice.pending)
+            assert attempts == ["$first", "$second", "$second", "$first"]
+        finally:
+            await worker.stop()
+        assert worker.pending_task_count == 0
+
+    async def test_retry_waits_for_failed_head_when_scan_resumes_in_later_page(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A rotating scan must not dispatch later room events ahead of the failed head."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if attempts == ["$first"]:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        for event_id in ("$first", "$second", "$third"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            await _dispatch_worker_pass(worker)
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            for _ in range(6):
+                await _dispatch_worker_pass(worker)
+            assert attempts == ["$first", "$first", "$second", "$third"]
+            assert await alice.unsettled_event_ids() == frozenset()
+        finally:
+            await worker.stop()
+
+    async def test_settled_failed_head_releases_later_events_after_cooldown(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """External settlement cannot leave an absent failed head blocking later work."""
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$failed":
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$failed"))
+        await TestPendingEventWorker._admit(alice, text_event("$later"))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            await alice.settle("$failed")
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            await _dispatch_worker_pass(worker)
+            assert attempts == ["$failed", "$later"]
+            assert await alice.unsettled_event_ids() == frozenset()
+        finally:
+            await worker.stop()
+
+    @pytest.mark.parametrize("cooldown_passes", [0, 4])
+    async def test_reclaimed_earlier_event_does_not_release_later_slice_before_failed_head(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        cooldown_passes: int,
+    ) -> None:
+        """Reclaimed work before the failure cannot make a later scan slice safe."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        attempts: list[str] = []
+        owner_live = True
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$earlier":
+                return not owner_live
+            if event.event_id == "$failed" and attempts.count("$failed") == 1:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        for event_id in ("$earlier", "$failed", "$later", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: owner_live)
+        try:
+            await _dispatch_worker_pass(worker)
+            await _dispatch_worker_pass(worker)
+            owner_live = False
+            for _ in range(cooldown_passes):
+                await _dispatch_worker_pass(worker)
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            for _ in range(8):
+                await _dispatch_worker_pass(worker)
+            assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
+        finally:
+            await worker.stop()
+
+    async def test_failed_head_read_does_not_block_other_rooms(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """Checking a failed head must keep store failures scoped to that room."""
+        handled: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$failed"))
+        store = _FlakyReplayView(alice, fail_is_pending={"$failed"})
+        worker = PendingEventWorker(store=store, handle=handle)
+        try:
+            await _dispatch_worker_pass(worker)
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            store.fail_is_pending.add("$failed")
+            await TestPendingEventWorker._admit(alice, text_event("$healthy"), "!healthy:example.org")
+            await _dispatch_worker_pass(worker)
+            assert handled == ["$healthy"]
+            assert retry_sleeps[-1][0] == 2
+        finally:
+            await worker.stop()
+
+    @pytest.mark.parametrize("owner_dies_during_scan", [False, True])
+    async def test_retry_admission_reclaims_earlier_deferral_after_awaited_page(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        owner_dies_during_scan: bool,
+    ) -> None:
+        """Cooldown expiry or owner death during I/O cannot hide an earlier deferral."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        owner_live = True
+        block_page = False
+        page_entered = asyncio.Event()
+        release_page = asyncio.Event()
+        attempts: list[str] = []
+        for event_id in ("$earlier", "$failed", "$later", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        earlier = (await alice.pending())[0]
+
+        class BlockingRetryPage(_FlakyReplayView):
+            async def pending(
+                self,
+                *,
+                limit: int = 256,
+                after_receipt_order: int | None = None,
+                runtime_generation: str = "unmanaged",
+            ) -> PendingPage:
+                page = await super().pending(
+                    limit=limit,
+                    after_receipt_order=after_receipt_order,
+                    runtime_generation=runtime_generation,
+                )
+                if block_page and after_receipt_order == earlier.receipt_order:
+                    page_entered.set()
+                    await release_page.wait()
+                return page
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if event.event_id == "$earlier":
+                return not owner_live
+            if event.event_id == "$failed" and attempts.count("$failed") == 1:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        worker = PendingEventWorker(
+            store=BlockingRetryPage(alice),
+            handle=handle,
+            deferral_is_live=lambda _event: owner_live,
+        )
+        await _dispatch_worker_pass(worker)
+        await _dispatch_worker_pass(worker)
+        owner_live = owner_dies_during_scan
+        for _ in range(4):
+            await _dispatch_worker_pass(worker)
+        assert worker._scan_cursor == earlier.receipt_order
+        block_page = True
+        scanning = asyncio.create_task(_dispatch_worker_pass(worker))
+        try:
+            await page_entered.wait()
+            owner_live = False
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            release_page.set()
+            await scanning
+            assert attempts == ["$earlier", "$failed", "$earlier", "$failed"]
+            for _ in range(4):
+                await _dispatch_worker_pass(worker)
+            assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
+            assert await alice.unsettled_event_ids() == frozenset()
+        finally:
+            release_page.set()
+            scanning.cancel()
+            await asyncio.gather(scanning, return_exceptions=True)
+            await worker.stop()
+
+    @pytest.mark.parametrize("drain", [False, True])
+    async def test_stale_tail_cannot_overtake_head_that_failed_during_scan(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        drain: bool,
+    ) -> None:
+        """Final lane admission rechecks failures that appeared during an awaited scan."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
+        entered_head = asyncio.Event()
+        fail_head = asyncio.Event()
+        entered_last_page = asyncio.Event()
+        release_last_page = asyncio.Event()
+        attempts: list[str] = []
+        for event_id in ("$head", "$tail", "$last"):
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        admitted = await alice.pending()
+        tail = admitted[1]
+
+        class BlockingLastPage(_FlakyReplayView):
+            async def pending(
+                self,
+                *,
+                limit: int = 256,
+                after_receipt_order: int | None = None,
+                runtime_generation: str = "unmanaged",
+            ) -> PendingPage:
+                page = await super().pending(
+                    limit=limit,
+                    after_receipt_order=after_receipt_order,
+                    runtime_generation=runtime_generation,
+                )
+                if after_receipt_order == tail.receipt_order:
+                    entered_last_page.set()
+                    await release_last_page.wait()
+                return page
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if attempts == ["$head"]:
+                entered_head.set()
+                await fail_head.wait()
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        worker = PendingEventWorker(store=BlockingLastPage(alice), handle=handle)
+        await worker._dispatch_ready_rooms()
+        await entered_head.wait()
+        head_lane = worker._lanes[ROOM]
+        monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 2)
+        scanning = asyncio.create_task(worker._collect_dispatchable() if drain else worker._dispatch_ready_rooms())
+        try:
+            await entered_last_page.wait()
+            fail_head.set()
+            await head_lane
+            await asyncio.sleep(0)
+            retry_sleeps[0][1].set()
+            await asyncio.sleep(0)
+            release_last_page.set()
+            await scanning
+            if drain:
+                await worker._drain_room(ROOM, [tail], stop_generation=worker._stop_generation)
+            await asyncio.gather(*worker._lanes.values())
+            assert attempts == ["$head"]
+            for _ in range(4):
+                await _dispatch_worker_pass(worker)
+            assert attempts == ["$head", "$head", "$tail", "$last"]
+            assert await alice.unsettled_event_ids() == frozenset()
+        finally:
+            fail_head.set()
+            release_last_page.set()
+            scanning.cancel()
+            await asyncio.gather(scanning, return_exceptions=True)
+            await worker.stop()
+
+    async def test_shutdown_cancels_room_cooldown_and_restart_replays_pending_work(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """A cooling room owns a cancellable timer and leaves its journal work durable."""
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            if len(attempts) == 1:
+                msg = "callback unavailable"
+                raise RuntimeError(msg)
+            return True
+
+        await TestPendingEventWorker._admit(alice, text_event("$failed"))
+        worker = PendingEventWorker(store=alice, handle=handle)
+        await _dispatch_worker_pass(worker)
+        assert len(retry_sleeps) == 1
+        worker.begin_shutdown()
+        assert await worker.wait_stopped(timeout_seconds=0.1)
+        assert worker.pending_task_count == 0
+        assert await alice.is_pending("$failed")
+        worker.start()
+        try:
+            await _eventually_async(alice.pending)
+        finally:
+            await worker.stop()
+        assert attempts == ["$failed", "$failed"]
+
+
 class TestOutOfBandDispatch:
     """An event its caller runs itself is still an event with one handler."""
 
@@ -3050,7 +3504,11 @@ class TestAdmittedWorkReachesItsCallback:
         assert [event.event_id for event in handled] == ["$call"]
         assert not await alice.is_pending("$call")
 
-    async def test_failed_call_callback_replays_from_durable_work(self, alice: PrincipalStore) -> None:
+    async def test_failed_call_callback_replays_from_durable_work(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
         """A callback failure keeps the RTC event pending for a later pass."""
         failure = RuntimeError("call reconciliation failed")
         on_rtc = AsyncMock(side_effect=[failure, None])
@@ -3077,8 +3535,13 @@ class TestAdmittedWorkReachesItsCallback:
         assert await alice.is_pending("$call-retry")
 
         await dispatcher.drain_once()
+        assert on_rtc.await_count == 1
+        retry_sleeps[0][1].set()
+        await asyncio.sleep(0)
+        await dispatcher.drain_once()
         assert on_rtc.await_count == 2
         assert not await alice.is_pending("$call-retry")
+        await dispatcher.stop()
 
 
 class TestScheduleTriggerDispatch:

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1336,20 +1336,22 @@ class TestPendingEventWorker:
         assert handled == ["$first"]
         assert {event.event_id for event in await alice.pending()} == {"$first", "$second"}
 
-    async def test_owner_lost_within_one_page_rewinds_before_later_callback(
+    async def test_owner_completion_within_one_page_rewinds_before_later_callback(
         self,
         alice: PrincipalStore,
         retry_sleeps: list[tuple[float, asyncio.Event]],
     ) -> None:
-        """An earlier handoff can die while the same page checks its next source."""
+        """An earlier owner returns its source while the page checks its next source."""
         owner_live = True
         handled: list[str] = []
 
         class OwnerLostDuringRead(_FlakyReplayView):
             async def is_pending(self, event_id: str) -> bool:
                 nonlocal owner_live
-                if event_id == "$later":
+                if event_id == "$later" and owner_live:
                     owner_live = False
+                    worker.release(("$earlier",))
+                    worker.wake(room_id=ROOM)
                 return await super().is_pending(event_id)
 
         async def handle(event: JournalEvent) -> bool:
@@ -1851,6 +1853,7 @@ class TestPendingEventWorker:
     async def test_a_deferral_whose_owner_died_is_dispatched_again(
         self,
         alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
     ) -> None:
         """The hole this closes: durable work owed to an owner that is gone.
 
@@ -1877,8 +1880,12 @@ class TestPendingEventWorker:
 
         owner_alive = False
         await worker.drain_once()
-
-        assert attempts == ["$m", "$m"]
+        worker.start()
+        try:
+            retry_sleeps[0][1].set()
+            await _eventually(lambda: attempts == ["$m", "$m"])
+        finally:
+            await worker.stop()
 
     async def test_a_reclaimed_deferral_does_not_jump_ahead_of_an_earlier_event(
         self,
@@ -1903,7 +1910,7 @@ class TestPendingEventWorker:
         # A lost owner requests replay; the room query determines its order.
         late = await alice.load_event("$late")
         assert late is not None
-        worker._deferred["$late"] = late
+        worker._defer(late)
 
         owner_alive = False
         await worker.drain_once()
@@ -2000,6 +2007,175 @@ async def _dispatch_worker_pass(worker: PendingEventWorker) -> None:
 class TestRoomRetryBackoff:
     """Only a room's own successful work resets its bounded retry delay."""
 
+    async def test_worker_restart_retains_a_live_downstream_handoff(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """Restarting discovery does not duplicate a response or lose its release bookkeeping."""
+        owner_live = True
+        attempts: list[str] = []
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            return not owner_live
+
+        await TestPendingEventWorker._admit(alice, text_event("$source"))
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: owner_live)
+        worker.start()
+        try:
+            await _eventually(lambda: "$source" in worker._deferred and not worker._lanes)
+            await worker.stop()
+            worker.start()
+            await worker.drain_once()
+            assert attempts == ["$source"]
+            owner_live = False
+            worker.release(("$source",))
+            worker.wake(room_id=ROOM)
+            await _eventually_async(alice.pending)
+            assert attempts == ["$source", "$source"]
+        finally:
+            await worker.stop()
+
+    async def test_terminal_release_cleans_up_an_idle_rooms_ownership(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A terminal-only release needs no later admission to discard room history."""
+        await TestPendingEventWorker._admit(alice, text_event("$source"))
+
+        async def handle(_event: JournalEvent) -> bool:
+            return False
+
+        worker = PendingEventWorker(store=alice, handle=handle)
+        worker.start()
+        try:
+            await _eventually(lambda: "$source" in worker._deferred and not worker._lanes)
+            await alice.settle("$source")
+            worker.release(("$source",))
+            await _eventually(lambda: ROOM not in worker._rooms)
+            assert not worker._deferred
+        finally:
+            await worker.stop()
+
+    async def test_fallback_sweep_reaches_owners_beyond_one_probe_batch(
+        self,
+        alice: PrincipalStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A quiet backlog is swept in yielding batches without waiting extra periods."""
+        monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 2)
+        attempts: list[str] = []
+        lost: set[str] = set()
+        sources = [f"$source-{index}" for index in range(5)]
+        block_discovery = False
+        discovery_blocked = asyncio.Event()
+        release_discovery = asyncio.Event()
+
+        class SlowDiscovery(_FlakyReplayView):
+            async def pending(
+                self,
+                *,
+                limit: int = 256,
+                room_id: str | None = None,
+                after_receipt_order: int | None = None,
+                runtime_generation: str = "unmanaged",
+            ) -> PendingPage:
+                if room_id is None and block_discovery:
+                    discovery_blocked.set()
+                    await release_discovery.wait()
+                return await super().pending(
+                    limit=limit,
+                    room_id=room_id,
+                    after_receipt_order=after_receipt_order,
+                    runtime_generation=runtime_generation,
+                )
+
+        async def handle(event: JournalEvent) -> bool:
+            attempts.append(event.event_id)
+            return event.event_id in lost
+
+        for event_id in sources:
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(
+            store=SlowDiscovery(alice),
+            handle=handle,
+            deferral_is_live=lambda event: event.event_id not in lost,
+            deferral_scan_seconds=0.01,
+        )
+        worker.start()
+        try:
+            await _eventually(lambda: len(worker._deferred) == len(sources))
+            block_discovery = True
+            worker.wake()
+            await asyncio.wait_for(discovery_blocked.wait(), timeout=5)
+            lost.add(sources[-1])
+            await _eventually(lambda: attempts.count(sources[-1]) == 2, seconds=5)
+            assert attempts == [*sources, sources[-1]]
+        finally:
+            release_discovery.set()
+            await worker.stop()
+
+    async def test_owner_failure_after_lane_completion_keeps_exponential_cooldown(
+        self,
+        alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
+    ) -> None:
+        """A detached response owns retry history after its admission lane exits."""
+        attempts: list[str] = []
+        owner_live = False
+
+        async def handle(event: JournalEvent) -> bool:
+            nonlocal owner_live
+            attempts.append(event.event_id)
+            owner_live = True
+            return False
+
+        await TestPendingEventWorker._admit(alice, text_event("$source"))
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: owner_live)
+        worker.start()
+        try:
+            for index, delay in enumerate((1, 2, 4)):
+                await _eventually(lambda index=index: len(attempts) == index + 1 and not worker._lanes)
+                owner_live = False
+                worker.release(("$source",))
+                worker.wake(room_id=ROOM)
+                await _eventually(lambda index=index: len(retry_sleeps) > index or len(attempts) > index + 1)
+                assert len(attempts) == index + 1
+                assert retry_sleeps[index][0] == delay
+                retry_sleeps[index][1].set()
+        finally:
+            await worker.stop()
+
+    @pytest.mark.parametrize("count", [128, 256])
+    async def test_bulk_handoffs_require_only_linear_owner_probes(
+        self,
+        alice: PrincipalStore,
+        count: int,
+    ) -> None:
+        """Each admission must not rescan all previously handed-off sources."""
+        probes = 0
+        handled: list[str] = []
+
+        def owner_is_live(_event: JournalEvent) -> bool:
+            nonlocal probes
+            probes += 1
+            return True
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            return False
+
+        sources = [f"$source-{index}" for index in range(count)]
+        for event_id in sources:
+            await TestPendingEventWorker._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=owner_is_live)
+        try:
+            await worker.drain_once()
+            assert handled == sources
+            assert probes <= count * 2
+        finally:
+            await worker.stop()
+
     async def test_alternating_failed_owners_cannot_keep_a_drain_running(
         self,
         alice: PrincipalStore,
@@ -2013,6 +2189,9 @@ class TestRoomRetryBackoff:
 
         async def handle(event: JournalEvent) -> bool:
             attempts.append(event.event_id)
+            if live:
+                worker.release(tuple(live))
+                worker.wake(room_id=event.room_id)
             live.clear()
             live.add(event.event_id)
             return False
@@ -2502,6 +2681,8 @@ class TestRoomRetryBackoff:
             await _dispatch_worker_pass(worker)
             await _dispatch_worker_pass(worker)
             owner_live = False
+            worker.release(("$earlier",))
+            worker.wake(room_id=ROOM)
             for _ in range(cooldown_passes):
                 await _dispatch_worker_pass(worker)
             retry_sleeps[0][1].set()
@@ -2611,6 +2792,9 @@ class TestRoomRetryBackoff:
             await _eventually(lambda: len(retry_sleeps) == 1)
             assert attempts == ["$earlier", "$failed"]
             owner_live = owner_dies_during_scan
+            if not owner_live:
+                worker.release(("$earlier",))
+                worker.wake(room_id=ROOM)
             block_next_room_page = True
             worker.start()
             retry_sleeps[0][1].set()
@@ -2618,6 +2802,9 @@ class TestRoomRetryBackoff:
             assert blocked_event_ids == ["$failed" if owner_dies_during_scan else "$earlier"]
             assert attempts == ["$earlier", "$failed"]
             owner_live = False
+            if owner_dies_during_scan:
+                worker.release(("$earlier",))
+                worker.wake(room_id=ROOM)
             release_page.set()
             await _eventually_async(alice.pending)
             assert attempts == ["$earlier", "$failed", "$earlier", "$failed", "$later", "$last"]
@@ -3231,7 +3418,7 @@ class TestABoundedScanIsFair:
             return True
 
         worker = PendingEventWorker(store=alice, handle=handle, deferral_is_live=lambda _event: False)
-        worker._deferred[admitted[0].event_id] = admitted[0]
+        worker._defer(admitted[0])
         worker._scan_cursor = admitted[0].receipt_order
         worker.start()
         try:
@@ -3601,6 +3788,7 @@ class TestRecoveryDoesNotReenterALiveTurn:
     async def test_a_deferred_source_is_still_taken_back_when_its_owner_dies(
         self,
         alice: PrincipalStore,
+        retry_sleeps: list[tuple[float, asyncio.Event]],
     ) -> None:
         """Skipping an owned source may not become losing an abandoned one.
 
@@ -3624,8 +3812,12 @@ class TestRecoveryDoesNotReenterALiveTurn:
 
         live_claims.clear()
         await dispatcher.drain_once()
-
-        assert entered == ["$m", "$m"]
+        dispatcher.start()
+        try:
+            retry_sleeps[0][1].set()
+            await _eventually(lambda: entered == ["$m", "$m"])
+        finally:
+            await dispatcher.stop()
 
 
 async def _eventually_async(query: Callable[[], Awaitable[Sized]], *, seconds: float = 10.0) -> None:

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1336,6 +1336,52 @@ class TestPendingEventWorker:
         assert handled == ["$first"]
         assert {event.event_id for event in await alice.pending()} == {"$first", "$second"}
 
+    @pytest.mark.parametrize("boundary", ["handler", "pending_check"])
+    async def test_shutdown_stops_admission_after_cancellation_is_absorbed(
+        self,
+        alice: PrincipalStore,
+        boundary: str,
+    ) -> None:
+        """Cleanup may finish, but no later callback may enter a stopped worker."""
+        entered = asyncio.Event()
+        handled: list[str] = []
+        stopping = True
+
+        async def finish_on_cancel() -> None:
+            entered.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.Event().wait()
+
+        class FinishingRead(_FlakyReplayView):
+            async def is_pending(self, event_id: str) -> bool:
+                if stopping and boundary == "pending_check" and event_id == "$head":
+                    await finish_on_cancel()
+                return await super().is_pending(event_id)
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            if stopping and boundary == "handler" and event.event_id == "$head":
+                await finish_on_cancel()
+            return True
+
+        for event_id in ("$head", "$tail"):
+            await self._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(store=FinishingRead(alice), handle=handle)
+        worker.start()
+        try:
+            await asyncio.wait_for(entered.wait(), timeout=5)
+            await asyncio.wait_for(worker.stop(), timeout=5)
+            assert handled == (["$head"] if boundary == "handler" else [])
+            assert await alice.unsettled_event_ids() == (
+                frozenset({"$tail"}) if boundary == "handler" else frozenset({"$head", "$tail"})
+            )
+            stopping = False
+            worker.start()
+            await _eventually_async(alice.pending)
+            assert handled == ["$head", "$tail"]
+        finally:
+            await worker.stop()
+
     async def test_a_recovery_drain_runs_a_room_through_its_lane_not_beside_it(
         self,
         alice: PrincipalStore,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1336,6 +1336,39 @@ class TestPendingEventWorker:
         assert handled == ["$first"]
         assert {event.event_id for event in await alice.pending()} == {"$first", "$second"}
 
+    async def test_owner_lost_within_one_page_rewinds_before_later_callback(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """An earlier handoff can die while the same page checks its next source."""
+        owner_live = True
+        handled: list[str] = []
+
+        class OwnerLostDuringRead(_FlakyReplayView):
+            async def is_pending(self, event_id: str) -> bool:
+                nonlocal owner_live
+                if event_id == "$later":
+                    owner_live = False
+                return await super().is_pending(event_id)
+
+        async def handle(event: JournalEvent) -> bool:
+            handled.append(event.event_id)
+            return event.event_id != "$earlier" or not owner_live
+
+        for event_id in ("$earlier", "$later"):
+            await self._admit(alice, text_event(event_id))
+        worker = PendingEventWorker(
+            store=OwnerLostDuringRead(alice),
+            handle=handle,
+            deferral_is_live=lambda _event: owner_live,
+        )
+        try:
+            await asyncio.wait_for(worker.drain_once(), timeout=5)
+            assert handled == ["$earlier", "$earlier", "$later"]
+            assert await alice.unsettled_event_ids() == frozenset()
+        finally:
+            await worker.stop()
+
     @pytest.mark.parametrize("boundary", ["handler", "pending_check"])
     async def test_shutdown_stops_admission_after_cancellation_is_absorbed(
         self,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -1351,7 +1351,7 @@ class TestPendingEventWorker:
 
         The handler claims a semantic consumer the way a reaction's does, so
         the second handler is not merely wasteful: its claim raises against
-        the row the first one already settled, and `_run_lane` logs that and
+        the row the first one already settled, and the room owner logs that and
         stops the room mid-pass. The claim is right to raise. Nothing settles
         an event while its own handler is running, so a settled row there
         means the event was already being run somewhere else.
@@ -1449,14 +1449,9 @@ class TestPendingEventWorker:
                 tracked_lane.cancel()
             await asyncio.gather(stopping, draining, *worker._lanes.values(), return_exceptions=True)
 
-    @pytest.mark.parametrize("retry_source", [False, True])
-    @pytest.mark.parametrize("read_fails", [False, True])
     async def test_a_pre_stop_recovery_drain_cannot_dispatch_after_restart(
         self,
         alice: PrincipalStore,
-        *,
-        retry_source: bool,
-        read_fails: bool,
     ) -> None:
         """Restarting does not make an old drain current again."""
         first_read_started = asyncio.Event()
@@ -1472,8 +1467,6 @@ class TestPendingEventWorker:
                 self,
                 *,
                 limit: int = 256,
-                room_id: str | None = None,
-                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
@@ -1481,16 +1474,11 @@ class TestPendingEventWorker:
                 if self.pending_calls == 1:
                     page = await self.inner.pending(
                         limit=limit,
-                        room_id=room_id,
-                        event_id=event_id,
                         after_receipt_order=after_receipt_order,
                         runtime_generation=runtime_generation,
                     )
                     first_read_started.set()
                     await release_first_read.wait()
-                    if read_fails:
-                        msg = "stale read failed"
-                        raise RuntimeError(msg)
                     return page
                 return PendingPage((), resume_after=None, reached_end=True, unreadable_rows=0)
 
@@ -1507,8 +1495,6 @@ class TestPendingEventWorker:
 
         await self._admit(alice, text_event("$message"))
         worker = PendingEventWorker(store=BlockingFirstRead(alice), handle=handle)
-        if retry_source:
-            worker.wake(event_ids=("$message",))
         stale_drain = asyncio.create_task(worker.drain_once())
         await first_read_started.wait()
 
@@ -1516,16 +1502,10 @@ class TestPendingEventWorker:
         worker.start()
         try:
             release_first_read.set()
-            if read_fails and not retry_source:
-                with pytest.raises(RuntimeError, match="stale read failed"):
-                    await asyncio.wait_for(stale_drain, timeout=1.0)
-            else:
-                await asyncio.wait_for(stale_drain, timeout=1.0)
+            await asyncio.wait_for(stale_drain, timeout=1.0)
             await asyncio.sleep(0)
 
             assert not handled.is_set()
-            assert worker._rooms == {}
-            assert worker._retry_sources == set()
         finally:
             release_first_read.set()
             await worker.stop()
@@ -2058,7 +2038,6 @@ class TestRoomRetryBackoff:
                 *,
                 limit: int = 256,
                 room_id: str | None = None,
-                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
@@ -2066,7 +2045,6 @@ class TestRoomRetryBackoff:
                 page = await super().pending(
                     limit=limit,
                     room_id=room_id,
-                    event_id=event_id,
                     after_receipt_order=after_receipt_order,
                     runtime_generation=runtime_generation,
                 )
@@ -2094,18 +2072,15 @@ class TestRoomRetryBackoff:
         finally:
             await worker.stop()
 
-    @pytest.mark.parametrize("lookup_race", ["ready", "stale", "failed"])
-    async def test_exact_approval_wake_rewinds_before_unstarted_tail(
+    async def test_room_approval_wake_invalidates_a_pending_tail_read(
         self,
         alice: PrincipalStore,
-        retry_sleeps: list[tuple[float, asyncio.Event]],
         monkeypatch: pytest.MonkeyPatch,
-        lookup_race: str,
     ) -> None:
-        """Exact wakes survive stale or failed reads after approval ownership moves."""
+        """A retry handoff invalidates room admission before any further awaited lookup."""
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
         generation = "runtime-a"
-        store = _ApprovalWakeReplayView(alice, lookup_race=lookup_race)
+        store = _ApprovalWakeReplayView(alice)
         attempts: list[str] = []
 
         async def handle(event: JournalEvent) -> bool:
@@ -2126,7 +2101,7 @@ class TestRoomRetryBackoff:
 
         for event_id in ("$source-1", "$source-2", "$middle", "$tail"):
             await TestPendingEventWorker._admit(alice, text_event(event_id))
-        middle = (await alice.pending(event_id="$middle"))[0]
+        middle = (await alice.pending())[2]
         worker = PendingEventWorker(store=store, handle=handle, runtime_generation=generation)
         try:
             worker.start()
@@ -2134,10 +2109,6 @@ class TestRoomRetryBackoff:
             assert attempts == ["$source-1", "$middle"]
             assert store.tail_read_after == middle.receipt_order
             worker.release(("$source-1",))
-            assert await alice.pending(event_id="$source-1", runtime_generation=generation) == ()
-            if lookup_race == "stale":
-                worker.wake(event_ids=("$source-1",))
-                await asyncio.wait_for(store.empty_lookup_entered.wait(), timeout=5)
             recorded = await alice.resolve_continuation_approval_card(
                 card_event_id="$approval",
                 requested_status="approved",
@@ -2145,14 +2116,10 @@ class TestRoomRetryBackoff:
                 resolution={"status": "approved"},
             )
             assert recorded.continuation_ready
-            worker.wake(event_ids=("$source-1",))
-            store.release_empty_lookup.set()
-            if lookup_race == "failed":
-                await _eventually(lambda: len(retry_sleeps) == 1)
-                retry_sleeps[0][1].set()
-            await asyncio.wait_for(store.fresh_lookup_returned.wait(), timeout=5)
-            assert store.exact_reads == (1 if lookup_race == "ready" else 2)
-            assert attempts == ["$source-1", "$middle"]
+            assert recorded.continuation_room_id == ROOM
+            worker.wake(room_id=ROOM)
+            # Release the stale tail immediately; retry admission must already
+            # be invalidated when the synchronous handoff returns.
             store.release_tail_read.set()
             await _eventually_async(lambda: alice.pending(runtime_generation=generation))
             assert attempts == ["$source-1", "$middle", "$source-1", "$tail"]
@@ -2160,7 +2127,6 @@ class TestRoomRetryBackoff:
             assert await alice.is_pending("$source-2")
             assert not await alice.is_pending("$tail")
         finally:
-            store.release_empty_lookup.set()
             store.release_tail_read.set()
             await worker.stop()
 
@@ -2440,7 +2406,6 @@ class TestRoomRetryBackoff:
                 *,
                 limit: int = 256,
                 room_id: str | None = None,
-                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
@@ -2448,7 +2413,6 @@ class TestRoomRetryBackoff:
                 page = await super().pending(
                     limit=limit,
                     room_id=room_id,
-                    event_id=event_id,
                     after_receipt_order=after_receipt_order,
                     runtime_generation=runtime_generation,
                 )
@@ -2577,12 +2541,11 @@ class TestRoomRetryBackoff:
                 *,
                 limit: int = 256,
                 room_id: str | None = None,
-                event_id: str | None = None,
                 after_receipt_order: int | None = None,
                 runtime_generation: str = "unmanaged",
             ) -> PendingPage:
                 nonlocal global_reads
-                if room_id is None and event_id is None:
+                if room_id is None:
                     global_reads += 1
                     if global_reads > 1:
                         discovery_started.set()
@@ -2590,7 +2553,6 @@ class TestRoomRetryBackoff:
                 return await super().pending(
                     limit=limit,
                     room_id=room_id,
-                    event_id=event_id,
                     after_receipt_order=after_receipt_order,
                     runtime_generation=runtime_generation,
                 )
@@ -3192,7 +3154,6 @@ class _FlakyReplayView:
         *,
         limit: int = 256,
         room_id: str | None = None,
-        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
@@ -3203,7 +3164,6 @@ class _FlakyReplayView:
         return await self.inner.pending(
             limit=limit,
             room_id=room_id,
-            event_id=event_id,
             after_receipt_order=after_receipt_order,
             runtime_generation=runtime_generation,
         )
@@ -3239,7 +3199,6 @@ class _ReservedRoomReplayView(_FlakyReplayView):
         *,
         limit: int = 256,
         room_id: str | None = None,
-        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
@@ -3252,11 +3211,10 @@ class _ReservedRoomReplayView(_FlakyReplayView):
         page = await super().pending(
             limit=limit,
             room_id=room_id,
-            event_id=event_id,
             after_receipt_order=after_receipt_order,
             runtime_generation=runtime_generation,
         )
-        if room_id is None and event_id is None and asyncio.current_task() is self.competing_drain and page.reached_end:
+        if room_id is None and asyncio.current_task() is self.competing_drain and page.reached_end:
             self.competing_discovered.set()
         if hold_this_read:
             self.page_entered.set()
@@ -3266,44 +3224,26 @@ class _ReservedRoomReplayView(_FlakyReplayView):
 
 @dataclass
 class _ApprovalWakeReplayView(_FlakyReplayView):
-    """Hold one room snapshot while approval wake lookups race its eligibility."""
+    """Hold a room snapshot across an approval eligibility change."""
 
-    lookup_race: str = "ready"
     tail_read_entered: asyncio.Event = field(default_factory=asyncio.Event)
     release_tail_read: asyncio.Event = field(default_factory=asyncio.Event)
-    empty_lookup_entered: asyncio.Event = field(default_factory=asyncio.Event)
-    release_empty_lookup: asyncio.Event = field(default_factory=asyncio.Event)
-    fresh_lookup_returned: asyncio.Event = field(default_factory=asyncio.Event)
     tail_read_after: int | None = None
-    exact_reads: int = 0
 
     async def pending(
         self,
         *,
         limit: int = 256,
         room_id: str | None = None,
-        event_id: str | None = None,
         after_receipt_order: int | None = None,
         runtime_generation: str = "unmanaged",
     ) -> PendingPage:
         page = await super().pending(
             limit=limit,
             room_id=room_id,
-            event_id=event_id,
             after_receipt_order=after_receipt_order,
             runtime_generation=runtime_generation,
         )
-        if event_id == "$source-1":
-            self.exact_reads += 1
-            if self.lookup_race == "failed" and self.exact_reads == 1:
-                msg = "retry source lookup failed"
-                raise RuntimeError(msg)
-            if self.lookup_race == "stale" and self.exact_reads == 1:
-                assert page == ()
-                self.empty_lookup_entered.set()
-                await self.release_empty_lookup.wait()
-            elif page:
-                self.fresh_lookup_returned.set()
         if room_id == ROOM and not self.tail_read_entered.is_set() and any(event.event_id == "$tail" for event in page):
             self.tail_read_after = after_receipt_order
             self.tail_read_entered.set()

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -7410,7 +7410,7 @@ async def test_sidecar_gate_failure_retries_original_media_callback(tmp_path: Pa
 
     assert outcome is _IngressAdmissionOutcome.DEFERRED
     assert drain_result.dispatch_failure_count == 1
-    retry_pending_source.assert_called_once_with(sidecar.event_id)
+    retry_pending_source.assert_called_once_with(room.room_id, sidecar.event_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_typing.py
+++ b/tests/test_matrix_typing.py
@@ -111,6 +111,7 @@ async def test_process_shutdown_releases_typing_without_new_matrix_request() -> 
         hold_typing(),
         name="test_process_shutdown_typing",
         recovery_proof_ready=lambda: False,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(entered.wait(), timeout=1.0)
 

--- a/tests/test_pre_model_preparation.py
+++ b/tests/test_pre_model_preparation.py
@@ -375,6 +375,7 @@ async def test_blocked_agent_build_exposes_fixed_response_shutdown_phase(
         blocked_response(),
         name="test_blocked_agent_build_shutdown_phase",
         recovery_proof_ready=lambda: True,
+        room_id="!room:example.org",
     )
     try:
         assert await asyncio.to_thread(agent_started.wait, 1.0)

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -2373,6 +2373,7 @@ class TestAnEndedMembershipStopsTheAnswer:
             cancel_visible_note(),
             name="test_process_shutdown_cancel_note",
             recovery_proof_ready=lambda: False,
+            room_id=_ROOM_ID,
         )
         await asyncio.wait_for(started.wait(), timeout=1.0)
 
@@ -2421,6 +2422,7 @@ class TestAnEndedMembershipStopsTheAnswer:
             deliver_final(),
             name="test_process_shutdown_final_hook",
             recovery_proof_ready=lambda: False,
+            room_id=_ROOM_ID,
         )
         await asyncio.wait_for(hook_started.wait(), timeout=1.0)
 
@@ -3769,6 +3771,7 @@ class TestTurnDeliverySerialization:
             ),
             name="test_process_shutdown_completed_final",
             recovery_proof_ready=lambda: bot._response_recovery_ready(turn),
+            room_id=_ROOM_ID,
         )
         await send_started.wait()
         runner.begin_process_shutdown()
@@ -3857,6 +3860,7 @@ class TestTurnDeliverySerialization:
             ),
             name="test_process_shutdown_repeated_cancel_after_final_ack",
             recovery_proof_ready=lambda: bot._response_recovery_ready(turn),
+            room_id=_ROOM_ID,
         )
         await send_started.wait()
         original_request_task_cancel = request_task_cancel
@@ -3960,6 +3964,7 @@ class TestTurnDeliverySerialization:
             ),
             name="test_process_shutdown_completed_final_edit",
             recovery_proof_ready=lambda: bot._response_recovery_ready(turn),
+            room_id=_ROOM_ID,
         )
         await send_started.wait()
         runner.begin_process_shutdown()

--- a/tests/test_response_departure_recovery.py
+++ b/tests/test_response_departure_recovery.py
@@ -68,6 +68,7 @@ async def test_departure_during_generation_allows_orderly_shutdown(
         name="generation_during_departure",
         recovery_proof_ready=lambda: bot._response_recovery_ready(turn),
         source_event_ids=sources,
+        room_id=ROOM,
     )
     try:
         await generating.wait()

--- a/tests/test_response_recovery_ownership.py
+++ b/tests/test_response_recovery_ownership.py
@@ -1505,8 +1505,9 @@ async def test_preparation_outcomes_reach_controller_and_journal_owners(  # noqa
             ),
             name="inbox_response:preparation",
             recovery_proof_ready=lambda: True,
-            on_failure=lambda: dispatcher.retry_turn_sources((SOURCE,)),
+            on_failure=lambda: dispatcher.retry_turn_sources(callback_room.room_id, (SOURCE,)),
             source_event_ids=(SOURCE,),
+            room_id=callback_room.room_id,
         )
         tasks.append(task)
         return TurnDispatchOutcome.DEFERRED

--- a/tests/test_response_recovery_ownership.py
+++ b/tests/test_response_recovery_ownership.py
@@ -1476,6 +1476,7 @@ async def test_preparation_outcomes_reach_controller_and_journal_owners(  # noqa
 
     runner.deps.resolver.fetch_thread_history = AsyncMock(side_effect=history)
     tasks = []
+    response_started = asyncio.Event()
 
     async def callback(callback_room: nio.MatrixRoom, event: nio.RoomMessageFormatted) -> TurnDispatchOutcome:
         dispatch = PreparedDispatch(
@@ -1510,6 +1511,7 @@ async def test_preparation_outcomes_reach_controller_and_journal_owners(  # noqa
             room_id=callback_room.room_id,
         )
         tasks.append(task)
+        response_started.set()
         return TurnDispatchOutcome.DEFERRED
 
     dispatcher = _dispatcher(principal, callback)
@@ -1561,8 +1563,14 @@ async def test_preparation_outcomes_reach_controller_and_journal_owners(  # noqa
             assert await principal.load_matrix_delivery(delivery_id=SOURCE, stage=DeliveryStage.FINAL) is None
             assert store.get_turn_record(SOURCE).response_event_id == INITIAL
             assert model_requests == []
+            response_started.clear()
             await dispatcher.drain_once()
-            await tasks[-1]
+            dispatcher.start()
+            try:
+                await asyncio.wait_for(response_started.wait(), timeout=5)
+                await tasks[-1]
+            finally:
+                await dispatcher.stop()
             assert len(model_requests) == 1
             assert "PRIVATE_CONTEXT_TO_DELETE" not in str(model_requests)
             assert visible == {INITIAL: "survivor answer"}

--- a/tests/test_response_redaction_recovery.py
+++ b/tests/test_response_redaction_recovery.py
@@ -126,6 +126,7 @@ async def test_pending_redaction_owns_interrupted_initial_response(  # noqa: PLR
         name="inbox_response:deleted",
         recovery_proof_ready=lambda: bot._response_recovery_ready(turn),
         source_event_ids=turn.source_event_ids,
+        room_id=ROOM,
     )
     await started.wait()
     try:

--- a/tests/test_response_redaction_recovery.py
+++ b/tests/test_response_redaction_recovery.py
@@ -213,6 +213,7 @@ async def test_restart_survivor_cleans_pending_redaction_before_generation(  # n
     await reopened.warm()
     bot = _response_recovery_bot(journal_store, reopened)
     model = _ReplayCaptureModel(id="test", name="test", provider="test")
+    survivor_delivered = asyncio.Event()
 
     async def survivor(_room: nio.MatrixRoom, event: nio.RoomMessageFormatted) -> TurnDispatchOutcome:
         assert event.event_id == "$survivor"
@@ -240,6 +241,7 @@ async def test_restart_survivor_cleans_pending_redaction_before_generation(  # n
             payload={"msgtype": "m.text", "body": answer.content},
             settle_source_event_ids=("$survivor",),
         )
+        survivor_delivered.set()
         return TurnDispatchOutcome.DEFERRED
 
     dispatcher = _dispatcher(principal, survivor)
@@ -248,6 +250,11 @@ async def test_restart_survivor_cleans_pending_redaction_before_generation(  # n
         await dispatcher._worker.drain_once()
         assert not await principal.is_pending(REDACTION)
     await dispatcher.drain_once()
+    dispatcher.start()
+    try:
+        await asyncio.wait_for(survivor_delivered.wait(), timeout=5)
+    finally:
+        await dispatcher.stop()
     assert len(model.requests) == 1
     assert "keep prompt" in model.requests[0]
     assert "deleted prompt" not in model.requests[0]

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -1625,6 +1625,7 @@ class TestAgentBot(AgentBotTestBase):
             finalize_after_cancellation(),
             name="test_process_shutdown_placeholder",
             recovery_proof_ready=lambda: False,
+            room_id="!room:example.org",
         )
         await asyncio.wait_for(started.wait(), timeout=1.0)
 

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -200,6 +200,7 @@ async def test_process_shutdown_refuses_new_response_owners_until_admissions_res
                 refused_response,
                 name="test_late_process_shutdown_response",
                 recovery_proof_ready=lambda: True,
+                room_id=_target().room_id,
             )
     finally:
         if accidentally_owned is not None:
@@ -214,6 +215,7 @@ async def test_process_shutdown_refuses_new_response_owners_until_admissions_res
         asyncio.sleep(0),
         name="test_resumed_response",
         recovery_proof_ready=lambda: True,
+        room_id=_target().room_id,
     )
     await resumed_response
     assert runner.pending_inbox_response_count == 0
@@ -246,6 +248,7 @@ async def test_process_shutdown_releases_claim_when_response_never_starts() -> N
             name="test_never_started_claimed_response",
             recovery_proof_ready=recovery_proof_ready,
             on_terminal=release_claim,
+            room_id=_target().room_id,
         )
     except BaseException:
         response.close()
@@ -350,6 +353,7 @@ async def test_repeated_inbox_drains_keep_failed_recovery_proof_fail_closed() ->
         interrupted_response(),
         name="test_unrecoverable_interrupted_response",
         recovery_proof_ready=lambda: False,
+        room_id=_target().room_id,
     )
     await response_started.wait()
 
@@ -368,6 +372,7 @@ async def test_repeated_inbox_drains_keep_failed_recovery_proof_fail_closed() ->
         recoverable_interrupted_response(),
         name="test_recoverable_interrupted_response",
         recovery_proof_ready=lambda: True,
+        room_id=_target().room_id,
     )
     await recoverable_response_started.wait()
 
@@ -404,6 +409,7 @@ async def test_process_shutdown_accepts_clean_response_without_recovery_proof() 
         response_finishes_cleanly(),
         name="test_clean_process_shutdown_response",
         recovery_proof_ready=invalid_recovery_proof,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -438,6 +444,7 @@ async def test_process_shutdown_reports_terminal_durable_response_as_drained() -
         interrupted_response(),
         name="test_durable_process_shutdown_response",
         recovery_proof_ready=durable_recovery_ready,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -475,6 +482,7 @@ async def test_process_shutdown_waits_for_durable_proof_to_become_ready() -> Non
         interrupted_response(),
         name="test_eventually_durable_process_response",
         recovery_proof_ready=eventually_durable_recovery,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -509,6 +517,7 @@ async def test_process_shutdown_retries_cancellation_within_bounded_cleanup() ->
         layered_cleanup(),
         name="test_layered_process_shutdown_cleanup",
         recovery_proof_ready=lambda: True,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -554,6 +563,7 @@ async def test_process_shutdown_keeps_indefinitely_resistant_response_owned() ->
         indefinitely_resistant_response(),
         name="test_indefinitely_resistant_process_response",
         recovery_proof_ready=lambda: True,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -603,6 +613,7 @@ async def test_process_shutdown_bounds_async_recovery_proof() -> None:
         interrupted_response(),
         name="test_stuck_process_shutdown_recovery_proof",
         recovery_proof_ready=stuck_recovery_proof,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -660,6 +671,7 @@ async def test_process_shutdown_retains_cancellation_resistant_recovery_proof_ow
         interrupted_response(),
         name="test_resistant_process_shutdown_recovery_proof",
         recovery_proof_ready=cancellation_resistant_proof,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -729,6 +741,7 @@ async def test_process_shutdown_reuses_late_recovery_proof_on_cleanup_retry() ->
         interrupted_response(),
         name="test_late_recovery_proof_reuse",
         recovery_proof_ready=cancellation_resistant_proof,
+        room_id=_target().room_id,
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -781,6 +794,7 @@ async def test_recovery_proofs_wait_until_every_response_is_terminal() -> None:
         live_response(),
         name="terminal_gate",
         recovery_proof_ready=stuck_recovery_proof,
+        room_id=_target().room_id,
     )
     await finished_task
 
@@ -857,6 +871,7 @@ async def test_process_shutdown_drains_four_owned_response_lifecycles(
                 owned_response(index),
                 name=f"test_process_shutdown_response_{index}",
                 recovery_proof_ready=lambda: True,
+                room_id=_target().room_id,
             )
             for index in range(4)
         ]
@@ -917,11 +932,13 @@ async def test_process_shutdown_starts_terminal_proof_while_peer_unwinds() -> No
             fast_response(),
             name="test_fast_terminal_response",
             recovery_proof_ready=fast_proof,
+            room_id=_target().room_id,
         ),
         runner.track_inbox_response(
             slow_response(),
             name="test_slow_unwinding_response",
             recovery_proof_ready=lambda: True,
+            room_id=_target().room_id,
         ),
     ]
     await fast_started.wait()
@@ -959,6 +976,7 @@ async def test_failed_detached_inbox_response_returns_sources_to_retry_owner() -
         name="test_failed_detached_inbox_response",
         recovery_proof_ready=lambda: False,
         on_failure=on_failure,
+        room_id=_target().room_id,
     )
 
     await asyncio.gather(response_task, return_exceptions=True)
@@ -970,7 +988,8 @@ async def test_failed_detached_inbox_response_returns_sources_to_retry_owner() -
 @pytest.mark.asyncio
 async def test_detached_inbox_response_owns_source_until_task_finishes() -> None:
     """Journal replay must not reclaim a source while its response task is alive."""
-    runner = ResponseRunner(deps=MagicMock())
+    retry_sources = MagicMock()
+    runner = ResponseRunner(deps=MagicMock(retry_approval_sources=retry_sources))
     response_started = asyncio.Event()
     release_response = asyncio.Event()
 
@@ -983,6 +1002,7 @@ async def test_detached_inbox_response_owns_source_until_task_finishes() -> None
         name="test_source_owned_inbox_response",
         recovery_proof_ready=lambda: False,
         source_event_ids=("$reaction",),
+        room_id=_target().room_id,
     )
 
     assert runner.has_live_inbox_response("$reaction")
@@ -992,6 +1012,7 @@ async def test_detached_inbox_response_owns_source_until_task_finishes() -> None
     await asyncio.sleep(0)
 
     assert not runner.has_live_inbox_response("$reaction")
+    retry_sources.assert_called_once_with(_target().room_id, ("$reaction",))
 
 
 class RecordingStopManager(StopManager):
@@ -3775,7 +3796,7 @@ async def test_automatic_pause_publishes_ordered_tools_and_wakes_continuation(tm
     assert edit_request.new_text == paused.response_text
     assert edit_request.tool_trace == list(paused.tool_trace)
     send_text.assert_not_awaited()
-    retry_sources.assert_called_once_with(("$source",))
+    retry_sources.assert_called_once_with(request.room_id, ("$source",))
     assert outcome.final_visible_body == paused.response_text
     assert outcome.delivery_kind == "edited"
     assert outcome.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
@@ -3828,7 +3849,7 @@ async def test_automatic_pause_without_visible_event_sends_ordered_tools(tmp_pat
     assert send_request.response_text == paused.response_text
     assert send_request.tool_trace == list(paused.tool_trace)
     assert send_request.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
-    retry_sources.assert_called_once_with(("$source",))
+    retry_sources.assert_called_once_with(request.room_id, ("$source",))
     assert outcome.final_visible_body == paused.response_text
     assert outcome.delivery_kind == "sent"
     assert outcome.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
@@ -4330,7 +4351,7 @@ async def test_missing_approver_denial_stays_neutral_and_wakes_continuation(tmp_
     edit_request = edit_text.await_args.args[0]
     assert edit_request.new_text == paused.response_text
     assert edit_request.tool_trace == list(paused.tool_trace)
-    retry_sources.assert_called_once_with(("$source",))
+    retry_sources.assert_called_once_with(request.room_id, ("$source",))
     assert outcome.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
 
 
@@ -4453,7 +4474,7 @@ async def test_chained_pause_persists_and_publishes_only_human_gated_calls(
         awaited.kwargs["tool_name"] for awaited in approval_store.prepare_detached_approval.await_args_list
     ] == expected_cards
     if expected_state == "ready":
-        retry_sources.assert_called_once_with(("$source",))
+        retry_sources.assert_called_once_with(current.room_id, ("$source",))
         restarted = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
         claimed = await restarted.deps.approval_store.claim_approval_continuation(
             continuation.approval_id,
@@ -5646,6 +5667,7 @@ async def test_non_streaming_final_delivery_exposes_fixed_shutdown_phase(tmp_pat
             coordinator._process_and_respond(_plain_request(_target())),
             name="test_non_streaming_final_delivery_phase",
             recovery_proof_ready=lambda: True,
+            room_id=_target().room_id,
         )
         await finalization_started.wait()
         coordinator.begin_process_shutdown()
@@ -6077,6 +6099,7 @@ async def test_process_shutdown_exposes_retained_streaming_response_phase(
             coordinator._process_and_respond_streaming(_plain_request(_target())),
             name="test_retained_streaming_response_phase",
             recovery_proof_ready=lambda: True,
+            room_id=_target().room_id,
         )
         await generation_started.wait()
         coordinator.begin_process_shutdown()
@@ -6135,6 +6158,7 @@ async def test_process_shutdown_exposes_retained_final_delivery_phase(
             coordinator._process_and_respond_streaming(_plain_request(_target())),
             name="test_retained_final_delivery_phase",
             recovery_proof_ready=lambda: True,
+            room_id=_target().room_id,
         )
         await finalization_started.wait()
         coordinator.begin_process_shutdown()
@@ -7930,6 +7954,7 @@ async def test_generic_retry_reuses_cancelled_offloaded_proof() -> None:
         name="generic_offloaded",
         recovery_proof_ready=proof,
         source_event_ids=("$source",),
+        room_id=_target().room_id,
     )
     await started.wait()
     with pytest.raises(response_runner.ResponseShutdownTimeoutError):
@@ -7977,6 +8002,7 @@ async def test_cancelled_generic_drain_keeps_proof_owner() -> None:
         name="cancelled_generic",
         recovery_proof_ready=proof,
         source_event_ids=("$source",),
+        room_id=_target().room_id,
     )
     await started.wait()
     draining = asyncio.create_task(runner.drain_inbox_responses(cancel_after_seconds=0.1))
@@ -8023,6 +8049,7 @@ async def test_generic_to_process_proof_promotion_retries_false_result(completed
         name="promoted_generic",
         recovery_proof_ready=proof,
         source_event_ids=("$source",),
+        room_id=_target().room_id,
     )
     await started.wait()
     with pytest.raises(response_runner.ResponseShutdownTimeoutError):
@@ -8055,11 +8082,21 @@ async def test_overlapping_drains_keep_snapshot_ownership() -> None:
         second_started.set()
         await release_second.wait()
 
-    first = runner.track_inbox_response(first_response(), name="first_snapshot", recovery_proof_ready=lambda: True)
+    first = runner.track_inbox_response(
+        first_response(),
+        name="first_snapshot",
+        recovery_proof_ready=lambda: True,
+        room_id="!room:example.org",
+    )
     await first_started.wait()
     first_drain = asyncio.create_task(runner.drain_inbox_responses(cancel_after_seconds=0.01))
     await asyncio.sleep(0)
-    second = runner.track_inbox_response(second_response(), name="second_snapshot", recovery_proof_ready=lambda: True)
+    second = runner.track_inbox_response(
+        second_response(),
+        name="second_snapshot",
+        recovery_proof_ready=lambda: True,
+        room_id="!room:example.org",
+    )
     await second_started.wait()
     second_drain = asyncio.create_task(runner.drain_inbox_responses(cancel_after_seconds=0.1))
     assert not await first_drain

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -256,6 +256,7 @@ async def test_team_delivery_exposes_fixed_shutdown_phase(
             team_response_owner(),
             name=f"test_team_{boundary}_shutdown_phase",
             recovery_proof_ready=lambda: True,
+            room_id="!room:example.org",
         )
         await boundary_started.wait()
         coordinator.begin_process_shutdown()

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -488,6 +488,15 @@ class TestRoutingRegression:
     ) -> None:
         """Recover ready selections while retaining only an exact unready target."""
         router_bot, _healthy_bot, stuck_bot, room = _selective_router_recovery_runtime(tmp_path)
+
+        async def recover_until_settled(event_id: str) -> None:
+            async with asyncio.timeout(5):
+                while await router_bot._journal_dispatcher.store.is_pending(event_id):
+                    await router_bot.recover_pending_turn_journal_events()
+                    await drain_coalescing(router_bot)
+                    assert await wait_for_background_tasks(timeout=1, owner=router_bot._runtime_view)
+                    await asyncio.sleep(0.01)
+
         room_id = room.room_id
         event = _router_readiness_event("$selective-recovery")
         router_bot.client.room_send.return_value = nio.RoomSendResponse.from_dict(
@@ -503,10 +512,7 @@ class TestRoutingRegression:
             EventClass.ACTIONABLE,
         )
 
-        await router_bot.recover_pending_turn_journal_events()
-        await drain_coalescing(router_bot)
-        assert await wait_for_background_tasks(timeout=1, owner=router_bot._runtime_view)
-        await router_bot.recover_pending_turn_journal_events()
+        await recover_until_settled(event.event_id)
 
         mock_suggest_responder.assert_awaited_once()
         content = router_bot.client.room_send.await_args.kwargs["content"]
@@ -539,10 +545,7 @@ class TestRoutingRegression:
             {"event_id": "$stuck-router-response"},
             room_id=room_id,
         )
-        await router_bot.recover_pending_turn_journal_events()
-        await drain_coalescing(router_bot)
-        assert await wait_for_background_tasks(timeout=1, owner=router_bot._runtime_view)
-        await router_bot.recover_pending_turn_journal_events()
+        await recover_until_settled(blocked_event.event_id)
 
         content = router_bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == "@mindroom_stuck:localhost could you help with this?"

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2374,6 +2374,7 @@ class TestStreamingBehavior:
             run_stream(),
             name="test_process_shutdown_stream",
             recovery_proof_ready=lambda: False,
+            room_id="!room:example.org",
         )
         with patch("mindroom.streaming.edit_message_result", new=AsyncMock(side_effect=record_edit)):
             await asyncio.wait_for(first_edit_finished.wait(), timeout=1.0)

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -647,6 +647,7 @@ async def test_process_shutdown_signals_responses_before_coalescing_drain() -> N
         response(),
         name="test_early_process_shutdown_response",
         recovery_proof_ready=lambda: True,
+        room_id="!room:example.org",
     )
     await asyncio.wait_for(response_started.wait(), timeout=1.0)
     cancellation_seen_at_coalescing: list[bool] = []
@@ -3929,6 +3930,7 @@ async def test_deferred_agent_stop_waits_for_retained_proof_before_resources() -
         interrupted_response(),
         name="test_deferred_agent_stop_response",
         recovery_proof_ready=retained_proof,
+        room_id="!room:example.org",
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -4003,6 +4005,7 @@ async def test_deferred_agent_stop_replaces_settled_cancelling_proof() -> None: 
         interrupted_response(),
         name="test_deferred_agent_stop_cancelling_proof",
         recovery_proof_ready=retryable_proof,
+        room_id="!room:example.org",
     )
     await response_started.wait()
     runner.begin_process_shutdown()
@@ -4145,6 +4148,7 @@ async def test_deferred_agent_stop_deadline_keeps_resources_under_live_proof() -
         interrupted_response(),
         name="test_deferred_agent_stop_deadline_response",
         recovery_proof_ready=resistant_proof,
+        room_id="!room:example.org",
     )
     await response_started.wait()
     runner.begin_process_shutdown()

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -714,9 +714,9 @@ async def test_continuation_decision_wakes_its_owning_bot_sources(tmp_path: Path
         cards_provider=lambda: None,
     )
 
-    await transport._wake_continuation_sources("code", ("$source-1", "$source-2"))
+    await transport._wake_continuation_sources("code", "!room:example.org", ("$source-1", "$source-2"))
 
-    owner.retry_approval_sources.assert_called_once_with(("$source-1", "$source-2"))
+    owner.retry_approval_sources.assert_called_once_with("!room:example.org", ("$source-1", "$source-2"))
 
 
 @pytest.mark.asyncio
@@ -919,6 +919,7 @@ async def test_deadline_sweep_expires_an_unacknowledged_card_and_wakes_its_conti
         recorded=True,
         continuation_ready=True,
         continuation_entity_name="code",
+        continuation_room_id="!room:example.org",
         source_event_ids=("$source",),
     )
     cards = MagicMock()
@@ -938,7 +939,7 @@ async def test_deadline_sweep_expires_an_unacknowledged_card_and_wakes_its_conti
     assert await manager._expire_stored("!room:localhost", stored) is False
 
     cards.expire_unacknowledged_approval_card.assert_awaited_once_with(delivery_id="approval-card-1")
-    wake.assert_awaited_once_with("code", ("$source",))
+    wake.assert_awaited_once_with("code", "!room:example.org", ("$source",))
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -1338,6 +1338,14 @@ async def test_duplicate_router_relay_claim_settles_without_restart(config: Conf
     await harness.runner.settle_inbox_responses()
     await obligation_runner.drain_once()
 
+    obligation_runner.start()
+    try:
+        async with asyncio.timeout(5):
+            while await obligation_runner.store.unsettled_event_ids():  # noqa: ASYNC110 - settlement has no event signal
+                await asyncio.sleep(0.01)
+    finally:
+        await obligation_runner.stop()
+
     assert not await obligation_runner.store.is_pending(first.event_id)
     assert not await obligation_runner.store.is_pending(second.event_id)
 

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -2317,8 +2317,13 @@ async def test_membership_uncertainty_does_not_complete_ingress(tmp_path: Path, 
     assert await validator.precheck_event(room, event, is_edit=kind == "edit") == _SENDER
     client.joined_members.return_value = nio.JoinedMembersResponse(members=[], room_id=room.room_id)
     await memberships.refresh(config, runtime_paths_for(config), client)
-    await dispatcher.drain_once()
-    await dispatcher.stop()
+    dispatcher.start()
+    try:
+        async with asyncio.timeout(5):
+            while await dispatcher.store.is_pending(event.event_id):  # noqa: ASYNC110 - journal settlement has no event signal
+                await asyncio.sleep(0.01)
+    finally:
+        await dispatcher.stop()
     assert await dispatcher.store.pending() == ()
     assert harness.turn_store.is_handled(event.event_id)
     assert harness.runner.requests == []

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -800,6 +800,16 @@ def _obligation_runner(
     )
 
 
+async def _settle_dispatcher(harness: _Harness, dispatcher: JournalDispatcher) -> None:
+    """Drive test-owned response tasks and honor retry cooldowns until journal settlement."""
+    async with asyncio.timeout(5):
+        while await dispatcher.store.unsettled_event_ids():
+            await dispatcher.drain_once()
+            await harness.gate.drain_all()
+            await harness.runner.settle_inbox_responses()
+            await asyncio.sleep(0.01)
+
+
 def _router_relay_event(
     config: Config,
     *,
@@ -4528,7 +4538,7 @@ async def test_pending_membership_preserves_receipt_order_and_quiet_retry(  # no
         await harness.gate.drain_all()
         await harness.runner.settle_inbox_responses()
         assert attempted == ["$first", "$first", "$second"]
-        await dispatcher.drain_once()
+        await _settle_dispatcher(harness, dispatcher)
     finally:
         await dispatcher.stop()
     assert [request.prompt for request in harness.runner.requests] == (
@@ -4626,9 +4636,7 @@ async def test_late_membership_change_preserves_exact_source(  # noqa: PLR0915
             assert before["ledger_exists"] is False
             assert before["retry_requests"] == [(event.event_id,)]
             await memberships.refresh(config, runtime_paths_for(config), client)
-        await dispatcher.drain_once()
-        await harness.gate.drain_all()
-        await harness.runner.settle_inbox_responses()
+        await _settle_dispatcher(harness, dispatcher)
         after_count = len(harness.runner.requests)
         await dispatcher.drain_once()
         await harness.gate.drain_all()

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -195,6 +195,7 @@ class _RecordingResponseRunner:
         response: Coroutine[Any, Any, None],
         *,
         name: str,
+        room_id: str,  # noqa: ARG002
         recovery_proof_ready: Callable[[], Awaitable[bool]],
         on_failure: Callable[[], None] | None = None,
         on_terminal: Callable[[], None] | None = None,
@@ -528,7 +529,7 @@ def _build_harness(
     async def _dispatch_source_is_terminal(_source_event_id: str) -> bool:
         return False
 
-    def _retry_dispatch_sources(source_event_ids: tuple[str, ...]) -> None:
+    def _retry_dispatch_sources(_room_id: str, source_event_ids: tuple[str, ...]) -> None:
         retried_dispatch_sources.append(source_event_ids)
 
     def _retry_failed_coalesced_dispatch(

--- a/tests/test_turn_delivery_handoff.py
+++ b/tests/test_turn_delivery_handoff.py
@@ -18,6 +18,7 @@ restart would resend the frozen answer *and* run the model again for it.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, patch
@@ -463,9 +464,12 @@ class TestTheJournalNoLongerAsksWhetherATurnFinished:
         """
         bot = _make_bot(tmp_path)
         dispatched: list[str] = []
+        replayed = asyncio.Event()
 
         async def on_message(_room: nio.MatrixRoom, event: nio.RoomMessageText) -> TurnDispatchOutcome:
             dispatched.append(event.event_id)
+            if len(dispatched) == 2:
+                replayed.set()
             return TurnDispatchOutcome.DEFERRED
 
         dispatcher = _dispatcher(bot, on_message)
@@ -475,6 +479,11 @@ class TestTheJournalNoLongerAsksWhetherATurnFinished:
 
         await bot._turn_store.record_turn(TurnRecord.create(["$cause"], response_event_id="$response"))
         await dispatcher.drain_once()
+        dispatcher.start()
+        try:
+            await asyncio.wait_for(replayed.wait(), timeout=5)
+        finally:
+            await dispatcher.stop()
 
         assert bot._turn_store.is_handled("$cause")
         assert dispatched == ["$cause", "$cause"], "the journal decided on the turn engine's behalf"


### PR DESCRIPTION
A rotating journal scan could skip earlier messages while their room was busy or postpone a failed callback indefinitely as new events kept arriving. Repeated admissions could also bypass retry backoff.

Global scanning now discovers rooms, while one reserved lane per room reads fresh room-filtered journal pages and owns receipt order, progress, and continuation. Room retries use independent one-to-thirty-second cooldowns and continue even while global discovery is delayed. The journal remains authoritative for approval eligibility.

Retry handoffs carry their existing room identity and invalidate that room's current page synchronously before later callbacks can run. Response ownership retains the room ID; approval and ingress callbacks forward it through their existing wiring. Room progress remains owned while detached responses hold unsettled sources. Completion notifications rewind immediately; missed notifications are recovered by a rotating fallback sweep that repeats independently of discovery and yields between bounded batches. A room receipt marker survives page boundaries and puts repeated eligible work under the existing cooldown, bounding immediate and alternating downstream handoffs with constant memory per room. Shutdown cancels owned work without settling pending sources.

The worker shrinks from 558 to 513 lines. The change adds an indexed room filter to the existing replay query and removes failed-head ordering barriers. Changes in the bot lifecycle shell only forward room identity.

Validation: journal ingress/storage/crash recovery, durable ingestion, turn-controller, approval, coalescing, response, configuration, and shutdown suites passed, including SQLite and PostgreSQL. Regressions cover busy-room order, continuing admissions, blocked discovery, synchronous approval handoffs, concurrent drains, unreadable pages, backoff, and restart. Changed-file pre-commit checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when deferred events are released, retried, reclaimed, or recovered after an owner becomes unavailable.
  - Prevented duplicate event admission and retry loops during room recovery.
  - Preserved deferred work across shutdown and worker restarts.
  - Added room-aware retry cooldowns and more complete recovery scans.

- **Improvements**
  - Pending event queries can now be narrowed by room.
  - Approval and response handoffs retain room context for more accurate retry and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->