### PR TITLE
Log bounded await chains when Matrix sync stops progressing

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -298,6 +298,9 @@ Ordinary Matrix transport silence still reaches the watchdog after 120 seconds a
 While Nio commits durable ingestion progress, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for up to `MINDROOM_MATRIX_INGESTION_GRACE_SECONDS` (default 600).
 Both stop deferring when that grace expires or progress stops advancing for their respective silence timeout.
 Successful sync completion refreshes both liveness clocks and clears the ingestion grace window.
+After 90 seconds without sync or durable ingestion progress, `matrix_sync_stall_diagnostics` logs bounded await chains for that agent's sync, ingestion runner, ingestion pump, and delivery recovery tasks, including during first-sync and restarted-sync startup grace.
+Reports repeat at most every 90 seconds and include sync age, time without progress, and ingestion generation without changing watchdog or readiness behavior.
+Snapshots contain at most four tasks and 32 code locations per task, with strings capped at 240 characters; they exclude locals, message content, and source text, and stop at opaque Future or Task await boundaries.
 Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -869,6 +869,9 @@ Ordinary Matrix transport silence still reaches the watchdog after 120 seconds a
 While Nio commits durable ingestion progress, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for up to `MINDROOM_MATRIX_INGESTION_GRACE_SECONDS` (default 600).
 Both stop deferring when that grace expires or progress stops advancing for their respective silence timeout.
 Successful sync completion refreshes both liveness clocks and clears the ingestion grace window.
+After 90 seconds without sync or durable ingestion progress, `matrix_sync_stall_diagnostics` logs bounded await chains for that agent's sync, ingestion runner, ingestion pump, and delivery recovery tasks, including during first-sync and restarted-sync startup grace.
+Reports repeat at most every 90 seconds and include sync age, time without progress, and ingestion generation without changing watchdog or readiness behavior.
+Snapshots contain at most four tasks and 32 code locations per task, with strings capped at 240 characters; they exclude locals, message content, and source text, and stop at opaque Future or Task await boundaries.
 Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -294,6 +294,9 @@ Ordinary Matrix transport silence still reaches the watchdog after 120 seconds a
 While Nio commits durable ingestion progress, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for up to `MINDROOM_MATRIX_INGESTION_GRACE_SECONDS` (default 600).
 Both stop deferring when that grace expires or progress stops advancing for their respective silence timeout.
 Successful sync completion refreshes both liveness clocks and clears the ingestion grace window.
+After 90 seconds without sync or durable ingestion progress, `matrix_sync_stall_diagnostics` logs bounded await chains for that agent's sync, ingestion runner, ingestion pump, and delivery recovery tasks, including during first-sync and restarted-sync startup grace.
+Reports repeat at most every 90 seconds and include sync age, time without progress, and ingestion generation without changing watchdog or readiness behavior.
+Snapshots contain at most four tasks and 32 code locations per task, with strings capped at 240 characters; they exclude locals, message content, and source text, and stop at opaque Future or Task await boundaries.
 Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix

--- a/src/mindroom/matrix/sync_diagnostics.py
+++ b/src/mindroom/matrix/sync_diagnostics.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 _STALL_REPORT_INTERVAL_SECONDS = 90.0
-_MAX_TASKS = 4
 _MAX_FRAMES = 32
 _MAX_STRING_LENGTH = 240
 
@@ -65,7 +64,8 @@ def _capture_sync_task_snapshots(agent_name: str) -> list[_SyncTaskSnapshot]:
     for task in asyncio.all_tasks():
         if task.get_name() in names and not task.done():
             snapshots.append(_snapshot_task(task))
-            if len(snapshots) == _MAX_TASKS:
+            names.remove(task.get_name())
+            if not names:
                 break
     return sorted(snapshots, key=lambda snapshot: snapshot.task_name)
 

