### PR TITLE
refactor: isolate legacy streaming and revision replay rules

### DIFF
--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -25,7 +25,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first thirteen rows were created or renamed by the migration-boundary isolation work.
+The first fourteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -43,6 +43,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
 | [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -75,6 +76,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
 | [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
+| [`legacy_revision_replay.py`][legacy-revision-replay] | [Revision replay][legacy-revision-replay-tests], [turn-store][turn-store-tests], and [handled-turn][handled-turn-tests] tests cover reconstruction, monotonic preservation, historical and modern selection, and cold-reopen cleanup. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -90,7 +92,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | ID | Status | Owner and reason |
 | --- | --- | --- |
 | J1 | Isolated | [`legacy_handled_turns.py`][legacy-handled] adopts pre-journal JSON once and renames it. |
-| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery, and [`legacy_handled_turns.py`][legacy-handled] restores only absent historical revision provenance. |
+| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery and cleanup, [`legacy_handled_turns.py`][legacy-handled] reconstructs absent historical revision facts, and [`legacy_revision_replay.py`][legacy-revision-replay] owns their preservation and source-only summary decisions. |
 | J3 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] replaces the old additive conversion framework with the Nio ownership cutoff. |
 | J4 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] drops old interactive tables instead of archiving or translating them. |
 | J5 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] retires the old response outbox rather than converting delivery debt. |
