### PR TITLE
Preserve unclaimed private scopes without blocking startup

### DIFF
--- a/docs/deployment/private-storage-upgrade.md
+++ b/docs/deployment/private-storage-upgrade.md
@@ -42,6 +42,12 @@ It renames the matching session directory first, then the primary scope, and fin
 Database files, WAL companions, credentials, workspaces, and histories retain their contents.
 Worker credential directories remain separate and are not relocated.
 
+Older versions can leave populated private scopes without an owner record.
+Startup warns and leaves these scopes and their matching session mirrors in place, without moving data, assigning an owner, or granting historical alias access.
+Directory names and session metadata are not used to infer ownership.
+New requester scopes remain separate; the retained unclaimed history is not automatically attached to them.
+Recover that history only after independently verifying its owner, with all writers stopped.
+
 Each pending scope temporarily contains `.mindroom-private-storage-migration.json` with its exact owner, volume paths, and original directory inodes.
 The intent moves with the primary scope and is removed after both locations and the current owner record are durable.
 It contains private owner information and belongs on the protected storage volume.
@@ -54,7 +60,7 @@ Do not remove or copy pending intent records, create destination directories, or
 Abrupt process death can leave partial temporary files from durable intent or owner writes.
 These remain protected, untouched files and never authorize recovery; only the exact final intent and owner records do.
 
-Startup rejects ambiguous owners, populated scopes without owner records, conflicting destinations, missing recorded session mirrors, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
+Startup rejects malformed or ambiguous owner records, conflicting destinations, missing recorded session mirrors, session-only data without a primary scope, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
 Inspect and correct the reported conflict with all writers stopped, then restart.
 There is no migration CLI or automatic rollback.
 To return to an older deployment, stop all writers and restore the coordinated backups together before starting it.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18197,6 +18197,12 @@ It renames the matching session directory first, then the primary scope, and fin
 Database files, WAL companions, credentials, workspaces, and histories retain their contents.
 Worker credential directories remain separate and are not relocated.
 
+Older versions can leave populated private scopes without an owner record.
+Startup warns and leaves these scopes and their matching session mirrors in place, without moving data, assigning an owner, or granting historical alias access.
+Directory names and session metadata are not used to infer ownership.
+New requester scopes remain separate; the retained unclaimed history is not automatically attached to them.
+Recover that history only after independently verifying its owner, with all writers stopped.
+
 Each pending scope temporarily contains `.mindroom-private-storage-migration.json` with its exact owner, volume paths, and original directory inodes.
 The intent moves with the primary scope and is removed after both locations and the current owner record are durable.
 It contains private owner information and belongs on the protected storage volume.
@@ -18209,7 +18215,7 @@ Do not remove or copy pending intent records, create destination directories, or
 Abrupt process death can leave partial temporary files from durable intent or owner writes.
 These remain protected, untouched files and never authorize recovery; only the exact final intent and owner records do.
 
-Startup rejects ambiguous owners, populated scopes without owner records, conflicting destinations, missing recorded session mirrors, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
+Startup rejects malformed or ambiguous owner records, conflicting destinations, missing recorded session mirrors, session-only data without a primary scope, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
 Inspect and correct the reported conflict with all writers stopped, then restart.
 There is no migration CLI or automatic rollback.
 To return to an older deployment, stop all writers and restore the coordinated backups together before starting it.

--- a/skills/mindroom-docs/references/page__deployment__private-storage-upgrade__index.md
+++ b/skills/mindroom-docs/references/page__deployment__private-storage-upgrade__index.md
@@ -42,6 +42,12 @@ It renames the matching session directory first, then the primary scope, and fin
 Database files, WAL companions, credentials, workspaces, and histories retain their contents.
 Worker credential directories remain separate and are not relocated.
 
+Older versions can leave populated private scopes without an owner record.
+Startup warns and leaves these scopes and their matching session mirrors in place, without moving data, assigning an owner, or granting historical alias access.
+Directory names and session metadata are not used to infer ownership.
+New requester scopes remain separate; the retained unclaimed history is not automatically attached to them.
+Recover that history only after independently verifying its owner, with all writers stopped.
+
 Each pending scope temporarily contains `.mindroom-private-storage-migration.json` with its exact owner, volume paths, and original directory inodes.
 The intent moves with the primary scope and is removed after both locations and the current owner record are durable.
 It contains private owner information and belongs on the protected storage volume.