--- a/src/mindroom/matrix/sync_diagnostics.py
+++ b/src/mindroom/matrix/sync_diagnostics.py
@@ -1,0 +1,112 @@
+"""Bounded await-chain diagnostics for stalled Matrix receive loops."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import CoroutineType, GeneratorType
+from typing import TYPE_CHECKING
+
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from typing import Any
+
+logger = get_logger(__name__)
+
+_STALL_REPORT_INTERVAL_SECONDS = 90.0
+_MAX_TASKS = 4
+_MAX_FRAMES = 32
+_MAX_STRING_LENGTH = 240
+
+
+@dataclass(frozen=True, slots=True)
+class _SyncTaskSnapshot:
+    """Code locations only; opaque awaitables terminate the visible chain."""
+
+    task_name: str
+    await_chain: tuple[str, ...]
+    await_boundary: str | None
+    truncated: bool
+
+
+def _snapshot_task(task: asyncio.Task[Any]) -> _SyncTaskSnapshot:
+    awaited = task.get_coro()
+    frames: list[str] = []
+    for _ in range(_MAX_FRAMES):
+        if isinstance(awaited, CoroutineType):
+            frame, awaited = awaited.cr_frame, awaited.cr_await
+        elif isinstance(awaited, GeneratorType):
+            frame, awaited = awaited.gi_frame, awaited.gi_yieldfrom
+        else:
+            break
+        if frame is not None:
+            code = frame.f_code
+            location = f"{Path(code.co_filename).name}:{frame.f_lineno}:{code.co_name}"
+            frames.append(location[:_MAX_STRING_LENGTH])
+    return _SyncTaskSnapshot(
+        task_name=task.get_name()[:_MAX_STRING_LENGTH],
+        await_chain=tuple(frames),
+        await_boundary=type(awaited).__name__[:_MAX_STRING_LENGTH] if awaited is not None else None,
+        truncated=isinstance(awaited, (CoroutineType, GeneratorType)),
+    )
+
+
+def _capture_sync_task_snapshots(agent_name: str) -> list[_SyncTaskSnapshot]:
+    """Inspect at most four live, exactly named tasks belonging to one agent."""
+    names = {
+        f"matrix_sync_{agent_name}",
+        f"matrix_ingestion_runner_{agent_name}",
+        f"matrix_ingestion_pump_{agent_name}",
+        f"delivery_recovery_{agent_name}",
+    }
+    snapshots: list[_SyncTaskSnapshot] = []
+    for task in asyncio.all_tasks():
+        if task.get_name() in names and not task.done():
+            snapshots.append(_snapshot_task(task))
+            if len(snapshots) == _MAX_TASKS:
+                break
+    return sorted(snapshots, key=lambda snapshot: snapshot.task_name)
+
+
+@dataclass(slots=True)
+class SyncStallDiagnostics:
+    """Observe progress independently of watchdog cancellation and health grace."""
+
+    agent_name: str
+    last_progress_monotonic: float
+    generation: int | None
+    _last_report_monotonic: float | None = field(default=None, init=False)
+
+    def observe(self, *, now: float, sync_age: float | None, generation: int | None) -> None:
+        """Log no more than once per 90 seconds after 90 seconds without progress."""
+        if generation != self.generation:
+            self.generation = generation
+            if generation is not None:
+                self.last_progress_monotonic = now
+        if sync_age is not None:
+            self.last_progress_monotonic = max(self.last_progress_monotonic, now - sync_age)
+        no_progress_seconds = now - self.last_progress_monotonic
+        if no_progress_seconds < _STALL_REPORT_INTERVAL_SECONDS or (
+            self._last_report_monotonic is not None
+            and now - self._last_report_monotonic < _STALL_REPORT_INTERVAL_SECONDS
+        ):
+            return
+        self._last_report_monotonic = now
+        logger.warning(
+            "matrix_sync_stall_diagnostics",
+            agent=self.agent_name[:_MAX_STRING_LENGTH],
+            sync_age=sync_age,
+            no_progress_seconds=no_progress_seconds,
+            generation=generation,
+            snapshots=[
+                {
+                    "task_name": snapshot.task_name,
+                    "await_chain": snapshot.await_chain,
+                    "await_boundary": snapshot.await_boundary,
+                    "truncated": snapshot.truncated,
+                }
+                for snapshot in _capture_sync_task_snapshots(self.agent_name)
+            ],
+        )

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -35,6 +35,7 @@ from mindroom.matrix.health import (
     matrix_versions_url,
     response_has_matrix_versions,
 )
+from mindroom.matrix.sync_diagnostics import SyncStallDiagnostics
 from mindroom.runtime_shutdown import (
     GENERIC_SHUTDOWN,
     SYNC_RESTART_SHUTDOWN,
@@ -285,6 +286,7 @@ class _SyncIteration:
         ingestion_grace_seconds = matrix_ingestion_grace_seconds(bot.runtime_paths)
         startup_monotonic = time.monotonic()
         observed_ingestion_generation = bot.durable_ingestion_progress_generation()
+        diagnostics = SyncStallDiagnostics(bot.agent_name, startup_monotonic, observed_ingestion_generation)
         while _matrix_sync_receive_loop_active(bot) and not sync_task.done():
             await asyncio.sleep(_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS)
             if not _matrix_sync_receive_loop_active(bot):
@@ -295,6 +297,11 @@ class _SyncIteration:
                 if ingestion_generation is not None:
                     mark_matrix_ingestion_progress(bot.agent_name)
             sync_age_seconds = bot.seconds_since_last_sync_activity()
+            diagnostics.observe(
+                now=time.monotonic(),
+                sync_age=sync_age_seconds,
+                generation=ingestion_generation,
+            )
 
             if sync_age_seconds is None:
                 # Still waiting for the first SyncResponse/SyncError.

--- a/tests/test_matrix_sync_diagnostics.py
+++ b/tests/test_matrix_sync_diagnostics.py
@@ -1,0 +1,116 @@
+"""Bounded, payload-free diagnostics for suspended Matrix tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict
+from types import coroutine
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.matrix.sync_diagnostics import _capture_sync_task_snapshots
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@coroutine
+def _generator_wait(event: asyncio.Event) -> Generator[object, None, None]:
+    yield from _generator_leaf(event)
+
+
+def _generator_leaf(event: asyncio.Event) -> Generator[object, None, None]:
+    yield from event.wait().__await__()
+
+
+async def _nested_wait(event: asyncio.Event, depth: int = 0, *, _payload: str = "example-message-payload") -> None:
+    if depth:
+        await _nested_wait(event, depth - 1)
+    else:
+        await event.wait()
+
+
+async def _legacy_wait(event: asyncio.Event) -> None:
+    await _generator_wait(event)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy", [False, True])
+async def test_snapshots_follow_nested_coroutines_and_generator_waits(legacy: bool) -> None:
+    """Show the inner wait without exposing its local values or source text."""
+    event = asyncio.Event()
+    task = asyncio.create_task(_legacy_wait(event) if legacy else _nested_wait(event), name="matrix_sync_test_agent")
+    try:
+        await asyncio.sleep(0)
+        snapshots = _capture_sync_task_snapshots("test_agent")
+        assert len(snapshots) == 1
+        snapshot = snapshots[0]
+        assert snapshot.task_name == "matrix_sync_test_agent"
+        assert snapshot.truncated is False
+        if legacy:
+            assert any(frame.endswith(":_legacy_wait") for frame in snapshot.await_chain)
+            assert any(frame.endswith(":_generator_wait") for frame in snapshot.await_chain)
+            assert any(frame.endswith(":_generator_leaf") for frame in snapshot.await_chain)
+        else:
+            assert any(frame.endswith(":_nested_wait") for frame in snapshot.await_chain)
+            assert any(frame.endswith(":wait") for frame in snapshot.await_chain)
+        assert snapshot.await_boundary is not None
+        assert all("/" not in frame for frame in snapshot.await_chain)
+        assert "yield from" not in json.dumps(asdict(snapshot))
+        assert "Event object" not in json.dumps(asdict(snapshot))
+        assert "example-message-payload" not in json.dumps(asdict(snapshot))
+        assert not task.done()
+        assert not task.cancelling()
+    finally:
+        event.set()
+        await task
+
+
+@pytest.mark.asyncio
+async def test_snapshots_include_only_exact_owned_task_names() -> None:
+    """Exclude other agents, watchdogs, unrelated tasks, and finished tasks."""
+    event = asyncio.Event()
+    names = [
+        "matrix_sync_test_agent",
+        "matrix_ingestion_runner_test_agent",
+        "matrix_ingestion_pump_test_agent",
+        "delivery_recovery_test_agent",
+        "matrix_sync_test_agent_other",
+        "matrix_sync_other_agent",
+        "matrix_sync_watchdog_test_agent",
+        "response_test_agent",
+    ]
+    tasks = [asyncio.create_task(_nested_wait(event), name=name) for name in names]
+    finished = asyncio.create_task(asyncio.sleep(0), name="matrix_sync_test_agent")
+    try:
+        await finished
+        snapshots = _capture_sync_task_snapshots("test_agent")
+        assert {snapshot.task_name for snapshot in snapshots} == set(names[:4])
+        assert len(snapshots) == 4
+        assert all(not task.cancelling() for task in tasks)
+    finally:
+        event.set()
+        await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_snapshots_bound_duplicate_tasks_deep_chains_and_strings() -> None:
+    """Large agent names and deep waits cannot produce unbounded log records."""
+    event = asyncio.Event()
+    agent_name = "agent_" + "x" * 500
+    tasks = [asyncio.create_task(_nested_wait(event, 100), name=f"matrix_sync_{agent_name}") for _ in range(12)]
+    try:
+        await asyncio.sleep(0)
+        snapshots = _capture_sync_task_snapshots(agent_name)
+        assert 0 < len(snapshots) <= 4
+        for snapshot in snapshots:
+            assert len(snapshot.task_name) <= 240
+            assert 0 < len(snapshot.await_chain) <= 32
+            assert all(len(frame) <= 240 for frame in snapshot.await_chain)
+            assert snapshot.truncated is True
+        assert len(json.dumps([asdict(snapshot) for snapshot in snapshots])) < 40_000
+    finally:
+        event.set()
+        await asyncio.gather(*tasks)