@@ -243,6 +245,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
@@ -306,6 +309,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [journal-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_event_journal_store.py
 [journal-upgrade-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_journal_upgrade_boundary.py
 [knowledge-indexing-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_knowledge_indexing_config.py
+[legacy-revision-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_legacy_revision_replay.py
 [matrix-agent-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_agent_manager.py
 [matrix-identity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_identity.py
 [memory-flush-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_memory_auto_flush.py
@@ -321,5 +325,6 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [streaming-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_streaming_behavior.py
 [sync-continuity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_sync_continuity_store.py
 [trigger-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_external_trigger_replay_store.py
+[turn-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_turn_store.py
 [usage-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_usage_stats_storage.py
 [workflow-scheduling-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_workflow_scheduling.py

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -25,7 +25,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first twelve rows were created or renamed by the migration-boundary isolation work.
+The first thirteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -42,6 +42,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -73,7 +74,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_private_storage.py`][private-legacy] and [`legacy_private_storage_aliases.py`][private-legacy-aliases] | [Private-storage tests][private-storage-tests] cover verified owner relocation, content preservation, historical aliases, and tamper rejection. |
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
-| [`execution_preparation.py`][execution-preparation] and [`streaming.py`][streaming] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical markers, current structured-status precedence, and interruption classification. |
+| [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -195,7 +196,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body markers recognized by [`streaming.py`][streaming] only as a fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 
@@ -242,6 +243,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -42,7 +42,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
-| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters body-only `[cancelled]` or `[error]` suffixes (each preceded by one space). | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
@@ -198,7 +198,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old `[cancelled]` and `[error]` body suffixes (each preceded by one space) owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17723,7 +17723,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first twelve rows were created or renamed by the migration-boundary isolation work.
+The first thirteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -17740,6 +17740,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -17771,7 +17772,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_private_storage.py`][private-legacy] and [`legacy_private_storage_aliases.py`][private-legacy-aliases] | [Private-storage tests][private-storage-tests] cover verified owner relocation, content preservation, historical aliases, and tamper rejection. |
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
-| [`execution_preparation.py`][execution-preparation] and [`streaming.py`][streaming] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical markers, current structured-status precedence, and interruption classification. |
+| [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -17893,7 +17894,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body markers recognized by [`streaming.py`][streaming] only as a fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 
@@ -17940,6 +17941,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17723,7 +17723,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first thirteen rows were created or renamed by the migration-boundary isolation work.
+The first fourteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -17741,6 +17741,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
 | [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -17773,6 +17774,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
 | [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
+| [`legacy_revision_replay.py`][legacy-revision-replay] | [Revision replay][legacy-revision-replay-tests], [turn-store][turn-store-tests], and [handled-turn][handled-turn-tests] tests cover reconstruction, monotonic preservation, historical and modern selection, and cold-reopen cleanup. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -17788,7 +17790,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | ID | Status | Owner and reason |
 | --- | --- | --- |
 | J1 | Isolated | [`legacy_handled_turns.py`][legacy-handled] adopts pre-journal JSON once and renames it. |
-| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery, and [`legacy_handled_turns.py`][legacy-handled] restores only absent historical revision provenance. |
+| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery and cleanup, [`legacy_handled_turns.py`][legacy-handled] reconstructs absent historical revision facts, and [`legacy_revision_replay.py`][legacy-revision-replay] owns their preservation and source-only summary decisions. |
 | J3 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] replaces the old additive conversion framework with the Nio ownership cutoff. |
 | J4 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] drops old interactive tables instead of archiving or translating them. |
 | J5 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] retires the old response outbox rather than converting delivery debt. |
@@ -17941,6 +17943,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
@@ -18004,6 +18007,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [journal-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_event_journal_store.py
 [journal-upgrade-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_journal_upgrade_boundary.py
 [knowledge-indexing-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_knowledge_indexing_config.py
+[legacy-revision-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_legacy_revision_replay.py
 [matrix-agent-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_agent_manager.py
 [matrix-identity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_identity.py
 [memory-flush-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_memory_auto_flush.py
@@ -18019,6 +18023,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [streaming-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_streaming_behavior.py
 [sync-continuity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_sync_continuity_store.py
 [trigger-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_external_trigger_replay_store.py
+[turn-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_turn_store.py
 [usage-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_usage_stats_storage.py
 [workflow-scheduling-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_workflow_scheduling.py
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17740,7 +17740,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
-| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters body-only `[cancelled]` or `[error]` suffixes (each preceded by one space). | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
@@ -17896,7 +17896,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old `[cancelled]` and `[error]` body suffixes (each preceded by one space) owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 

--- a/skills/mindroom-docs/references/page__architecture__migrations__index.md
+++ b/skills/mindroom-docs/references/page__architecture__migrations__index.md
@@ -21,7 +21,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first thirteen rows were created or renamed by the migration-boundary isolation work.
+The first fourteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -39,6 +39,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
 | [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -71,6 +72,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
 | [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
+| [`legacy_revision_replay.py`][legacy-revision-replay] | [Revision replay][legacy-revision-replay-tests], [turn-store][turn-store-tests], and [handled-turn][handled-turn-tests] tests cover reconstruction, monotonic preservation, historical and modern selection, and cold-reopen cleanup. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -86,7 +88,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | ID | Status | Owner and reason |
 | --- | --- | --- |
 | J1 | Isolated | [`legacy_handled_turns.py`][legacy-handled] adopts pre-journal JSON once and renames it. |
-| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery, and [`legacy_handled_turns.py`][legacy-handled] restores only absent historical revision provenance. |
+| J2 | Isolated | [`handled_turns.py`][handled] keeps current sparse fields, [`turn_store.py`][turn-store] owns Agno run recovery and cleanup, [`legacy_handled_turns.py`][legacy-handled] reconstructs absent historical revision facts, and [`legacy_revision_replay.py`][legacy-revision-replay] owns their preservation and source-only summary decisions. |
 | J3 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] replaces the old additive conversion framework with the Nio ownership cutoff. |
 | J4 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] drops old interactive tables instead of archiving or translating them. |
 | J5 | Removed/superseded | [`event_journal/legacy_schema.py`][journal-legacy-schema] retires the old response outbox rather than converting delivery debt. |
@@ -239,6 +241,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
@@ -302,6 +305,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [journal-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_event_journal_store.py
 [journal-upgrade-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_journal_upgrade_boundary.py
 [knowledge-indexing-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_knowledge_indexing_config.py
+[legacy-revision-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_legacy_revision_replay.py
 [matrix-agent-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_agent_manager.py
 [matrix-identity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_matrix_identity.py
 [memory-flush-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_memory_auto_flush.py
@@ -317,5 +321,6 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [streaming-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_streaming_behavior.py
 [sync-continuity-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_sync_continuity_store.py
 [trigger-replay-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_external_trigger_replay_store.py
+[turn-store-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_turn_store.py
 [usage-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_usage_stats_storage.py
 [workflow-scheduling-tests]: https://github.com/mindroom-ai/mindroom/blob/main/tests/test_workflow_scheduling.py

--- a/skills/mindroom-docs/references/page__architecture__migrations__index.md
+++ b/skills/mindroom-docs/references/page__architecture__migrations__index.md
@@ -21,7 +21,7 @@ It describes the current source rather than promising support for every earlier 
 
 ## Named boundaries
 
-The first twelve rows were created or renamed by the migration-boundary isolation work.
+The first thirteen rows were created or renamed by the migration-boundary isolation work.
 The remaining rows were already focused boundaries and complete the current map.
 
 | Boundary | Trigger and current caller | Retained guarantees |
@@ -38,6 +38,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
 | [`src/mindroom/legacy_private_storage.py`][private-legacy], [`legacy_private_storage_aliases.py`][private-legacy-aliases], and [`private_storage_paths.py`][private-paths] | Startup finds a verified private scope with the historical requester spelling. | Intent records, owner and inode checks, worker quiescence, ordered renames, and verified aliases protect recovery and current callers. |
@@ -69,7 +70,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_private_storage.py`][private-legacy] and [`legacy_private_storage_aliases.py`][private-legacy-aliases] | [Private-storage tests][private-storage-tests] cover verified owner relocation, content preservation, historical aliases, and tamper rejection. |
 | [`oauth/legacy_credentials.py`][oauth-legacy-credentials] and [`oauth/credential_store.py`][oauth-store] | [OAuth store tests][oauth-store-tests] cover literal SQLite bindings, publication normalization, the removed JSON reader, reconnect disposition, and inert old files. |
 | [`memory/auto_flush.py`][auto-flush], [`report_publishing/store.py`][report-store], [`scheduling.py`][scheduling], [`external_triggers/replay_store.py`][replay-store], and [`cli/owner.py`][cli-owner] | [Memory][memory-flush-tests], [report][report-tests], [scheduling][workflow-scheduling-tests], [trigger replay][trigger-replay-tests], and [pairing][cli-connect-tests] tests drive the retained defaults through their public read or mutation paths. |
-| [`execution_preparation.py`][execution-preparation] and [`streaming.py`][streaming] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical markers, current structured-status precedence, and interruption classification. |
+| [`legacy_streaming.py`][legacy-streaming] and [`execution_preparation.py`][execution-preparation] | [Partial-reply][partial-reply-tests] and [streaming][streaming-tests] tests cover bounded historical suffixes, exact stripping order, current structured-status precedence, and interruption classification. |
 | [`session_storage_preflight.py`][session-preflight] | [Session recovery tests][session-recovery-tests] cover schema-based archive, locks, rollback recovery, unrelated tables, current corruption, and byte preservation without inventing one release cutoff. |
 | [SSO cookie routes][sso] | [SSO endpoint tests][sso-cookie-tests] assert exact shared-domain and host-only expiry cookies on both endpoints and retain current host-only behavior for localhost, IP addresses, and single-label hosts. |
 
@@ -191,7 +192,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body markers recognized by [`streaming.py`][streaming] only as a fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 
@@ -238,6 +239,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [knowledge-index]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/index_metadata.py
 [knowledge-legacy]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/legacy_metadata.py
 [knowledge-settings]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/knowledge/indexing_config.py
+[legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py

--- a/skills/mindroom-docs/references/page__architecture__migrations__index.md
+++ b/skills/mindroom-docs/references/page__architecture__migrations__index.md
@@ -38,7 +38,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
 | [`src/mindroom/matrix/legacy_state.py`][matrix-legacy-state] | Matrix state has accounts without a domain or a noncanonical serialized shape. | Runtime-domain resolution, parsing, caching, and atomic persistence stay in `matrix/state.py`; rewrites happen only when data differs. |
 | [`src/mindroom/config/legacy_fields.py`][config-legacy] | Agent or defaults validation sees a retired field. | Pydantic remains the strict validation boundary and the helper provides directed replacement errors. |
-| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters a body-only ` [cancelled]` or ` [error]` suffix. | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
+| [`src/mindroom/legacy_streaming.py`][legacy-streaming] | Streaming replay encounters body-only `[cancelled]` or `[error]` suffixes (each preceded by one space). | Current markers stay in `streaming.py`; `execution_preparation.py` gives recognized structured status precedence and delegates body fallback to the streaming reader. |
 | [`src/mindroom/legacy_revision_replay.py`][legacy-revision-replay] | Turn-record merges and redaction cleanup encounter reconstructed revision provenance from pre-v2026.9.43 summaries. | Current revision facts win, storage mutation stays in `turn_store.py`, and source-only summary ownership applies only to labeled historical replay. |
 | [`src/mindroom/event_journal/legacy_schema.py`][journal-legacy-schema] | A journal has `journal_events` but lacks Nio-owned `matrix_sync_consumers`. | One schema transaction preserves history, handled turns, generation, and visible projection while retiring obsolete pending execution. |
 | [`src/mindroom/config/legacy_access.py`][access-legacy] | Config loading or `mindroom config migrate` finds retired access fields. | Complete-source validation, concrete grants, a backup, and atomic membership-schema publication are retained. |
@@ -194,7 +194,7 @@ The OAuth credential and sync-continuity stores reject unsupported versions; oth
 Several sparse readers deliberately ignore unknown fields or drop malformed reconstructible records.
 
 Additional small compatibility branches stay with current readers.
-[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old ` [cancelled]` and ` [error]` body suffixes owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
+[`execution_preparation.py`][execution-preparation] classifies structured stream status first and uses the old `[cancelled]` and `[error]` body suffixes (each preceded by one space) owned by [`legacy_streaming.py`][legacy-streaming] only through the streaming reader fallback.
 Interrupted visible replies are excluded; eligible in-progress text is cleaned before it is included in model context.
 [`external_triggers/replay_store.py`][replay-store] supplies an empty `threads` map for replay stores written before thread keys existed.
 

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -155,10 +155,10 @@ def _classify_partial_reply(
     active_event_ids: Collection[str],
 ) -> _PartialReplyKind | None:
     """Classify a self-authored partial reply from persisted stream metadata first."""
-    # Legacy format: Body-only cancellation, error, and interruption markers without stream_status.
+    # Legacy format: mindroom.legacy_streaming owns body-only terminal suffix parsing without stream_status.
     # Last legacy release: v2026.3.121; replacement: v2026.3.122 wrote structured stream status.
     # Handling: Structured status wins; consult body markers only when status is absent or unrecognized.
-    # Coverage: tests/test_partial_reply_context.py::test_legacy_interrupted_markers_without_metadata_are_interrupted.
+    # Coverage: tests/test_partial_reply_context.py::TestClassifyPartialReply::test_legacy_interrupted_markers_without_metadata_are_interrupted.
     status = msg.stream_status
     if status == STREAM_STATUS_COMPLETED:
         return None

--- a/src/mindroom/legacy_revision_replay.py
+++ b/src/mindroom/legacy_revision_replay.py
@@ -1,0 +1,36 @@
+"""Own historical revision-summary replay decisions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from mindroom.turn_record import RevisionReplay
+
+# Legacy format: Source-level revision summaries without per-revision replay provenance.
+# Last legacy release: v2026.9.42; replacement: v2026.9.43 added per-revision provenance.
+# Handling: Preserve and select source-only summary ownership only for reconstructed historical revisions.
+# Coverage: tests/test_legacy_revision_replay.py and tests/test_turn_store.py::test_legacy_compacted_revision_uses_retained_owner_on_cold_reopen.
+
+
+def preserve_summary_provenance(current: RevisionReplay, previous: RevisionReplay) -> RevisionReplay:
+    """Retain historical summary ownership across current replay updates."""
+    return replace(current, legacy_summary_provenance=True) if previous.legacy_summary_provenance else current
+
+
+def summary_source_id(revision: RevisionReplay) -> str | None:
+    """Return the source ID only when an old summary owns the revision indirectly."""
+    return revision.source_event_id if revision.legacy_summary_provenance else None
+
+
+def summary_depends_on_source(
+    legacy_source_event_id: str | None,
+    *,
+    has_summary: bool,
+    seen_event_ids: Collection[str],
+) -> bool:
+    """Return whether a historical summary consumed the retained source owner."""
+    return has_summary and legacy_source_event_id is not None and legacy_source_event_id in seen_event_ids

--- a/src/mindroom/legacy_streaming.py
+++ b/src/mindroom/legacy_streaming.py
@@ -1,0 +1,23 @@
+"""Read body suffixes written before structured stream status existed."""
+
+from __future__ import annotations
+
+_LEGACY_TERMINAL_SUFFIXES = (" [cancelled]", " [error]")
+
+# Legacy format: Body-only cancellation and error suffixes without stream_status.
+# Last legacy release: v2026.3.121; replacement: v2026.3.122 wrote structured stream status.
+# Handling: Detect and strip only the two bounded suffixes in their historical single-pass order.
+# Coverage: tests/test_streaming_behavior.py::TestStreamingBehavior::test_clean_partial_reply_text_preserves_marker_stripping_order.
+
+
+def has_legacy_terminal_suffix(text: str) -> bool:
+    """Return whether text ends with an old body-only terminal suffix."""
+    return text.endswith(_LEGACY_TERMINAL_SUFFIXES)
+
+
+def strip_legacy_terminal_suffixes(text: str) -> str:
+    """Strip each old body-only terminal suffix once in historical order."""
+    for suffix in _LEGACY_TERMINAL_SUFFIXES:
+        if text.endswith(suffix):
+            text = text[: -len(suffix)].rstrip()
+    return text

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -25,6 +25,7 @@ from mindroom.constants import (
     STREAM_WARMUP_SUFFIX_KEY,
 )
 from mindroom.final_delivery import StreamTransportOutcome
+from mindroom.legacy_streaming import has_legacy_terminal_suffix, strip_legacy_terminal_suffixes
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import build_edit_event_content, edit_message_result, send_message_result
 from mindroom.matrix.large_messages import should_send_oversized_nonterminal_streaming_edit
@@ -264,31 +265,27 @@ def _format_stream_error_note(error: Exception) -> str:
 
 def is_interrupted_partial_reply(text: object) -> bool:
     """Return True when text carries a terminal interrupted partial-reply marker."""
-    # Legacy format: Body-only cancellation, error, and interruption markers without stream_status.
-    # Last legacy release: v2026.3.121; replacement: v2026.3.122 wrote structured stream status.
-    # Handling: Recognize and strip the bounded historical marker forms for stable interrupted replay.
-    # Coverage: tests/test_streaming_behavior.py::TestStreamingBehavior::test_is_interrupted_partial_reply_detects_terminal_markers.
     if not isinstance(text, str):
         return False
     trimmed_text = text.rstrip()
-    return trimmed_text.endswith(
-        (
-            _CANCELLED_RESPONSE_NOTE,
-            _INTERRUPTED_RESPONSE_NOTE,
-            RESTART_INTERRUPTED_RESPONSE_NOTE,
-            " [cancelled]",
-            " [error]",
-        ),
-    ) or (_STREAM_ERROR_RESPONSE_NOTE in trimmed_text)
+    return (
+        has_legacy_terminal_suffix(trimmed_text)
+        or trimmed_text.endswith(
+            (
+                _CANCELLED_RESPONSE_NOTE,
+                _INTERRUPTED_RESPONSE_NOTE,
+                RESTART_INTERRUPTED_RESPONSE_NOTE,
+            ),
+        )
+        or (_STREAM_ERROR_RESPONSE_NOTE in trimmed_text)
+    )
 
 
 def clean_partial_reply_text(text: str) -> str:
     """Strip partial-reply status notes from persisted text."""
-    cleaned = text.rstrip()
+    cleaned = strip_legacy_terminal_suffixes(text.rstrip())
 
     for marker in (
-        " [cancelled]",
-        " [error]",
         _CANCELLED_RESPONSE_NOTE,
         _INTERRUPTED_RESPONSE_NOTE,
         RESTART_INTERRUPTED_RESPONSE_NOTE,

--- a/src/mindroom/turn_record.py
+++ b/src/mindroom/turn_record.py
@@ -9,6 +9,7 @@ from enum import Enum
 from types import MappingProxyType
 
 from mindroom.history.types import HistoryScope
+from mindroom.legacy_revision_replay import preserve_summary_provenance
 from mindroom.message_target import MessageTarget
 from mindroom.timestamp_formatting import normalize_timestamp_ms
 
@@ -761,8 +762,7 @@ def sanitize_revision_replay(  # noqa: C901
             )
         elif old.response_event_id is not None and new.response_event_id is None:
             replay[event_id] = replace(new, response_event_id=old.response_event_id)
-        if old.legacy_summary_provenance:
-            replay[event_id] = replace(replay[event_id], legacy_summary_provenance=True)
+        replay[event_id] = preserve_summary_provenance(replay[event_id], old)
     for event_id in tombstoned_event_ids:
         value = replay.get(event_id)
         if value is not None and not value.redacted:

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -22,6 +22,7 @@ from mindroom.handled_turns import (
     with_user_stop,
 )
 from mindroom.history.storage import invalidate_compacted_replay, read_scope_seen_event_ids
+from mindroom.legacy_revision_replay import summary_depends_on_source, summary_source_id
 from mindroom.session_ids import create_session_id
 from mindroom.turn_record import (
     EditPreparation,
@@ -721,9 +722,7 @@ class TurnStore:
                             target=owner.conversation_target,
                             requester_user_id=owner.requester_id,
                             redacted_event_id=revision_id,
-                            legacy_summary_source_id=(
-                                revision.source_event_id if revision.legacy_summary_provenance else None
-                            ),
+                            legacy_summary_source_id=summary_source_id(revision),
                         ),
                     )
                 await self._acknowledge_revision_cleanup(owner.source_event_ids[0], revision_id)
@@ -1123,12 +1122,12 @@ class TurnStore:
                 if session_type is SessionType.TEAM
                 else get_agent_session(storage, target.session_id)
             )
-            scope_contains_source = session is not None and redacted_event_id in read_scope_seen_event_ids(
-                session,
-                history_scope,
+            seen_event_ids = read_scope_seen_event_ids(session, history_scope) if session is not None else set()
+            scope_contains_source = redacted_event_id in seen_event_ids or summary_depends_on_source(
+                legacy_summary_source_id,
+                has_summary=session is not None and session.summary is not None,
+                seen_event_ids=seen_event_ids,
             )
-            if session is not None and session.summary is not None and legacy_summary_source_id is not None:
-                scope_contains_source |= legacy_summary_source_id in read_scope_seen_event_ids(session, history_scope)
             removed_summary_dependents = bool(
                 session is not None and session.summary is not None and scope_contains_source and session.runs,
             )

--- a/tach.toml
+++ b/tach.toml
@@ -144,6 +144,7 @@ depends_on = [
     "mindroom.legacy_delivery_payloads",
     "mindroom.logging_config",
     "mindroom.matrix.sidecar_content",
+    "mindroom.turn_record",
 ]
 visibility = [
     "mindroom.agent_reply_membership_sync",
@@ -536,6 +537,14 @@ visibility = [
 path = "mindroom.legacy_openai_tool_replay"
 depends_on = []
 visibility = ["mindroom.openai_models"]
+
+[[modules]]
+path = "mindroom.legacy_revision_replay"
+depends_on = []
+visibility = [
+    "mindroom.turn_record",
+    "mindroom.turn_store",
+]
 
 [[modules]]
 path = "mindroom.legacy_handled_turns"
@@ -1512,6 +1521,7 @@ depends_on = [
     "mindroom.matrix_delivery",
     "mindroom.runtime_protocols",
     "mindroom.streaming",
+    "mindroom.turn_record",
 ]
 
 [[modules]]
@@ -1527,6 +1537,7 @@ depends_on = [
     "mindroom.response_runner",
     "mindroom.runtime_protocols",
     "mindroom.timestamp_formatting",
+    "mindroom.turn_record",
     "mindroom.turn_store",
 ]
 
@@ -1940,6 +1951,7 @@ depends_on = [
     "mindroom.tool_system.events",
     "mindroom.tool_system.runtime_context",
     "mindroom.tool_system.worker_routing",
+    "mindroom.turn_record",
     "mindroom.user_turn_time",
 ]
 
@@ -2129,6 +2141,7 @@ visibility = [
     "mindroom.execution_preparation",
     "mindroom.handled_turns",
     "mindroom.turn_controller",
+    "mindroom.turn_record",
     "mindroom.user_turn_time",
 ]
 
@@ -3796,7 +3809,18 @@ depends_on = [
     "mindroom.constants",
     "mindroom.handled_turns",
     "mindroom.history.storage",
+    "mindroom.legacy_revision_replay",
     "mindroom.thread_utils",
+    "mindroom.turn_record",
+]
+
+[[modules]]
+path = "mindroom.turn_record"
+depends_on = [
+    "mindroom.history.types",
+    "mindroom.legacy_revision_replay",
+    "mindroom.message_target",
+    "mindroom.timestamp_formatting",
 ]
 
 [[modules]]
@@ -3836,6 +3860,7 @@ depends_on = [
     "mindroom.response_lifecycle",
     "mindroom.response_payload_preparation",
     "mindroom.timing",
+    "mindroom.turn_record",
     "mindroom.visible_response_reconciliation",
 ]
 visibility = ["mindroom.turn_controller"]
@@ -3852,6 +3877,7 @@ depends_on = [
     "mindroom.matrix.identity",
     "mindroom.message_target",
     "mindroom.turn_policy",
+    "mindroom.turn_record",
     "mindroom.turn_store",
     "mindroom.visible_response_reconciliation",
 ]
@@ -3884,6 +3910,7 @@ depends_on = [
     "mindroom.event_journal",
     "mindroom.handled_turns",
     "mindroom.message_target",
+    "mindroom.turn_record",
     "mindroom.turn_store",
 ]
 visibility = [
@@ -3948,6 +3975,7 @@ depends_on = [
     "mindroom.teams",
     "mindroom.text_ingress_dispatch",
     "mindroom.timestamp_formatting",
+    "mindroom.turn_record",
     "mindroom.turn_store",
     "mindroom.turn_policy",
     "mindroom.visible_response_reconciliation",

--- a/tach.toml
+++ b/tach.toml
@@ -3743,10 +3743,16 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.legacy_streaming"
+depends_on = []
+visibility = ["mindroom.streaming"]
+
+[[modules]]
 path = "mindroom.streaming"
 depends_on = [
     "mindroom.constants",
     "mindroom.interactive",
+    "mindroom.legacy_streaming",
     "mindroom.matrix.client_delivery",
     "mindroom.matrix.mentions",
     "mindroom.message_target",

--- a/tests/test_legacy_revision_replay.py
+++ b/tests/test_legacy_revision_replay.py
@@ -1,0 +1,84 @@
+"""Tests for historical revision-summary replay decisions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from mindroom.legacy_revision_replay import (
+    preserve_summary_provenance,
+    summary_depends_on_source,
+    summary_source_id,
+)
+from mindroom.turn_record import RevisionReplay
+
+
+def test_preserve_summary_provenance_retains_historical_flag_and_current_response() -> None:
+    """A current replay update must retain historical summary ownership."""
+    old = RevisionReplay("$source", 10, legacy_summary_provenance=True)
+    new = RevisionReplay("$source", 10, response_event_id="$response")
+
+    retained = preserve_summary_provenance(new, old)
+
+    assert retained.legacy_summary_provenance is True
+    assert retained.response_event_id == "$response"
+    assert new.legacy_summary_provenance is False
+
+
+def test_preserve_summary_provenance_changes_only_the_historical_flag() -> None:
+    """Provenance retention must preserve current physical revision facts."""
+    old = RevisionReplay("$old-source", 5, legacy_summary_provenance=True)
+    current = RevisionReplay(
+        "$source",
+        10,
+        redacted=True,
+        cleanup_pending=True,
+        response_event_id="$response",
+    )
+
+    assert preserve_summary_provenance(current, old) == replace(
+        current,
+        legacy_summary_provenance=True,
+    )
+
+
+def test_false_prior_provenance_does_not_overwrite_current_true_provenance() -> None:
+    """A modern prior replay cannot clear provenance already held by current state."""
+    previous = RevisionReplay("$source", 10)
+    current = RevisionReplay("$source", 20, legacy_summary_provenance=True)
+
+    assert preserve_summary_provenance(current, previous) is current
+
+
+def test_summary_source_id_selects_only_historical_summary_owners() -> None:
+    """Source-only summary ownership applies only to reconstructed replay facts."""
+    historical = RevisionReplay("$source", 10, legacy_summary_provenance=True)
+    modern = RevisionReplay("$source", 10)
+
+    assert summary_source_id(historical) == "$source"
+    assert summary_source_id(modern) is None
+
+
+def test_summary_dependency_requires_summary_owner_and_seen_source() -> None:
+    """Cleanup reaches a source-only summary only when every ownership fact agrees."""
+    seen_event_ids = {"$source"}
+
+    assert summary_depends_on_source(
+        "$source",
+        has_summary=True,
+        seen_event_ids=seen_event_ids,
+    )
+    assert not summary_depends_on_source(
+        "$source",
+        has_summary=False,
+        seen_event_ids=seen_event_ids,
+    )
+    assert not summary_depends_on_source(
+        None,
+        has_summary=True,
+        seen_event_ids=seen_event_ids,
+    )
+    assert not summary_depends_on_source(
+        "$elsewhere",
+        has_summary=True,
+        seen_event_ids=seen_event_ids,
+    )

--- a/tests/test_partial_reply_context.py
+++ b/tests/test_partial_reply_context.py
@@ -255,6 +255,30 @@ class TestClassifyPartialReply:
             is None
         )
 
+    @pytest.mark.parametrize("body", ["Finished text [cancelled]", "Finished text [error]"])
+    @pytest.mark.parametrize(
+        ("stream_status", "expected"),
+        [
+            (STREAM_STATUS_COMPLETED, None),
+            (STREAM_STATUS_PENDING, _PartialReplyKind.IN_PROGRESS),
+            (STREAM_STATUS_STREAMING, _PartialReplyKind.IN_PROGRESS),
+        ],
+    )
+    def test_recognized_stream_status_wins_over_legacy_terminal_suffix(
+        self,
+        body: str,
+        stream_status: str,
+        expected: _PartialReplyKind | None,
+    ) -> None:
+        """Honor current metadata when an old terminal suffix contradicts it."""
+        assert (
+            _classify_partial_reply(
+                _make_visible_message(event_id="e_active", body=body, stream_status=stream_status),
+                active_event_ids={"e_active"},
+            )
+            is expected
+        )
+
     def test_trailing_marker_without_metadata_is_not_partial(self) -> None:
         """Messages without stream_status metadata are not classified as partial."""
         assert (

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -756,6 +756,8 @@ class TestStreamingBehavior:
         """Interrupted partial-reply detection should recognize shared cancelled/error notes."""
         assert is_interrupted_partial_reply(f"Draft answer\n\n{_CANCELLED_RESPONSE_NOTE}")
         assert is_interrupted_partial_reply("Draft answer\n\n**[Response interrupted by an error: boom]**")
+        assert is_interrupted_partial_reply("Draft [cancelled]   ")
+        assert not is_interrupted_partial_reply("Discuss [error] in this sentence")
         assert not is_interrupted_partial_reply("Finished answer")
         assert not is_interrupted_partial_reply(None)
 
@@ -771,8 +773,22 @@ class TestStreamingBehavior:
         assert (
             clean_partial_reply_text("Draft answer\n\n**[Response interrupted by an error: boom]**") == "Draft answer"
         )
+        assert clean_partial_reply_text("Draft [error]") == "Draft"
         assert clean_partial_reply_text(_PROGRESS_PLACEHOLDER) == ""
         assert clean_partial_reply_text("...") == ""
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            ("Draft [cancelled] [error]", "Draft [cancelled]"),
+            ("Draft [error] [cancelled]", "Draft"),
+            ("Draft **[Response cancelled by user]** [error]", "Draft"),
+            ("Draft [error] **[Response cancelled by user]**", "Draft [error]"),
+        ],
+    )
+    def test_clean_partial_reply_text_preserves_marker_stripping_order(self, body: str, expected: str) -> None:
+        """Strip historical suffixes once in order before removing current notes."""
+        assert clean_partial_reply_text(body) == expected
 
     def test_clean_partial_reply_text_normalises_user_stop_label_to_interrupted_marker(self) -> None:
         """User-stop labels should collapse to the canonical interrupted replay marker."""

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -3722,20 +3722,35 @@ async def test_edit_snapshot_rechecks_after_awaited_source_preparation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("explicit_revision_replay", "historical_summary_owner"),
+    [
+        pytest.param(None, True, id="historical-summary-only"),
+        pytest.param(
+            RevisionReplay("$user_msg", 10, response_event_id="$reply"),
+            False,
+            id="modern-per-revision",
+        ),
+    ],
+)
 async def test_legacy_compacted_revision_uses_retained_owner_on_cold_reopen(
     journal_store: EventJournalStore,
     tmp_path: Path,
+    explicit_revision_replay: RevisionReplay | None,
+    historical_summary_owner: bool,
 ) -> None:
-    """Legacy summaries lacking physical IDs are invalidated only through retained owners."""
+    """Only legacy summaries lacking physical IDs use retained source ownership."""
     target = MessageTarget.resolve("!room:example.org", "$thread", "$user_msg")
     scope = HistoryScope(kind="agent", scope_id="agent")
     original = replace(
         _owned_turn_record(target),
         source_event_prompts={"$user_msg": "DELETED_EDIT_MARKER"},
         source_event_revisions={"$user_msg": (10, "$physical-edit")},
+        revision_replay=(None if explicit_revision_replay is None else {"$physical-edit": explicit_revision_replay}),
     )
     raw = TurnRecordCodec._to_ledger_record(original)
-    raw.pop("revision_replay")
+    if explicit_revision_replay is None:
+        raw.pop("revision_replay")
     await journal_store.turn_records("agent").upsert(
         index_event_ids=original.indexed_event_ids,
         anchor_event_id="$user_msg",
@@ -3764,6 +3779,13 @@ async def test_legacy_compacted_revision_uses_retained_owner_on_cold_reopen(
     storage = storage_factory()
     persisted = get_agent_session(storage, target.session_id)
     assert persisted is not None
-    assert persisted.summary is None
-    assert store.get_turn_record("$user_msg").replay_source_event_ids == ("$user_msg",)
+    if historical_summary_owner:
+        assert persisted.summary is None
+    else:
+        assert persisted.summary is not None
+        assert persisted.summary.summary == "DELETED_EDIT_MARKER"
+    owner = store.get_turn_record("$user_msg")
+    assert owner is not None
+    assert owner.replay_source_event_ids == ("$user_msg",)
+    assert owner.revision_replay["$physical-edit"].legacy_summary_provenance is historical_summary_owner
     storage.close()


### PR DESCRIPTION
Historical stream suffix parsing and revision-summary ownership decisions still lived in current runtime modules. This PR gives each rule a focused owner: `legacy_streaming.py` for old body suffixes and `legacy_revision_replay.py` for historical provenance preservation and summary membership.

The callers retain current stream handling, durable record fields, and all storage and redaction execution. Both legacy modules carry version cutoffs and coverage references. Tach enforces their boundaries, and the migration inventory and generated documentation identify the new owners.

Production source changes: 83 lines added, 28 removed, net +55 including comments and spacing.

Validation:

- Full core suite: 17,938 passed, 10 skipped; 20 dependency, mock, and harness warnings.
- Focused suites: 158 stream tests and 429 replay, record, and import tests passed.
- Negative controls caught disabled historical suffix handling and historical summary ownership; modern-summary cases stayed valid.
- All-file pre-commit hooks and Tach dependency/interface checks passed.
- Persisted replay fields/codecs and all 76 migration inventory IDs are unchanged.
- Both independent task reviews and a final whole-branch review approved with no findings.

## Summary by Sourcery

Isolate historical streaming and revision replay compatibility rules behind dedicated legacy modules.

Enhancements:
- Isolate legacy stream suffix parsing and historical revision-summary ownership decisions into dedicated compatibility modules while preserving current runtime, storage, and redaction behavior.

Documentation:
- Update migration architecture documentation and generated references with the new legacy boundaries, ownership rules, and coverage links.

Tests:
- Add focused coverage for legacy streaming suffix handling, metadata precedence, revision provenance preservation, and historical versus modern summary cleanup.

Chores:
- Update Tach module boundaries and dependencies for the new legacy owners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of legacy streaming markers such as `[cancelled]` and `[error]`, including trailing whitespace and marker ordering.
  - Current structured stream status now takes precedence over legacy body suffixes.
  - Preserved historical summary ownership and provenance during revision replay and redaction cleanup.

- **Documentation**
  - Updated migration and architecture references to document legacy streaming and revision-replay behavior.

- **Tests**
  - Added coverage for legacy marker handling, status precedence, historical provenance, and cold-reopen scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->