@@ -54,7 +60,7 @@ Do not remove or copy pending intent records, create destination directories, or
 Abrupt process death can leave partial temporary files from durable intent or owner writes.
 These remain protected, untouched files and never authorize recovery; only the exact final intent and owner records do.
 
-Startup rejects ambiguous owners, populated scopes without owner records, conflicting destinations, missing recorded session mirrors, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
+Startup rejects malformed or ambiguous owner records, conflicting destinations, missing recorded session mirrors, session-only data without a primary scope, unrelated recovery records, unsafe scope or record links, nested mounts, and links that would break after relocation.
 Inspect and correct the reported conflict with all writers stopped, then restart.
 There is no migration CLI or automatic rollback.
 To return to an older deployment, stop all writers and restore the coordinated backups together before starting it.

--- a/src/mindroom/legacy_private_storage.py
+++ b/src/mindroom/legacy_private_storage.py
@@ -26,6 +26,7 @@ from mindroom.legacy_private_storage_aliases import (
     historical_private_instance_worker_key,
     load_private_instance_legacy_alias,
 )
+from mindroom.logging_config import get_logger
 from mindroom.private_instance_identity_store import (
     PrivateInstanceIdentity,
     load_private_instance_identity,
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
 _RECORD = ".mindroom-private-instance.json"
 _INTENT = ".mindroom-private-storage-migration.json"
 _LOCK = ".mindroom-storage-upgrade.lock"
+logger = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -222,10 +224,13 @@ def _discover(roots: tuple[Path, Path]) -> list[_Intent]:
             pending.append(intent)
             known_names.update(path.name for path in _locations(primary, intent))
             continue
-        payload = load_private_instance_record_payload(scope / _RECORD)
-        if payload is None:
+        record = scope / _RECORD
+        payload = load_private_instance_record_payload(record)
+        if payload is None and not record.exists():
             if any(scope.iterdir()):
-                _reject("populated private scope has no authoritative owner")
+                logger.warning("Preserving private scope without an owner record; not migrating", scope=str(scope))
+            # Retain its session mirror too, without claiming either directory.
+            known_names.add(scope.name)
             continue
         owner = parse_private_instance_identity_payload(payload)
         _old, new = _keys(owner)

--- a/src/mindroom/legacy_private_storage.py
+++ b/src/mindroom/legacy_private_storage.py
@@ -9,6 +9,11 @@ Managed workers must be absent before inspecting or moving any scope contents.
 # Handling: relocate only verified private owners; startup adoption began in v2026.9.36.
 # Coverage: tests/test_private_storage_migration.py::test_startup_moves_every_owner_and_preserves_contents.
 
+# Legacy format: private scopes created without authoritative owner records.
+# Last legacy release: v2026.8.132; replacement: v2026.8.133 writes owner records for fresh scopes.
+# Handling: preserve recordless scopes and matching session mirrors without adoption, including after later upgrades.
+# Coverage: tests/test_private_storage_migration.py::test_startup_preserves_recordless_scopes_without_adopting_them.
+
 from __future__ import annotations
 
 import os

--- a/src/mindroom/legacy_private_storage.py
+++ b/src/mindroom/legacy_private_storage.py
@@ -227,8 +227,7 @@ def _discover(roots: tuple[Path, Path]) -> list[_Intent]:
         record = scope / _RECORD
         payload = load_private_instance_record_payload(record)
         if payload is None and not record.exists():
-            if any(scope.iterdir()):
-                logger.warning("Preserving private scope without an owner record; not migrating", scope=str(scope))
+            logger.warning("Preserving private scope without an owner record; not migrating", scope=str(scope))
             # Retain its session mirror too, without claiming either directory.
             known_names.add(scope.name)
             continue

--- a/src/mindroom/legacy_private_storage_aliases.py
+++ b/src/mindroom/legacy_private_storage_aliases.py
@@ -62,6 +62,8 @@ def load_private_instance_legacy_alias(base_storage_path: Path, worker_key: str)
         info = alias.lstat()
     except FileNotFoundError:
         return None
+    if stat.S_ISDIR(info.st_mode):
+        return None  # An unmigrated directory grants no additional mount access.
     if not stat.S_ISLNK(info.st_mode):
         _raise_invalid_record("legacy alias must be a symlink")
     # Read the literal target: Path normalization would accept './name' as 'name'.

--- a/src/mindroom/legacy_private_storage_aliases.py
+++ b/src/mindroom/legacy_private_storage_aliases.py
@@ -3,7 +3,9 @@
 # Legacy format: relocated current private directories without historical sibling aliases.
 # Last legacy release: v2026.9.36; verified historical aliases introduced in v2026.9.37.
 # Handling: accept only aliases proven by the current owner and exact historical reconstruction.
+# Real historical directories grant no alias access, including preserved recordless scopes.
 # Coverage: tests/test_private_storage_migration.py::test_completed_aliases_reject_tampering.
+# Coverage: tests/test_private_storage_migration.py::test_worker_mount_plan_never_infers_historical_access.
 
 from __future__ import annotations
 

--- a/tests/test_private_instance_identity_store.py
+++ b/tests/test_private_instance_identity_store.py
@@ -73,7 +73,7 @@ def test_load_alias_requires_existing_namespace_provenance(tmp_path: Path) -> No
 
 @pytest.mark.parametrize(
     "damage",
-    ["absolute", "relative_dot", "chain", "missing", "real", "owner", "canonical_link", "wrong_hash"],
+    ["absolute", "relative_dot", "chain", "missing", "file", "owner", "canonical_link", "wrong_hash"],
 )
 def test_load_alias_rejects_invalid_owner_or_link(tmp_path: Path, damage: str) -> None:
     """Aliases must bind one literal sibling name to its real current owner directory."""
@@ -86,8 +86,8 @@ def test_load_alias_rejects_invalid_owner_or_link(tmp_path: Path, damage: str) -
     elif damage == "chain":
         (old.parent / "chain").symlink_to(new.name)
         old.symlink_to("chain")
-    elif damage == "real":
-        old.mkdir()
+    elif damage == "file":
+        old.write_bytes(b"not a scope or alias")
     else:
         old.symlink_to(new.name)
         if damage == "missing":

--- a/tests/test_private_storage_migration.py
+++ b/tests/test_private_storage_migration.py
@@ -27,6 +27,7 @@ from mindroom.file_locks import file_lock_is_held
 from mindroom.private_instance_identity_store import (
     ensure_private_instance_identity,
     load_private_instance_identity,
+    private_instances_for_agent,
     reconstruct_private_instance_worker_key,
 )
 from mindroom.runtime_resolution import resolve_agent_runtime
@@ -36,6 +37,8 @@ from mindroom.workers.backends._dedicated_worker_common import plan_scoped_visib
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from mindroom.tool_system.worker_routing import WorkerScope
 
 _RECORD = ".mindroom-private-instance.json"
 _INTENT = ".mindroom-private-storage-migration.json"
@@ -147,6 +150,59 @@ _REQUESTER = "@alice:example.org"
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("separate", [False, True])
+@pytest.mark.parametrize("verified_neighbor", [False, True])
+@pytest.mark.parametrize(
+    ("old_key", "current_key", "worker_scope"),
+    [
+        (_OLD, _NEW, "user"),
+        (
+            "v1:default:user_agent:@alice:example.org:writer",
+            "v1:default:user_agent:~@alice:example.org:writer",
+            "user_agent",
+        ),
+    ],
+)
+async def test_startup_preserves_recordless_scopes_without_adopting_them(
+    tmp_path: Path,
+    separate: bool,
+    verified_neighbor: bool,
+    old_key: str,
+    current_key: str,
+    worker_scope: WorkerScope,
+) -> None:
+    """Legacy unclaimed data cannot stop startup or gain a guessed requester identity."""
+    migration = importlib.import_module("mindroom.legacy_private_storage")
+    paths = _paths(tmp_path, separate=separate)
+    old = _seed(paths, old_key, _REQUESTER)
+    (old / _RECORD).unlink()
+    mirror = resolve_session_state_root(old, paths)
+    before, mirror_before = _files(old), _files(mirror)
+    inode, mirror_inode = old.stat().st_ino, mirror.stat().st_ino
+    if verified_neighbor:
+        neighbor = _seed(paths, "v1:default:user:bob", "bob")
+
+    await migration.migrate_private_storage(paths)
+    await migration.migrate_private_storage(paths)
+
+    assert not old.is_symlink()
+    assert (old.stat().st_ino, mirror.stat().st_ino) == (inode, mirror_inode)
+    assert (_files(old), _files(mirror)) == (before, mirror_before)
+    assert load_private_instance_identity(paths.storage_root, old) is None
+    assert not private_instance_scope_root_path(paths.storage_root, current_key).exists()
+    unclaimed = [
+        instance
+        for instance in private_instances_for_agent(paths.storage_root, "writer", worker_scope)
+        if instance.state_root == old / "writer"
+    ]
+    assert len(unclaimed) == 1
+    assert unclaimed[0].requester_id is None
+    if verified_neighbor:
+        assert neighbor.is_symlink()
+        assert load_private_instance_identity(paths.storage_root, neighbor.resolve()).requester_id == "bob"
+
+
+@pytest.mark.asyncio
 async def test_every_filesystem_mutation_boundary_resumes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Crashes around actual fsync, replace, rename and unlink never lose scope contents."""
     migration = importlib.import_module("mindroom.legacy_private_storage")
@@ -203,7 +259,7 @@ async def test_every_filesystem_mutation_boundary_resumes(tmp_path: Path, monkey
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "conflict",
-    ["primary", "session", "owner", "recordless", "orphan", "scope_link", "record_link", "intent"],
+    ["primary", "session", "owner", "null_owner", "orphan", "scope_link", "record_link", "intent"],
 )
 async def test_preflight_rejects_conflicts_before_any_move(
     tmp_path: Path,
@@ -223,8 +279,8 @@ async def test_preflight_rejects_conflicts_before_any_move(
         payload = json.loads((source / _RECORD).read_text())
         payload["requester_id"] = "@intruder:example.org"
         (source / _RECORD).write_text(json.dumps(payload))
-    elif conflict == "recordless":
-        (source / _RECORD).unlink()
+    elif conflict == "null_owner":
+        (source / _RECORD).write_text("null")
     elif conflict == "orphan":
         orphan = sessions.parent / "unowned"
         orphan.mkdir()
@@ -422,19 +478,19 @@ async def test_primary_admission_fails_before_credentials(
     monkeypatch: pytest.MonkeyPatch,
     entrypoint: str,
 ) -> None:
-    """Both primary entry points must reject unowned storage before starting runtime work."""
+    """Both primary entry points must reject invalid ownership before starting runtime work."""
     paths = _paths(tmp_path)
     source = _seed(paths, _OLD, _REQUESTER)
-    (source / _RECORD).unlink()
+    (source / _RECORD).write_text("null")
     module = importlib.import_module(f"mindroom.{'api.main' if entrypoint == 'api' else 'orchestrator'}")
     monkeypatch.setattr(module, "sync_env_to_credentials", Mock(side_effect=AssertionError("credentials started")))
     if entrypoint == "api":
         monkeypatch.setattr(module, "_app_runtime_paths", lambda _app: paths)
-        with pytest.raises(ValueError, match="authoritative owner"):
+        with pytest.raises(ValueError, match=r"[Pp]rivate"):
             async with module._lifespan(module.app):
                 pytest.fail("API admitted runtime work")
     else:
-        with pytest.raises(ValueError, match="authoritative owner"):
+        with pytest.raises(ValueError, match=r"[Pp]rivate"):
             await module.main("ERROR", paths, api=False)
 
 
@@ -697,7 +753,10 @@ async def test_current_runtime_export_and_mounts_find_migrated_contents(tmp_path
     assert source.is_symlink()
 
 
-@pytest.mark.parametrize("state", ["fresh", "ownerless", "owned_without_alias", "foreign_collision"])
+@pytest.mark.parametrize(
+    "state",
+    ["fresh", "ownerless", "owned_without_alias", "foreign_collision", "unowned_historical"],
+)
 def test_worker_mount_plan_never_infers_historical_access(tmp_path: Path, state: str) -> None:
     """Canonical-only scopes remain usable without granting unverified historical destinations."""
     worker_key = "v1:default:user:~alice_bob"
@@ -705,8 +764,12 @@ def test_worker_mount_plan_never_infers_historical_access(tmp_path: Path, state:
     if state == "ownerless":
         canonical.mkdir(parents=True)
         (canonical / "notes.txt").write_text("existing unowned workspace")
-    elif state in {"owned_without_alias", "foreign_collision"}:
+    elif state in {"owned_without_alias", "foreign_collision", "unowned_historical"}:
         ensure_private_instance_identity(tmp_path, worker_key=worker_key, requester_id="alice_bob")
+    if state == "unowned_historical":
+        historical = private_instance_scope_root_path(tmp_path, "v1:default:user:alice_bob")
+        historical.mkdir()
+        (historical / "notes.txt").write_text("unverified old data")
     if state == "foreign_collision":
         historical_key = "v1:default:user:alice_bob"
         foreign_key = reconstruct_private_instance_worker_key(historical_key, "alice/bob")

--- a/tests/test_private_storage_migration.py
+++ b/tests/test_private_storage_migration.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
+from structlog.testing import capture_logs
 
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, AgentThreadExportConfig
 from mindroom.config.main import Config
@@ -200,6 +201,27 @@ async def test_startup_preserves_recordless_scopes_without_adopting_them(
     if verified_neighbor:
         assert neighbor.is_symlink()
         assert load_private_instance_identity(paths.storage_root, neighbor.resolve()).requester_id == "bob"
+
+
+@pytest.mark.asyncio
+async def test_empty_recordless_primary_warns_for_retained_session_history(tmp_path: Path) -> None:
+    """Operators must hear about retained data even when only its session mirror is populated."""
+    migration = importlib.import_module("mindroom.legacy_private_storage")
+    paths = _paths(tmp_path)
+    primary = private_instance_scope_root_path(paths.storage_root, _OLD)
+    primary.mkdir(parents=True)
+    mirror = resolve_session_state_root(primary, paths)
+    mirror.mkdir(parents=True)
+    history = mirror / "history.db"
+    history.write_bytes(b"retained session history")
+
+    with capture_logs() as logs:
+        await migration.migrate_private_storage(paths)
+
+    assert any(entry["log_level"] == "warning" and entry.get("scope") == str(primary) for entry in logs)
+    assert history.read_bytes() == b"retained session history"
+    assert list(primary.iterdir()) == []
+    assert not private_instance_scope_root_path(paths.storage_root, _NEW).exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix the startup blocker found while deploying #1995 and #1997.
Older runtimes deliberately leave populated private scopes without an authoritative owner record, but startup migration rejected this existing state and prevented the entire primary from starting.

- Preserve truly recordless private scopes and their matching session mirrors without moving, adopting, or deleting their data; emit an operator warning.
- Continue migrating verified scopes independently.
- Treat an unmigrated historical directory as no alias, so new canonical scopes receive no historical mount access.
- Keep malformed owner records, unsafe links, interrupted intents, destination conflicts, and standalone orphan session data fail-closed.

Six net production lines, confined to the existing legacy migration and alias modules.
No owner is inferred from directory names or session metadata.
Unclaimed historical sessions remain retained on disk rather than being silently assigned to new requester scopes.
Existing runtime privacy cleanup of derived exports is unchanged.

## Verification

- Observed preservation and mount-plan regressions fail before the fix and pass afterward.
- 463 affected tests passed, covering both private-scope kinds, shared/separate session volumes, verified neighbors, repeat startup, identity validation, worker mount isolation, storage preflight, and import boundaries.
- All repository pre-commit hooks passed; generated documentation references synchronized.
- Read-only discovery against the affected production storage now succeeds, retaining its recordless scope and finding zero verified pending migrations. No production storage was changed by this check.
- Independent read-only review approved the change.

Production remains on its previous healthy release pending this upstream fix.

## Summary by Sourcery

Preserve unclaimed legacy private storage during startup without inferring ownership or granting historical access.

Bug Fixes:
- Allow startup to preserve populated private scopes without authoritative owner records instead of blocking the primary runtime.
- Prevent unverified historical directories from granting alias or mount access while retaining their data and session mirrors.
- Continue failing closed for malformed ownership records, unsafe links, interrupted migrations, destination conflicts, and session-only orphan data.

Documentation:
- Document preservation, warning, ownership-recovery, and historical-access behavior for unclaimed private storage.

Tests:
- Add coverage for preserving recordless scopes and session history across storage layouts, verified neighbors, repeat startup, and worker mount planning.

Chores:
- Synchronize generated deployment documentation references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Private-storage startup now preserves populated scopes without owner records instead of rejecting or adopting them.
  - Unverified historical scopes no longer receive inferred ownership or alias access.
  - Startup now clearly rejects malformed owner records and session-only data without a primary scope.
  - Legacy directory paths no longer grant additional alias access.

- **Documentation**
  - Updated private-storage migration guidance to explain warnings, preserved data, ownership verification, and recovery requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->