--- a/tests/test_matrix_sync_diagnostics.py
+++ b/tests/test_matrix_sync_diagnostics.py
@@ -104,7 +104,7 @@ async def test_snapshots_bound_duplicate_tasks_deep_chains_and_strings() -> None
     try:
         await asyncio.sleep(0)
         snapshots = _capture_sync_task_snapshots(agent_name)
-        assert 0 < len(snapshots) <= 4
+        assert len(snapshots) == 1
         for snapshot in snapshots:
             assert len(snapshot.task_name) <= 240
             assert 0 < len(snapshot.await_chain) <= 32

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1499,6 +1499,78 @@ def test_health_defers_only_bounded_recent_owned_ingestion_progress() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("first_sync_done", [False, True])
+@pytest.mark.parametrize(
+    ("progress_kind", "progress_times", "expected_report_times"),
+    [
+        (None, (), [90.0, 180.0, 270.0]),
+        ("ingestion", (80, 160, 240), [330.0]),
+        ("sync", (80, 160, 240), [330.0]),
+        ("ingestion", (60, 120, 180, 240, 300), []),
+        ("sync", (60, 120, 180, 240, 300), []),
+    ],
+)
+async def test_watchdog_reports_sustained_stalls_during_startup_grace(
+    monkeypatch: pytest.MonkeyPatch,
+    first_sync_done: bool,
+    progress_kind: str | None,
+    progress_times: tuple[int, ...],
+    expected_report_times: list[float],
+) -> None:
+    """First and restarted syncs get bounded diagnostics without losing grace."""
+    bot = _FakeBot()
+    bot._first_sync_done = first_sync_done
+    bot._durable_ingestion_progress_generation = 0
+    now = 0.0
+    last_sync: float | None = None
+    report_times: list[float] = []
+
+    async def advance_before_poll(delay: float) -> None:
+        nonlocal now, last_sync
+        assert delay == 5.0
+        now += delay
+        if now in progress_times:
+            if progress_kind == "ingestion":
+                assert bot._durable_ingestion_progress_generation is not None
+                bot._durable_ingestion_progress_generation += 1
+            else:
+                last_sync = now
+        if now >= 350.0:
+            bot.running = False
+
+    def record_log(_logger: object, _method: str, event: dict[str, object]) -> dict[str, object]:
+        if event.get("event") == "matrix_sync_stall_diagnostics":
+            report_times.append(now)
+        return event
+
+    monkeypatch.setattr(runtime_helpers, "time", SimpleNamespace(monotonic=lambda: now))
+    monkeypatch.setattr(bot, "seconds_since_last_sync_activity", lambda: None if last_sync is None else now - last_sync)
+    sync_task = asyncio.create_task(bot.sync_forever(), name="matrix_sync_test_agent")
+    watchdog_cancelled_sync = asyncio.Event()
+    reset_matrix_sync_health()
+    try:
+        await asyncio.sleep(0)
+        monkeypatch.setattr(runtime_helpers.asyncio, "sleep", advance_before_poll)
+        with capture_logs(processors=[record_log]) as logs:
+            await _SyncIteration._watch(bot, sync_task, watchdog_cancelled_sync)
+        assert report_times == expected_report_times
+        diagnostics = [event for event in logs if event["event"] == "matrix_sync_stall_diagnostics"]
+        for event in diagnostics:
+            assert event["agent"] == "test_agent"
+            assert event["no_progress_seconds"] >= 90.0
+            assert event["generation"] == (len(progress_times) if progress_kind == "ingestion" else 0)
+            assert event["snapshots"][0]["task_name"] == "matrix_sync_test_agent"
+            assert event["sync_age"] == (90.0 if progress_kind == "sync" else None)
+        assert not watchdog_cancelled_sync.is_set()
+        assert not sync_task.done()
+        assert not sync_task.cancelling()
+    finally:
+        sync_task.cancel()
+        await asyncio.gather(sync_task, return_exceptions=True)
+        reset_matrix_sync_health()
+
+
+@pytest.mark.asyncio
 async def test_watchdog_defers_while_owned_ingestion_commits_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1499,7 +1499,6 @@ def test_health_defers_only_bounded_recent_owned_ingestion_progress() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("first_sync_done", [False, True])
 @pytest.mark.parametrize(
     ("progress_kind", "progress_times", "expected_report_times"),
     [
@@ -1512,14 +1511,12 @@ def test_health_defers_only_bounded_recent_owned_ingestion_progress() -> None:
 )
 async def test_watchdog_reports_sustained_stalls_during_startup_grace(
     monkeypatch: pytest.MonkeyPatch,
-    first_sync_done: bool,
     progress_kind: str | None,
     progress_times: tuple[int, ...],
     expected_report_times: list[float],
 ) -> None:
-    """First and restarted syncs get bounded diagnostics without losing grace."""
+    """Startup grace permits bounded diagnostics without cancelling sync."""
     bot = _FakeBot()
-    bot._first_sync_done = first_sync_done
     bot._durable_ingestion_progress_generation = 0
     now = 0.0
     last_sync: float | None = None


### PR DESCRIPTION
When Matrix sync stops advancing, startup grace can delay watchdog cancellation without showing which receive task is waiting. Log bounded await chains after 90 seconds without sync or durable ingestion progress, including during first and restarted syncs.

Reports identify the sync, ingestion runner, ingestion pump, and delivery recovery tasks. They include code locations only, exclude locals and message content, and stop at opaque await boundaries. Logging repeats at most every 90 seconds and leaves cancellation, recovery, and readiness policies unchanged.

Validation:
- Focused diagnostics, watchdog, and orchestrator runtime tests passed.
- Repository pre-commit hooks passed for all changed files.
- Independent review approved the diagnostic bounds and unchanged watchdog behavior.

## Summary by Sourcery

Add bounded diagnostics for Matrix sync stalls so stalled receive tasks are identifiable during startup and recovery.

Enhancements:
- Add bounded Matrix sync stall diagnostics that periodically report progress age and await chains for the sync, ingestion, and delivery tasks without changing cancellation or readiness behavior.

Documentation:
- Document the new Matrix sync stall diagnostics, reporting cadence, and payload bounds.

Tests:
- Add coverage for bounded, payload-free await-chain snapshots and diagnostics during startup grace and sustained stalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added diagnostic logging for stalled Matrix synchronization and ingestion activity.
  - After 90 seconds without progress, logs include sync age, elapsed stall time, ingestion generation, and bounded task activity snapshots.
  - Diagnostics cover startup and restarted-sync periods and repeat no more than every 90 seconds.
  - Reports exclude message content and local data, with limits on captured tasks, locations, and text size.
  - Watchdog and readiness behavior remain unchanged.

- **Documentation**
  - Added Health & Readiness documentation describing the new diagnostics and reporting limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->