### PR TITLE
Measure agent and team startup after local request preparation

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -748,7 +748,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
-The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling through local preparation to the first Agno run invocation (not the provider SDK's HTTP-send boundary), plus separate context, queue, payload, agent-build, and model timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1631,7 +1631,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
-The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling through local preparation to the first Agno run invocation (not the provider SDK's HTTP-send boundary), plus separate context, queue, payload, agent-build, and model timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -744,7 +744,7 @@ The same flag also records successful tool-call rows in `mindroom_data/tracking/
 Tool failures are always recorded in `tool_calls.jsonl`, even when request logging is disabled.
 Tool-call rows include a `timing` object with result-ready, before-hook, and tool-body durations when those phases are measured.
 Set `MINDROOM_TIMING=1` to emit additional structured debug timing events for stream-visible tool-call start, stream-visible tool-call completion, and full bridge completion.
-The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling to the model request and separate context, queue, payload, agent-build, and provider timing spans when available.
+The same flag emits one `Dispatch pipeline timing` summary per turn at INFO level, including `time_to_model_request_ms` from message handling through local preparation to the first Agno run invocation (not the provider SDK's HTTP-send boundary), plus separate context, queue, payload, agent-build, and model timing spans when available.
 Audit logging remains enabled.
 Credential-bearing fields such as tokens, cookies, passwords, API keys, and authorization headers are redacted before log records are emitted.
 These artifacts can still contain sensitive non-credential prompt, argument, and result data.

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -881,6 +881,7 @@ async def _run_cached_agent_attempt(
     run_id_callback: Callable[[str], None] | None = None,
     media: MediaInputs | None = None,
     metadata: dict[str, Any] | None = None,
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> RunOutput:
     """Run one non-streaming Agno request with timing instrumentation."""
     return await ai_runtime.cached_agent_run(
@@ -892,6 +893,7 @@ async def _run_cached_agent_attempt(
         run_id_callback=run_id_callback,
         media=media,
         metadata=metadata,
+        pipeline_timing=pipeline_timing,
     )
 
 
@@ -906,8 +908,6 @@ async def _run_non_streaming_agent_attempts(
     """Run one non-streaming agent response attempt."""
     agent = run_context.prepared_run.agent
     try:
-        if pipeline_timing is not None:
-            pipeline_timing.mark_model_request()
         with bind_llm_request_log_context(
             **_attempt_request_log_context(
                 run_context.turn,
@@ -927,6 +927,7 @@ async def _run_non_streaming_agent_attempts(
                 run_id_callback=run_id_callback,
                 media=attempt.attempt_media_inputs,
                 metadata=run_context.metadata,
+                pipeline_timing=pipeline_timing,
             )
         if response.status == RunStatus.error:
             logger.warning(
@@ -1738,8 +1739,6 @@ async def _stream_agent_attempt_chunks(
     """Start and consume one streaming agent attempt."""
     agent = run_context.prepared_run.agent
     try:
-        if pipeline_timing is not None:
-            pipeline_timing.mark_model_request()
         ai_runtime.note_attempt_run_id(run_id_callback, attempt.attempt_run_id)
         request_context = _attempt_request_log_context(
             run_context.turn,
@@ -1754,6 +1753,8 @@ async def _stream_agent_attempt_chunks(
                 attempt.attempt_prompt,
                 attempt.attempt_media_inputs,
             )
+            if pipeline_timing is not None:
+                pipeline_timing.mark_model_request()
             stream_generator = agent.arun(
                 prepared_input,
                 session_id=run_context.session_id,

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from agno.models.base import Model
 
     from mindroom.history.runtime import ScopeSessionContext
+    from mindroom.timing import DispatchPipelineTiming
 
 __all__ = [
     "EMPTY_RESPONSE_NOTICE",
@@ -807,11 +808,14 @@ async def cached_agent_run(
     run_id_callback: Callable[[str], None] | None = None,
     media: MediaInputs | None = None,
     metadata: dict[str, Any] | None = None,
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> RunOutput:
     """Shared wrapper for one ``agent.arun()`` call."""
     media_inputs = media or MediaInputs()
     note_attempt_run_id(run_id_callback, run_id)
     prepared_input = attach_media_to_run_input(run_input, media_inputs)
+    if pipeline_timing is not None:
+        pipeline_timing.mark_model_request()
     return await agent.arun(
         prepared_input,
         session_id=session_id,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2882,8 +2882,11 @@ async def team_response(  # noqa: C901, PLR0915
                     metadata=run_metadata,
                 ),
             ):
+                prepared_input = list(current_run_input)
+                if pipeline_timing is not None:
+                    pipeline_timing.mark_model_request()
                 return await team.arun(
-                    list(current_run_input),
+                    prepared_input,
                     session_id=ctx.session_id,
                     run_id=current_run_id,
                     user_id=user_id,
@@ -3102,6 +3105,7 @@ async def _team_response_stream_raw(
     session_id: str | None = None,
     run_id: str | None = None,
     user_id: str | None = None,
+    pipeline_timing: DispatchPipelineTiming | None = None,
 ) -> AsyncIterator[Any]:
     """Yield raw team events (for structured live rendering). Falls back to a final response.
 
@@ -3126,8 +3130,11 @@ async def _team_response_stream_raw(
         logger.debug("team_member", agent=agent.name)
 
     try:
+        prepared_input = ai_runtime.copy_run_input(prompt)
+        if pipeline_timing is not None:
+            pipeline_timing.mark_model_request()
         return team.arun(
-            ai_runtime.copy_run_input(prompt),
+            prepared_input,
             stream=True,
             stream_events=True,
             session_id=session_id,
@@ -3392,6 +3399,13 @@ async def team_response_stream(  # noqa: C901, PLR0915
         usage = _TeamStreamUsage()
 
         ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
+        request_context = _team_request_log_context(
+            ctx,
+            team_name=configured_team_name or team_label,
+            prompt=continuation_state.active_prompt,
+            run_input=attempt_run_input,
+            metadata=run_metadata,
+        )
 
         raw_stream = await ai_runtime.run_attempt_with_model(
             attempt_model_runtime,
@@ -3404,6 +3418,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 session_id=ctx.session_id,
                 run_id=attempt_run_id,
                 user_id=user_id,
+                pipeline_timing=pipeline_timing,
             ),
         )
         raw_stream = ai_runtime.stream_attempt_with_model(
@@ -3414,13 +3429,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         raw_stream = _capture_stream_interrupt(
             stream_with_llm_request_log_context(
                 cast("AsyncGenerator[Any, None]", raw_stream),
-                request_context=_team_request_log_context(
-                    ctx,
-                    team_name=configured_team_name or team_label,
-                    prompt=continuation_state.active_prompt,
-                    run_input=attempt_run_input,
-                    metadata=run_metadata,
-                ),
+                request_context=request_context,
             ),
         )
         bound_team_id = run.scope_context.scope.scope_id if run.scope_context is not None else team.id or ""

--- a/tests/test_empty_response_guard.py
+++ b/tests/test_empty_response_guard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +16,7 @@ from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
+from mindroom import ai_runtime
 from mindroom.agent_storage import create_state_storage, get_agent_session, get_team_session
 from mindroom.ai import _PreparedAgentRun, ai_response, stream_agent_response
 from mindroom.ai_runtime import (
@@ -29,6 +31,7 @@ from mindroom.constants import resolve_runtime_paths
 from mindroom.history.runtime import ScopeSessionContext
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope, PreparedHistoryState
+from mindroom.timing import DispatchPipelineTiming
 from tests.conftest import make_turn_context, seed_session
 
 if TYPE_CHECKING:
@@ -36,10 +39,26 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
+    from mindroom.media_inputs import MediaInputs
 
 
 def _runtime_paths(tmp_path: Path) -> RuntimePaths:
     return resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path)
+
+
+@pytest.fixture
+def media_preparation_times(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Observe real input copying/attachment before each Agno invocation."""
+    completed_at: list[float] = []
+    attach_media = ai_runtime.attach_media_to_run_input
+
+    def attach(run_input: ai_runtime.ModelRunInput, media: MediaInputs) -> list[Message]:
+        prepared = attach_media(run_input, media)
+        completed_at.append(time.perf_counter())
+        return prepared
+
+    monkeypatch.setattr(ai_runtime, "attach_media_to_run_input", attach)
+    return completed_at
 
 
 def _config() -> Config:
@@ -259,10 +278,14 @@ def test_discard_empty_completed_team_run_removes_run_from_session_and_storage(t
 
 
 @pytest.mark.asyncio
-async def test_ai_response_retries_once_after_empty_completed_run(tmp_path: Path) -> None:
+async def test_ai_response_retries_once_after_empty_completed_run(
+    tmp_path: Path,
+    media_preparation_times: list[float],
+) -> None:
     """One empty completed response should trigger exactly one fresh model attempt."""
     empty_agent = _mock_agent(_completed_run("run-empty", None))
     recovered_agent = _mock_agent(_completed_run("run-good", "Recovered"))
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
 
     with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
         mock_prepare.side_effect = [
@@ -275,11 +298,15 @@ async def test_ai_response_retries_once_after_empty_completed_run(tmp_path: Path
             prompt="test",
             runtime_paths=_runtime_paths(tmp_path),
             config=_config(),
+            pipeline_timing=timing,
         )
 
     assert result == "Recovered"
     empty_agent.arun.assert_called_once()
     recovered_agent.arun.assert_called_once()
+    assert media_preparation_times[0] <= timing.marks["first_model_request_sent"]
+    assert media_preparation_times[-1] <= timing.marks["model_request_sent"]
+    assert timing.marks["first_model_request_sent"] < timing.marks["model_request_sent"]
 
 
 @pytest.mark.asyncio
@@ -362,7 +389,10 @@ async def test_ai_response_fallback_notice_stays_out_of_the_turn_recorder(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_stream_agent_response_retries_once_after_empty_completed_stream(tmp_path: Path) -> None:
+async def test_stream_agent_response_retries_once_after_empty_completed_stream(
+    tmp_path: Path,
+    media_preparation_times: list[float],
+) -> None:
     """One empty completed stream should trigger exactly one fresh streaming attempt."""
 
     async def empty_stream() -> AsyncIterator[object]:
@@ -374,6 +404,7 @@ async def test_stream_agent_response_retries_once_after_empty_completed_stream(t
 
     empty_agent = _mock_streaming_agent(empty_stream())
     recovered_agent = _mock_streaming_agent(recovered_stream())
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
 
     with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
         mock_prepare.side_effect = [
@@ -388,6 +419,7 @@ async def test_stream_agent_response_retries_once_after_empty_completed_stream(t
                 prompt="test",
                 runtime_paths=_runtime_paths(tmp_path),
                 config=_config(),
+                pipeline_timing=timing,
             )
         ]
 
@@ -395,6 +427,9 @@ async def test_stream_agent_response_retries_once_after_empty_completed_stream(t
     assert contents == ["Recovered"]
     empty_agent.arun.assert_called_once()
     recovered_agent.arun.assert_called_once()
+    assert media_preparation_times[0] <= timing.marks["first_model_request_sent"]
+    assert media_preparation_times[-1] <= timing.marks["model_request_sent"]
+    assert timing.marks["first_model_request_sent"] < timing.marks["model_request_sent"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_empty_response_and_replay.py
+++ b/tests/test_team_empty_response_and_replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,12 +16,13 @@ from agno.run.base import RunStatus
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import TeamRunOutput
 
-from mindroom import ai_runtime
+from mindroom import ai_runtime, teams
 from mindroom.constants import SILENT_SCHEDULE_NO_REPLY_TOKEN
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.teams import TeamMode, team_response, team_response_stream
+from mindroom.timing import DispatchPipelineTiming
 from tests.conftest import make_turn_context, runtime_paths_for
 from tests.identity_helpers import entity_ids
 from tests.test_team_dynamic_continuation import _dynamic_tool_team_output
@@ -68,6 +70,7 @@ def _completed_team_run(content: str) -> TeamRunOutput:
 async def test_team_response_retries_once_after_empty_completed_run() -> None:
     """One empty completed team run is discarded and retried before answering."""
     orchestrator, _config = _make_orchestrator()
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room:localhost")
     mock_team = _make_test_team()
     mock_team.arun = AsyncMock(side_effect=[_empty_team_run("team-run-1"), _completed_team_run("Recovered answer")])
 
@@ -81,10 +84,12 @@ async def test_team_response_retries_once_after_empty_completed_run() -> None:
             orchestrator=orchestrator,
             execution_identity=None,
             ctx=make_turn_context(session_id="session-1"),
+            pipeline_timing=timing,
         )
 
     assert "Recovered answer" in response
     assert mock_team.arun.await_count == 2
+    assert 0 < timing.marks["first_model_request_sent"] < timing.marks["model_request_sent"]
 
 
 @pytest.mark.asyncio
@@ -166,9 +171,21 @@ async def test_team_response_returns_fallback_notice_when_retry_is_also_empty() 
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_yields_fallback_notice_when_retry_is_also_empty() -> None:
+async def test_team_response_stream_yields_fallback_notice_when_retry_is_also_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The streaming empty-run guard retries once, then yields the notice chunk."""
     orchestrator, config = _make_orchestrator()
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room:localhost")
+    context_prepared_at: list[float] = []
+    render_input = teams._team_run_input_text
+
+    def render(run_input: str | list[Message]) -> str:
+        result = render_input(run_input)
+        context_prepared_at.append(time.perf_counter())
+        return result
+
+    monkeypatch.setattr(teams, "_team_run_input_text", render)
 
     async def empty_stream(run_id: str) -> AsyncIterator[object]:
         yield _empty_team_run(run_id)
@@ -188,10 +205,14 @@ async def test_team_response_stream_yields_fallback_notice_when_retry_is_also_em
                 orchestrator=orchestrator,
                 execution_identity=None,
                 ctx=make_turn_context(session_id="session-1"),
+                pipeline_timing=timing,
             )
         ]
 
     assert mock_team.arun.call_count == 2
+    assert context_prepared_at[0] <= timing.marks["first_model_request_sent"]
+    assert context_prepared_at[-1] <= timing.marks["model_request_sent"]
+    assert 0 < timing.marks["first_model_request_sent"] < timing.marks["model_request_sent"]
     rendered = "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     assert ai_runtime.EMPTY_RESPONSE_NOTICE in rendered
     # The discarded attempts' fallback documents must not leak ahead of the notice.


### PR DESCRIPTION
## Summary

Follow-up to #1995, which merged while these verified review corrections were being completed.

- Record the existing startup timestamp in both blocking and streaming team attempts.
- Mark agent and team attempts after local request-log rendering and input/media preparation, immediately before Agno invocation.
- Preserve the first-attempt timestamp across retries while updating latest-attempt diagnostics.
- Document that this measures the Agno invocation boundary, not the provider SDK's HTTP-send boundary.

This is timing instrumentation only: 14 net production lines, no caching, workers, migrations, or deployment changes.

## Verification

- Agent preparation-order regressions failed before the timestamp move and passed after it.
- Team regressions caught missing marks and streaming log preparation occurring after the mark; both now pass.
- 506 affected tests passed before cherry-picking onto the merged main branch; 210 directly affected tests passed again on current main.
- Repository pre-commit hooks passed; generated documentation references synchronized.
- Independent read-only review approved the final correction.

Addresses the actionable Qodo and Greptile findings on #1995.

## Summary by Sourcery

Measure agent and team startup timing at the Agno invocation boundary after local request preparation.

Enhancements:
- Refine agent and team pipeline timing instrumentation to measure from message handling through local request preparation to the first Agno invocation, while preserving first-attempt and latest-attempt diagnostics across retries.

Documentation:
- Clarify that model-request timing ends at the Agno invocation boundary rather than the provider SDK's HTTP-send boundary.

Tests:
- Add regression coverage confirming timing marks occur after agent and team input or media preparation for blocking, streaming, and retry attempts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pipeline timing definitions, including the boundary measured by model-request timing and the distinction between local preparation and provider HTTP transmission.
  * Updated timing terminology to refer to model timing spans.

* **Bug Fixes**
  * Improved timing accuracy for streaming, non-streaming, team, and retry workflows, including media and context preparation ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->