### PR TITLE
Require mindroom-nio 1.0.1 to unblock room history repair

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -98,7 +98,8 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio>=1,<2`, and `uv.lock` pins the published 1.0.0 release.
+MindRoom requires `mindroom-nio>=1.0.1,<2`, and `uv.lock` pins the published 1.0.1 release.
+This release parses encrypted attachments in ordinary history events and treats a null room-avatar URL as unset, preventing those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.
 Ingress admits that hidden event only from a managed sender, leaves it out of the visible-message projection, and classifies cold-history copies as context-only.

--- a/docs/dev/matrix-event-journal-contracts.md
+++ b/docs/dev/matrix-event-journal-contracts.md
@@ -26,7 +26,7 @@ One shared boundary helper encodes `None` to the empty string and decodes it bac
 ### Durable sync batch boundary
 
 The Matrix client uses `nio.durable.open_durable_sync` with Classic or Simplified Sliding Sync.
-Both development and published MindRoom wheels require the released `mindroom-nio>=1.0.0,<2` package, with no Git source override.
+Both development and published MindRoom wheels require the released `mindroom-nio>=1.0.1,<2` package, with no Git source override.
 Account, device, consumer and stream ownership bind once when opening the session.
 Soft-logout renewal requests the existing device; it preserves the bound stream, membership positions, and attempted-delivery sending identity.
 Hard logout, missing device storage, or changed identity stops startup instead of attempting a stream replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]>=1,<2",
+  "mindroom-nio[e2e]>=1.0.1,<2",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17278,7 +17278,8 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio>=1,<2`, and `uv.lock` pins the published 1.0.0 release.
+MindRoom requires `mindroom-nio>=1.0.1,<2`, and `uv.lock` pins the published 1.0.1 release.
+This release parses encrypted attachments in ordinary history events and treats a null room-avatar URL as unset, preventing those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.
 Ingress admits that hidden event only from a managed sender, leaves it out of the visible-message projection, and classifies cold-history copies as context-only.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -94,7 +94,8 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio>=1,<2`, and `uv.lock` pins the published 1.0.0 release.
+MindRoom requires `mindroom-nio>=1.0.1,<2`, and `uv.lock` pins the published 1.0.1 release.
+This release parses encrypted attachments in ordinary history events and treats a null room-avatar URL as unset, preventing those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.
 Ingress admits that hidden event only from a managed sender, leaves it out of the visible-message projection, and classifies cold-history copies as context-only.

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -258,7 +258,7 @@ def test_wheel_force_include_does_not_bundle_avatar_assets() -> None:
 
 
 def test_runtime_dependency_requires_released_durable_nio() -> None:
-    """The wheel requires the published durable API and excludes older releases."""
+    """The wheel requires published durable sync and history parsing fixes."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
     requirement = Requirement(
@@ -269,5 +269,6 @@ def test_runtime_dependency_requires_released_durable_nio() -> None:
     assert requirement.extras == {"e2e"}
     assert requirement.url is None
     assert Version("0.40.0") not in requirement.specifier
-    assert Version("1.0.0") in requirement.specifier
+    assert Version("1.0.0") not in requirement.specifier
+    assert Version("1.0.1") in requirement.specifier
     assert Version("2.0.0") not in requirement.specifier

--- a/tests/test_room_history_recovery.py
+++ b/tests/test_room_history_recovery.py
@@ -591,6 +591,41 @@ async def test_bad_event_at_server_exhaustion_stays_repairable(principal: Princi
     assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
 
+@pytest.mark.parametrize("old_event_type", ["encrypted_file", "cleared_avatar"])
+async def test_repair_accepts_encrypted_attachments_and_cleared_avatars(
+    principal: PrincipalStore,
+    old_event_type: str,
+) -> None:
+    """Readable historical metadata must not block newer conversation messages."""
+    old = raw("$old", "attachment.txt", ts=1_000)
+    if old_event_type == "encrypted_file":
+        old["content"] = {
+            "msgtype": "m.file",
+            "body": "attachment.txt",
+            "file": {
+                "url": "mxc://example.org/encrypted-attachment",
+                "key": {"alg": "A256CTR", "k": "test-key"},
+                "iv": "test-iv",
+                "hashes": {"sha256": "test-hash"},
+            },
+        }
+    else:
+        old.update(type="m.room.avatar", state_key="", content={"url": None})
+    client = PagedClient(pages=[([raw("$new", "new message", ts=2_000), old], None)])
+    await principal.record_room_history_recovery(ROOM)
+
+    await hydrator(principal, client).ensure_hydrated(room_id=ROOM, thread_id=None)
+
+    assert await principal.room_history_recovery(ROOM) is None
+    assert await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
+    page = await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)
+    expected_ids = ["$old", "$new"] if old_event_type == "encrypted_file" else ["$new"]
+    assert [message.logical_event_id for message in page.messages] == expected_ids
+    if old_event_type == "encrypted_file":
+        assert page.messages[0].content["file"] == old["content"]["file"]
+    assert client.calls == 1
+
+
 async def test_repair_pagination_error_leaves_the_obligation_repairable(principal: PrincipalStore) -> None:
     """A failed request may leave retry-safe pages but cannot publish them as whole."""
     client = PagedClient(

--- a/uv.lock
+++ b/uv.lock
@@ -4600,7 +4600,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = ">=1,<2" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = ">=1.0.1,<2" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4714,7 +4714,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4727,9 +4727,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/47/8c9f964e74183fe7603569a8974a5e2f64352847cefa10a67f0c132d3537/mindroom_nio-1.0.0.tar.gz", hash = "sha256:f52892703f185a44d8657c6cc0496b5b93a9864c153eed659648a68400e00d12", size = 210756, upload-time = "2026-09-07T06:36:43.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/aa/ac719f1997a99e4f82192ccd6a84ed90ebed73da8ca541940a71efabb387/mindroom_nio-1.0.1.tar.gz", hash = "sha256:611018898501089e48f2c471fb82f6ad269e51261293b5588294e02eefbe96fc", size = 210939, upload-time = "2026-09-10T09:35:38.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/05/d82e2ef322a8d32aaaa0962e3376cf85dad9b971ac755a7b14d74ea3b2e9/mindroom_nio-1.0.0-py3-none-any.whl", hash = "sha256:0ba851a930f3eb62ff3e3ce0a7a814fbfad6c209d528827d14aa14c77b91fbc2", size = 245942, upload-time = "2026-09-07T06:36:41.865Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/61afeb51d4947eb2f2b672e71a2478e9e1a007166ebd1d6284fa0a90196d/mindroom_nio-1.0.1-py3-none-any.whl", hash = "sha256:a6dcf309e3416f84a31c0dd80ba1ade6eb22b8740fa88d8e9d0967ab1ce9304b", size = 246086, upload-time = "2026-09-10T09:35:37.185Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Room history repair could repeatedly fail on an encrypted file inside an ordinary message event or an old room-avatar event with `url: null`, preventing newer conversation messages from being processed.

Require [mindroom-nio 1.0.1](https://github.com/mindroom-ai/mindroom-nio/releases/tag/1.0.1) and update the lockfile to consume its attachment-dispatch and cleared-avatar parsing fixes.
Add a regression test proving both event shapes allow history repair to finish, expose newer messages, and preserve encrypted attachment metadata on SQLite and PostgreSQL.
Existing tests continue to reject malformed messages and events without decryption keys.
Update the dependency contract test and maintained documentation to match the new minimum version.

Validation: 330 history, media, Olm encryption, and package-build tests passed against the published PyPI package; repository hooks passed.
The parser's own suite passed 968 tests with three skips, including CI on Python 3.12, 3.13, and 3.14.

## Summary by Sourcery

Require mindroom-nio 1.0.1 to ensure room history repair completes for previously unsupported event shapes.

Bug Fixes:
- Prevent room history repair from being blocked by encrypted attachments in ordinary message events or cleared room-avatar events.
- Preserve encrypted attachment metadata while allowing newer conversation messages to be hydrated.

Enhancements:
- Raise the minimum supported mindroom-nio version to 1.0.1 and update the lockfile.

Documentation:
- Update Matrix architecture and development dependency documentation for the mindroom-nio 1.0.1 requirement and its history-parsing fixes.

Tests:
- Add regression coverage for encrypted attachments and null room-avatar URLs across room history recovery.
- Update the package dependency contract test to enforce mindroom-nio 1.0.1 or newer.