### PR TITLE
Avoid needless authorization refresh scans and expose startup timing

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -748,6 +748,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1631,6 +1631,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -744,6 +744,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/src/mindroom/agent_reply_membership_sync.py
+++ b/src/mindroom/agent_reply_membership_sync.py
@@ -80,7 +80,10 @@ class AgentReplyMembershipSync:
         refresh: Callable[[], Awaitable[None]],
     ) -> None:
         """Refresh once when due and apply bounded retry backoff on failure."""
-        if not self._refresh_pending and not self._memberships.needs_refresh(config):
+        # A sync gap cannot invalidate explicit-user grants. Do not turn a
+        # no-op rebuild into downstream room and call reconciliation scans.
+        if not self._memberships.needs_refresh(config):
+            self._refresh_pending = False
             return
         if time.monotonic() < self._refresh_retry_at:
             return

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -907,7 +907,7 @@ async def _run_non_streaming_agent_attempts(
     agent = run_context.prepared_run.agent
     try:
         if pipeline_timing is not None:
-            pipeline_timing.mark("model_request_sent", overwrite=True)
+            pipeline_timing.mark_model_request()
         with bind_llm_request_log_context(
             **_attempt_request_log_context(
                 run_context.turn,
@@ -1739,7 +1739,7 @@ async def _stream_agent_attempt_chunks(
     agent = run_context.prepared_run.agent
     try:
         if pipeline_timing is not None:
-            pipeline_timing.mark("model_request_sent", overwrite=True)
+            pipeline_timing.mark_model_request()
         ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
         request_context = _attempt_request_log_context(
             run_context.turn,

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -77,6 +77,7 @@ _PRIMARY_SEGMENTS: tuple[tuple[str, str, str], ...] = (
 )
 
 _PRIMARY_TOTALS: tuple[tuple[str, str, str], ...] = (
+    ("time_to_model_request_ms", "message_received", "first_model_request_sent"),
     ("time_to_first_visible_reply_ms", "message_received", "first_visible_reply"),
     ("time_to_first_substantive_reply_ms", "message_received", "first_substantive_reply"),
     ("total_pipeline_ms", "message_received", "response_complete"),
@@ -136,6 +137,12 @@ class DispatchPipelineTiming:
             if value is not None:
                 self.metadata[key] = value
 
+    def mark_model_request(self) -> None:
+        """Keep initial startup separate from the latest model attempt's timings."""
+        now = time.perf_counter()
+        self.marks.setdefault("first_model_request_sent", now)
+        self.marks["model_request_sent"] = now
+
     def mark_first_visible_reply(self, kind: str, *, substantive: bool = False) -> None:
         """Record the first visible reply and, when confirmed, the first substantive reply."""
         needs_visible = "first_visible_reply" not in self.marks
@@ -159,12 +166,10 @@ class DispatchPipelineTiming:
         return elapsed_ms_between(start, end)
 
     def emit_summary(self, logger: BoundLogger, *, outcome: str) -> None:
-        """Log one structured end-to-end timing summary."""
+        """Log one opt-in summary at INFO; high-frequency spans remain DEBUG."""
         if self.summary_emitted:
             return
         self.summary_emitted = True
-        if not _debug_enabled(logger):
-            return
         summary: dict[str, Any] = {
             "source_event_id": self.source_event_id,
             "room_id": self.room_id,
@@ -176,7 +181,7 @@ class DispatchPipelineTiming:
             elapsed = self._elapsed_ms(start_label, end_label)
             if elapsed is not None:
                 summary[key] = elapsed
-        logger.debug("Dispatch pipeline timing", **summary)
+        logger.info("Dispatch pipeline timing", **summary)
 
 
 def create_dispatch_pipeline_timing(*, event_id: str, room_id: str) -> DispatchPipelineTiming | None:

--- a/tests/test_agent_reply_membership_sync.py
+++ b/tests/test_agent_reply_membership_sync.py
@@ -13,7 +13,10 @@ from mindroom.agent_reply_membership_sync import (
     AgentReplyMembershipSync,
     ReplyMembershipPreAdmission,
 )
+from mindroom.config.access import ResponderAccessConfig
+from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.config.models import RouterConfig
 from mindroom.event_journal import (
     DepartureSource,
     IngestionRecordAdmission,
@@ -65,6 +68,47 @@ def test_history_loss_invalidates_all_reply_membership_grants(tmp_path: Path) ->
     assert effects == ReplyMembershipPreAdmission(invalidate_reason="uncertain_sync_response")
     memberships.invalidate.assert_not_called()
     memberships.mark_room_unready.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("current_room_members", "members_of_rooms", "expected_refreshes"),
+    [(False, [], 0), (True, [], 1), (False, ["lobby"], 1)],
+)
+async def test_history_loss_refreshes_only_room_backed_grants(
+    current_room_members: bool,
+    members_of_rooms: list[str],
+    expected_refreshes: int,
+) -> None:
+    """Explicit-user access must not trigger room/call scans after every sync gap."""
+    config = Config(
+        router=RouterConfig(access=ResponderAccessConfig(current_room_members=False)),
+        agents={
+            "assistant": AgentConfig(
+                display_name="Assistant",
+                role="Assistant",
+                rooms=["lobby"],
+                access=ResponderAccessConfig(
+                    current_room_members=current_room_members,
+                    members_of_rooms=members_of_rooms,
+                    users=["@alice:localhost"],
+                ),
+            ),
+        },
+    )
+    memberships = AgentReplyMembershipIndex()
+    membership_sync = AgentReplyMembershipSync(memberships)
+    refreshes = 0
+
+    async def refresh() -> None:
+        nonlocal refreshes
+        refreshes += 1
+
+    membership_sync.invalidate(config, reason="uncertain_sync_response")
+    await membership_sync.refresh_if_needed(config, refresh)
+
+    assert refreshes == expected_refreshes
+    assert memberships.needs_refresh(config) is bool(expected_refreshes)
 
 
 def test_reported_control_departure_fences_room_before_admission(tmp_path: Path) -> None:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -458,6 +458,7 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
             "prompt_assembly_start": 16.8,
             "prompt_assembly_ready": 17.0,
             "history_ready": 17.0,
+            "first_model_request_sent": 18.0,
             "model_request_sent": 18.0,
             "model_first_token": 19.5,
             "first_visible_reply": 20.0,
@@ -469,9 +470,10 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
 
     timing.emit_summary(logger, outcome="edited")
 
-    logger.debug.assert_called_once()
-    assert logger.debug.call_args.args == ("Dispatch pipeline timing",)
-    summary = logger.debug.call_args.kwargs
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args == ("Dispatch pipeline timing",)
+    summary = logger.info.call_args.kwargs
+    assert summary["time_to_model_request_ms"] == 18000.0
     assert summary["first_visible_kind"] == "stream_update"
     assert summary["first_substantive_kind"] == "stream_update"
     assert summary["seg_ingress_ms"] == 1000.0
@@ -528,6 +530,23 @@ def test_dispatch_pipeline_visible_reply_milestones_are_first_write_wins(
     assert perf_counter.call_count == 2
 
 
+def test_dispatch_pipeline_startup_excludes_prior_model_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry and continuation latency must not be misreported as initial startup."""
+    monkeypatch.setattr(timing_module.time, "perf_counter", Mock(side_effect=[2.0, 12.0]))
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
+    timing.marks["message_received"] = 1.0
+    timing.mark_model_request()
+    timing.mark_model_request()
+    timing.marks["response_complete"] = 15.0
+    logger = Mock()
+
+    timing.emit_summary(logger, outcome="completed")
+
+    summary = logger.info.call_args.kwargs
+    assert summary["time_to_model_request_ms"] == 1000.0
+    assert summary["diag_model_request_to_completion_ms"] == 3000.0
+
+
 def test_dispatch_pipeline_placeholder_only_omits_substantive_reply_metrics(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -540,7 +559,7 @@ def test_dispatch_pipeline_placeholder_only_omits_substantive_reply_metrics(
     timing.mark_first_visible_reply("placeholder")
     timing.emit_summary(logger, outcome="failed")
 
-    summary = logger.debug.call_args.kwargs
+    summary = logger.info.call_args.kwargs
     assert summary["time_to_first_visible_reply_ms"] == 1500.0
     assert "first_substantive_reply" not in timing.marks
     assert "first_substantive_kind" not in summary
@@ -576,8 +595,8 @@ def test_emit_timing_event_still_emits_when_debug_is_enabled(
     assert logger.debug.call_args.kwargs == {"phase": "queued", "queue_size": 7}
 
 
-def test_dispatch_pipeline_summary_builds_no_payload_when_debug_is_disabled() -> None:
-    """The end-to-end summary walks every span pair, so it must not run when dropped."""
+def test_dispatch_pipeline_summary_survives_debug_filtering() -> None:
+    """Opt-in per-turn timings must remain available without verbose per-chunk logs."""
     logger = Mock()
     logger.isEnabledFor.return_value = False
     timing = DispatchPipelineTiming(
@@ -587,8 +606,11 @@ def test_dispatch_pipeline_summary_builds_no_payload_when_debug_is_disabled() ->
     )
 
     timing.emit_summary(logger, outcome="edited")
+    timing.emit_summary(logger, outcome="edited")
 
     logger.debug.assert_not_called()
+    logger.info.assert_called_once()
+    assert logger.info.call_args.kwargs["total_pipeline_ms"] == 1000.0
     assert timing.summary_emitted
 
 
@@ -656,4 +678,4 @@ def test_dispatch_pipeline_summary_emits_when_the_level_check_is_unsupported() -
 
     timing.emit_summary(logger, outcome="edited")
 
-    logger.debug.assert_called_once()
+    logger.info.assert_called_once()


### PR DESCRIPTION
## Summary

Stop sync-history invalidation from rebuilding authorization when the membership index has no room-backed grants to refresh.
For explicit-user configurations, those empty rebuilds were still triggering downstream invite scans and call reconciliation across rooms.
Room-backed permissions retain authoritative refresh and fail-closed behavior.

Keep the opt-in, once-per-turn `Dispatch pipeline timing` summary visible at INFO while high-frequency spans remain DEBUG.
Add `time_to_model_request_ms`, preserving the first attempt separately so retries and continuations cannot inflate startup with earlier model runtime.

## Evidence and scope

- The reported deployment showed 14 seconds before the message callback and multi-second startup phases.
- A non-blocking 30-second profile captured 243 samples: 117 in call reconciliation and 61 in synchronous SQLite commits. Sampling had errors; these are diagnostic counts, not an end-to-end speedup measurement.
- A read-only benchmark of the affected thread returned and decoded 161 messages in a median 5.7 ms over 20 reads, excluding hydration/repair and event-loop scheduling.
- This removes a demonstrated unnecessary refresh cascade; it does not claim all reported latency is eliminated. Deployment measurements are still required, including sync arrival, context, payload, agent build, and model timing separately.
- No caches, worker pools, durability changes, or migrations. Eight net production lines.
- The Nio 1.0.2 dependency update is already covered by #1993 and is deliberately not duplicated here.

## Verification

- Regression fails before the membership guard and passes after it; current-room and named-room permissions still require refresh.
- Retry regression preserves initial startup and the latest attempt's diagnostic spans independently.
- 329 affected tests passed with both Nio 1.0.2 and the unchanged Nio 1.0.1 lockfile.
- Repository pre-commit hooks passed; generated documentation references are synchronized.
- Independent read-only review approved the final code changes.

## Summary by Sourcery

Avoid unnecessary authorization refresh cascades and improve opt-in dispatch startup diagnostics.

New Features:
- Expose an opt-in per-turn dispatch timing summary at INFO level, including time to the first model request and separate diagnostic spans.

Bug Fixes:
- Prevent sync-history invalidation from triggering unnecessary authorization refreshes and downstream room or call reconciliation when only explicit-user grants are configured.
- Keep initial model-startup timing accurate across retries and continuations by preserving the first request separately from later attempts.

Documentation:
- Document the INFO-level dispatch timing summary and its startup and diagnostic timing fields.

Tests:
- Add regression coverage for skipping refreshes without room-backed grants and for preserving initial startup timing across retries.