### PR TITLE
Preserve approval ownership during deleted-response cleanup

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -270,7 +270,7 @@ Fallback eligibility and edits share the delivery lock with cleanup, and the tra
 Cleanup preserves the INITIAL identity for surviving sources, and stale history for a surviving request retries canonical preparation with a refreshed payload.
 An approval continuation retains its response INITIAL even when all source messages are deleted; the approval card remains the explicit consent surface.
 Approval creation and source-redaction admission serialize on the existing room-membership row, so creation cannot acquire a source that deletion already settled.
-Recovery can finish a failing approval whose INITIAL was already retired only after card expiration, with no FINAL debt and exact tombstones for its acknowledged response and every owned source.
+Recovery can finish a failing approval whose INITIAL was already retired only after card expiration; `event_journal/legacy_approval_recovery.py` proves no FINAL debt and exact tombstones for its acknowledged response and every owned source inside the current owner's transaction.
 That cleanup settles journal ownership without sending replacement text or recording tool success.
 Saved run metadata remains intentionally redundant so older turns removed by ledger compaction can still be restored for edits.
 `TurnStore` returns any present ledger record unchanged without opening model session storage.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -268,6 +268,10 @@ Same-requester supersession preserves canonical replay when an INITIAL already o
 When every current source is deleted and no FINAL owns the response, its unfinished INITIAL remains durable cleanup debt until Matrix disappearance and visible-response attribution detachment are confirmed.
 Fallback eligibility and edits share the delivery lock with cleanup, and the transactional ledger prevents late completion writes from restoring a deleted INITIAL or inventing an answer.
 Cleanup preserves the INITIAL identity for surviving sources, and stale history for a surviving request retries canonical preparation with a refreshed payload.
+An approval continuation retains its response INITIAL even when all source messages are deleted; the approval card remains the explicit consent surface.
+Approval creation and source-redaction admission serialize on the existing room-membership row, so creation cannot acquire a source that deletion already settled.
+Recovery can finish a failing approval whose INITIAL was already retired only after card expiration, with no FINAL debt and exact tombstones for its acknowledged response and every owned source.
+That cleanup settles journal ownership without sending replacement text or recording tool success.
 Saved run metadata remains intentionally redundant so older turns removed by ledger compaction can still be restored for edits.
 `TurnStore` returns any present ledger record unchanged without opening model session storage.
 Run metadata supplies a complete candidate only when the requested ledger identity is absent.

--- a/docs/architecture/migrations.md
+++ b/docs/architecture/migrations.md
@@ -37,6 +37,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/event_journal/legacy_turn_records.py`][legacy-turn-records] | The handled-turn importer adopts missing journal indexes. | The journal transaction is retained and migration writes never use current upsert deletion semantics. |
 | [`src/mindroom/legacy_delivery_payloads.py`][legacy-delivery] | Outbox reads or Matrix writes encounter inline FINAL results and the bounded marker. | Old inline outcomes keep rolling-writer precedence, current local results remain authoritative otherwise, and full recovery data stays off the wire. |
 | [`src/mindroom/legacy_approval_payloads.py`][legacy-approval] | Approval claim or resume encounters missing historical context or the older card ID. | Current approval ownership, authorization, exact-call checks, transaction settlement, and failure handling remain with current owners. |
+| [`src/mindroom/event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | Approval settlement encounters an INITIAL retired by historical deleted-response cleanup. | The helper proves exact source and response tombstones with no FINAL; current owners retain card expiration, failure fencing, retries, locking, and transactional settlement. |
 | [`src/mindroom/matrix/legacy_sync_continuity.py`][legacy-sync] | `SyncContinuityStore` loads a valid v2 or v3 record. | The helper validates the old shape, discards its checkpoint, increments revision once, and lets the store rewrite v4 under lock. |
 | [`src/mindroom/script_runs/legacy_schema.py`][script-legacy-schema] | `ScriptRunStore` finds missing resource snapshot columns. | Schema creation and the transaction stay in the store; old rows receive the established null or empty-map values. |
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
@@ -67,6 +68,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_handled_turns.py`][legacy-handled] and [`event_journal/legacy_turn_records.py`][legacy-turn-records] | [Handled-turn tests][handled-turn-tests] cover released JSON shapes, the deliberate unversioned cutoff, interrupted adoption, occupied indexes, reopen behavior, and reconstructed replay facts. |
 | [`event_journal/legacy_schema.py`][journal-legacy-schema] | [Journal upgrade tests][journal-upgrade-tests] start from literal pre-Nio DDL and verify retained history and terminal facts, retired unfinished work, and stable repeat opening. |
 | [`legacy_delivery_payloads.py`][legacy-delivery] and [`legacy_approval_payloads.py`][legacy-approval] | [Journal store][journal-store-tests], [response runner][response-runner-tests], and [approval][approval-tests] tests cover visible-result precedence, wire sanitation, frozen visibility, origin recovery, and sparse card identity. |
+| [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | [Journal store][journal-store-tests] tests preserve incomplete deletion proof and FINAL debt; [response runner][response-runner-tests] tests recover every approval state only after card expiration, without editing deleted responses or resuming tools. |
 | [`matrix/legacy_sync_continuity.py`][legacy-sync] and [`matrix/legacy_crypto_upgrade.py`][crypto-upgrade] | [Sync-continuity tests][sync-continuity-tests] cover complete v2/v3 conversion and retry, while [crypto upgrade tests][crypto-upgrade-tests] verify that identity, keys, and trust survive retirement of transport recovery. |
 | [`script_runs/legacy_schema.py`][script-legacy-schema] | [Script-run tests][script-run-tests] rebuild the literal old table, preserve every old value, add empty resource snapshots, and verify a second open. |
 | [`knowledge/legacy_metadata.py`][knowledge-legacy] | [Knowledge indexing tests][knowledge-indexing-tests] use independently written metadata from each field boundary and check preservation, nonmutation, repeated normalization, and corpus/query compatibility. |
@@ -105,6 +107,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | J12 | Removed/superseded | [The upgrade fixture][pre-journal-test] confirms old event-cache and dispatch-obligation files have no runtime reader and remain untouched. |
 | J13 | Current behavior | [`event_journal_open.py`][journal-open] owns binding, generation, adoption, and database ownership guards. |
 | J14 | Current behavior | [`sync_restart_retry.py`][restart-retry] and [`visible_response_reconciliation.py`][visible-recovery] keep current replay and visible-response safety. |
+| J15 | Isolated | [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] recognizes approvals stranded by historical INITIAL retirement; current owners retain consent, failure handling, and settlement. |
 
 ## Agent state, history, memory, and knowledge
 
@@ -248,6 +251,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
+[legacy-approval-recovery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/event_journal/legacy_approval_recovery.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py
 [legacy-openai]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_openai_tool_replay.py

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17687,6 +17687,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/event_journal/legacy_turn_records.py`][legacy-turn-records] | The handled-turn importer adopts missing journal indexes. | The journal transaction is retained and migration writes never use current upsert deletion semantics. |
 | [`src/mindroom/legacy_delivery_payloads.py`][legacy-delivery] | Outbox reads or Matrix writes encounter inline FINAL results and the bounded marker. | Old inline outcomes keep rolling-writer precedence, current local results remain authoritative otherwise, and full recovery data stays off the wire. |
 | [`src/mindroom/legacy_approval_payloads.py`][legacy-approval] | Approval claim or resume encounters missing historical context or the older card ID. | Current approval ownership, authorization, exact-call checks, transaction settlement, and failure handling remain with current owners. |
+| [`src/mindroom/event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | Approval settlement encounters an INITIAL retired by historical deleted-response cleanup. | The helper proves exact source and response tombstones with no FINAL; current owners retain card expiration, failure fencing, retries, locking, and transactional settlement. |
 | [`src/mindroom/matrix/legacy_sync_continuity.py`][legacy-sync] | `SyncContinuityStore` loads a valid v2 or v3 record. | The helper validates the old shape, discards its checkpoint, increments revision once, and lets the store rewrite v4 under lock. |
 | [`src/mindroom/script_runs/legacy_schema.py`][script-legacy-schema] | `ScriptRunStore` finds missing resource snapshot columns. | Schema creation and the transaction stay in the store; old rows receive the established null or empty-map values. |
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
@@ -17717,6 +17718,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_handled_turns.py`][legacy-handled] and [`event_journal/legacy_turn_records.py`][legacy-turn-records] | [Handled-turn tests][handled-turn-tests] cover released JSON shapes, the deliberate unversioned cutoff, interrupted adoption, occupied indexes, reopen behavior, and reconstructed replay facts. |
 | [`event_journal/legacy_schema.py`][journal-legacy-schema] | [Journal upgrade tests][journal-upgrade-tests] start from literal pre-Nio DDL and verify retained history and terminal facts, retired unfinished work, and stable repeat opening. |
 | [`legacy_delivery_payloads.py`][legacy-delivery] and [`legacy_approval_payloads.py`][legacy-approval] | [Journal store][journal-store-tests], [response runner][response-runner-tests], and [approval][approval-tests] tests cover visible-result precedence, wire sanitation, frozen visibility, origin recovery, and sparse card identity. |
+| [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | [Journal store][journal-store-tests] tests preserve incomplete deletion proof and FINAL debt; [response runner][response-runner-tests] tests recover every approval state only after card expiration, without editing deleted responses or resuming tools. |
 | [`matrix/legacy_sync_continuity.py`][legacy-sync] and [`matrix/legacy_crypto_upgrade.py`][crypto-upgrade] | [Sync-continuity tests][sync-continuity-tests] cover complete v2/v3 conversion and retry, while [crypto upgrade tests][crypto-upgrade-tests] verify that identity, keys, and trust survive retirement of transport recovery. |
 | [`script_runs/legacy_schema.py`][script-legacy-schema] | [Script-run tests][script-run-tests] rebuild the literal old table, preserve every old value, add empty resource snapshots, and verify a second open. |
 | [`knowledge/legacy_metadata.py`][knowledge-legacy] | [Knowledge indexing tests][knowledge-indexing-tests] use independently written metadata from each field boundary and check preservation, nonmutation, repeated normalization, and corpus/query compatibility. |
@@ -17755,6 +17757,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | J12 | Removed/superseded | [The upgrade fixture][pre-journal-test] confirms old event-cache and dispatch-obligation files have no runtime reader and remain untouched. |
 | J13 | Current behavior | [`event_journal_open.py`][journal-open] owns binding, generation, adoption, and database ownership guards. |
 | J14 | Current behavior | [`sync_restart_retry.py`][restart-retry] and [`visible_response_reconciliation.py`][visible-recovery] keep current replay and visible-response safety. |
+| J15 | Isolated | [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] recognizes approvals stranded by historical INITIAL retirement; current owners retain consent, failure handling, and settlement. |
 
 ## Agent state, history, memory, and knowledge
 
@@ -17898,6 +17901,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
+[legacy-approval-recovery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/event_journal/legacy_approval_recovery.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py
 [legacy-openai]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_openai_tool_replay.py

--- a/skills/mindroom-docs/references/page__architecture__migrations__index.md
+++ b/skills/mindroom-docs/references/page__architecture__migrations__index.md
@@ -33,6 +33,7 @@ The remaining rows were already focused boundaries and complete the current map.
 | [`src/mindroom/event_journal/legacy_turn_records.py`][legacy-turn-records] | The handled-turn importer adopts missing journal indexes. | The journal transaction is retained and migration writes never use current upsert deletion semantics. |
 | [`src/mindroom/legacy_delivery_payloads.py`][legacy-delivery] | Outbox reads or Matrix writes encounter inline FINAL results and the bounded marker. | Old inline outcomes keep rolling-writer precedence, current local results remain authoritative otherwise, and full recovery data stays off the wire. |
 | [`src/mindroom/legacy_approval_payloads.py`][legacy-approval] | Approval claim or resume encounters missing historical context or the older card ID. | Current approval ownership, authorization, exact-call checks, transaction settlement, and failure handling remain with current owners. |
+| [`src/mindroom/event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | Approval settlement encounters an INITIAL retired by historical deleted-response cleanup. | The helper proves exact source and response tombstones with no FINAL; current owners retain card expiration, failure fencing, retries, locking, and transactional settlement. |
 | [`src/mindroom/matrix/legacy_sync_continuity.py`][legacy-sync] | `SyncContinuityStore` loads a valid v2 or v3 record. | The helper validates the old shape, discards its checkpoint, increments revision once, and lets the store rewrite v4 under lock. |
 | [`src/mindroom/script_runs/legacy_schema.py`][script-legacy-schema] | `ScriptRunStore` finds missing resource snapshot columns. | Schema creation and the transaction stay in the store; old rows receive the established null or empty-map values. |
 | [`src/mindroom/knowledge/legacy_metadata.py`][knowledge-legacy] | Knowledge parsing sees absent or empty optional filter fields. | Current parsing still rejects unknown fields; missing corpus settings retain empty historical sentinels and rebuild only when the corresponding current corpus-compatibility value differs. |
@@ -63,6 +64,7 @@ When no stable tag contained an old native writer, the block uses an honest unre
 | [`legacy_handled_turns.py`][legacy-handled] and [`event_journal/legacy_turn_records.py`][legacy-turn-records] | [Handled-turn tests][handled-turn-tests] cover released JSON shapes, the deliberate unversioned cutoff, interrupted adoption, occupied indexes, reopen behavior, and reconstructed replay facts. |
 | [`event_journal/legacy_schema.py`][journal-legacy-schema] | [Journal upgrade tests][journal-upgrade-tests] start from literal pre-Nio DDL and verify retained history and terminal facts, retired unfinished work, and stable repeat opening. |
 | [`legacy_delivery_payloads.py`][legacy-delivery] and [`legacy_approval_payloads.py`][legacy-approval] | [Journal store][journal-store-tests], [response runner][response-runner-tests], and [approval][approval-tests] tests cover visible-result precedence, wire sanitation, frozen visibility, origin recovery, and sparse card identity. |
+| [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] | [Journal store][journal-store-tests] tests preserve incomplete deletion proof and FINAL debt; [response runner][response-runner-tests] tests recover every approval state only after card expiration, without editing deleted responses or resuming tools. |
 | [`matrix/legacy_sync_continuity.py`][legacy-sync] and [`matrix/legacy_crypto_upgrade.py`][crypto-upgrade] | [Sync-continuity tests][sync-continuity-tests] cover complete v2/v3 conversion and retry, while [crypto upgrade tests][crypto-upgrade-tests] verify that identity, keys, and trust survive retirement of transport recovery. |
 | [`script_runs/legacy_schema.py`][script-legacy-schema] | [Script-run tests][script-run-tests] rebuild the literal old table, preserve every old value, add empty resource snapshots, and verify a second open. |
 | [`knowledge/legacy_metadata.py`][knowledge-legacy] | [Knowledge indexing tests][knowledge-indexing-tests] use independently written metadata from each field boundary and check preservation, nonmutation, repeated normalization, and corpus/query compatibility. |
@@ -101,6 +103,7 @@ Journal IDs use `J` to avoid colliding with credential IDs.
 | J12 | Removed/superseded | [The upgrade fixture][pre-journal-test] confirms old event-cache and dispatch-obligation files have no runtime reader and remain untouched. |
 | J13 | Current behavior | [`event_journal_open.py`][journal-open] owns binding, generation, adoption, and database ownership guards. |
 | J14 | Current behavior | [`sync_restart_retry.py`][restart-retry] and [`visible_response_reconciliation.py`][visible-recovery] keep current replay and visible-response safety. |
+| J15 | Isolated | [`event_journal/legacy_approval_recovery.py`][legacy-approval-recovery] recognizes approvals stranded by historical INITIAL retirement; current owners retain consent, failure handling, and settlement. |
 
 ## Agent state, history, memory, and knowledge
 
@@ -244,6 +247,7 @@ Dependency migrations use their dependency's schema and locking contract, and Sa
 [legacy-revision-replay]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_revision_replay.py
 [legacy-streaming]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_streaming.py
 [legacy-approval]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_approval_payloads.py
+[legacy-approval-recovery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/event_journal/legacy_approval_recovery.py
 [legacy-delivery]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_delivery_payloads.py
 [legacy-handled]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_handled_turns.py
 [legacy-openai]: https://github.com/mindroom-ai/mindroom/blob/main/src/mindroom/legacy_openai_tool_replay.py

--- a/src/mindroom/approval_response.py
+++ b/src/mindroom/approval_response.py
@@ -415,9 +415,8 @@ class ApprovalResponseCoordinator:
         manager = approval_manager.get_approval_store()
         if manager is None or not await manager.expire_continuation_cards(current.approval_id):
             return False
-        failed_delivery = await self.final_delivery(current)
-        if failed_delivery is not None and failed_delivery.permanently_failed:
-            return await self.store.finish_approval_continuation(current.approval_id)
+        if await self.store.finish_approval_continuation(current.approval_id):
+            return True
         visible_reason = visible_text or (_USER_STOP_VISIBLE_NOTE if reason == _USER_STOP_FAILURE_REASON else reason)
         target = continuation_target(current)
         delivered = await self.delivery_gateway.edit_text(

--- a/src/mindroom/event_journal/approval_continuations.py
+++ b/src/mindroom/event_journal/approval_continuations.py
@@ -13,8 +13,8 @@ from mindroom.legacy_approval_payloads import resolve_legacy_visibility
 from mindroom.turn_origin import SenderKind, TurnIntent, TurnOrigin, TurnTrust
 
 from . import journal, membership_state, outbox
+from .legacy_approval_recovery import deleted_delivery_is_terminal
 from .models import DeliveryStage
-from .projection import is_tombstoned
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -732,30 +732,6 @@ def request_failure(
     return None if updated is None else get(transaction, principal_id, approval_id=approval_id)
 
 
-def _deleted_delivery_is_terminal(
-    transaction: Transaction,
-    principal_id: str,
-    continuation: ApprovalContinuation,
-) -> bool:
-    """Recognize failed approval state left behind by deleted INITIAL cleanup."""
-    if continuation.state != "failing":
-        return False
-    delivery_id = continuation.source_event_ids[0]
-    if outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.FINAL) is not None:
-        return False
-    initial = outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.INITIAL)
-    return (
-        initial is not None
-        and initial.retired
-        and initial.room_id == continuation.room_id
-        and initial.acknowledged_event_id == continuation.response_event_id
-        and all(
-            is_tombstoned(transaction, principal_id, room_id=continuation.room_id, event_id=event_id)
-            for event_id in (*continuation.source_event_ids, continuation.response_event_id)
-        )
-    )
-
-
 def finish(
     transaction: Transaction,
     principal_id: str,
@@ -774,7 +750,7 @@ def finish(
         """,
         (principal_id, continuation.source_event_ids[0], DeliveryStage.FINAL.value),
     )
-    if delivered is None and not _deleted_delivery_is_terminal(transaction, principal_id, continuation):
+    if delivered is None and not deleted_delivery_is_terminal(transaction, principal_id, continuation):
         return False
     journal.settle_many(transaction, principal_id, continuation.source_event_ids)
     transaction.execute(

--- a/src/mindroom/event_journal/approval_continuations.py
+++ b/src/mindroom/event_journal/approval_continuations.py
@@ -14,6 +14,7 @@ from mindroom.turn_origin import SenderKind, TurnIntent, TurnOrigin, TurnTrust
 
 from . import journal, membership_state, outbox
 from .models import DeliveryStage
+from .projection import is_tombstoned
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -378,13 +379,25 @@ def create(
     """Create one paused-run owner only while all of its sources remain pending."""
     if not continuation.source_event_ids:
         return None
+    # Admission and approval creation must agree which owner receives a
+    # concurrent source redaction, on PostgreSQL as well as SQLite.
+    if membership_state.claim_active_membership_epoch(transaction, principal_id, room_id=continuation.room_id) is None:
+        return None
+    initial = outbox.load(
+        transaction,
+        principal_id,
+        delivery_id=continuation.source_event_ids[0],
+        stage=DeliveryStage.INITIAL,
+    )
+    if initial is not None and initial.retired:
+        return None
     for event_id in continuation.source_event_ids:
         row = transaction.fetchone(
             """
             SELECT 1 AS present FROM journal_events
-            WHERE principal_id = ? AND event_id = ? AND state = 'pending'
+            WHERE principal_id = ? AND event_id = ? AND room_id = ? AND state = 'pending'
             """,
-            (principal_id, event_id),
+            (principal_id, event_id, continuation.room_id),
         )
         if row is None:
             return None
@@ -719,13 +732,37 @@ def request_failure(
     return None if updated is None else get(transaction, principal_id, approval_id=approval_id)
 
 
+def _deleted_delivery_is_terminal(
+    transaction: Transaction,
+    principal_id: str,
+    continuation: ApprovalContinuation,
+) -> bool:
+    """Recognize failed approval state left behind by deleted INITIAL cleanup."""
+    if continuation.state != "failing":
+        return False
+    delivery_id = continuation.source_event_ids[0]
+    if outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.FINAL) is not None:
+        return False
+    initial = outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.INITIAL)
+    return (
+        initial is not None
+        and initial.retired
+        and initial.room_id == continuation.room_id
+        and initial.acknowledged_event_id == continuation.response_event_id
+        and all(
+            is_tombstoned(transaction, principal_id, room_id=continuation.room_id, event_id=event_id)
+            for event_id in (*continuation.source_event_ids, continuation.response_event_id)
+        )
+    )
+
+
 def finish(
     transaction: Transaction,
     principal_id: str,
     *,
     approval_id: str,
 ) -> bool:
-    """Release sources after the continuation's FINAL reaches a terminal outcome."""
+    """Release sources after terminal FINAL delivery or proven failed-response deletion."""
     continuation = _get_locked(transaction, principal_id, approval_id=approval_id)
     if continuation is None:
         return False
@@ -737,7 +774,7 @@ def finish(
         """,
         (principal_id, continuation.source_event_ids[0], DeliveryStage.FINAL.value),
     )
-    if delivered is None:
+    if delivered is None and not _deleted_delivery_is_terminal(transaction, principal_id, continuation):
         return False
     journal.settle_many(transaction, principal_id, continuation.source_event_ids)
     transaction.execute(

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -805,7 +805,7 @@ def admit(
     into the raw-event cache this design exists to remove, at roughly half a
     kilobyte for every message the bot has ever seen.
     """
-    epoch = current_membership_epoch(transaction, principal_id, event.room_id)
+    epoch = _claim_membership_state(transaction, principal_id, event.room_id).membership_epoch
     actionable = event.event_class is EventClass.ACTIONABLE
     row = transaction.fetchone(
         """

--- a/src/mindroom/event_journal/legacy_approval_recovery.py
+++ b/src/mindroom/event_journal/legacy_approval_recovery.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .backend import Transaction
 
 # Legacy format: A live approval owns a retired INITIAL whose sources and response were deleted.
-# Last legacy release: v2026.9.63; replacement: unreleased approval-aware INITIAL cleanup.
+# Last legacy release: v2026.9.63; replacement: v2026.9.64 added approval-aware INITIAL cleanup.
 # Handling: Recognize terminal deletion inside the caller's transaction; current owners expire cards,
 # fence failure, settle sources, and delete the continuation without replaying tools or sending text.
 # Coverage: tests/test_event_journal_store.py::TestApprovalContinuations::test_deleted_approval_failure_settles_only_proven_terminal_delivery

--- a/src/mindroom/event_journal/legacy_approval_recovery.py
+++ b/src/mindroom/event_journal/legacy_approval_recovery.py
@@ -1,0 +1,44 @@
+"""Recognize approval ownership stranded by historical deleted-response cleanup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from . import outbox
+from .models import DeliveryStage
+from .projection import is_tombstoned
+
+if TYPE_CHECKING:
+    from .approval_continuations import ApprovalContinuation
+    from .backend import Transaction
+
+# Legacy format: A live approval owns a retired INITIAL whose sources and response were deleted.
+# Last legacy release: v2026.9.63; replacement: unreleased approval-aware INITIAL cleanup.
+# Handling: Recognize terminal deletion inside the caller's transaction; current owners expire cards,
+# fence failure, settle sources, and delete the continuation without replaying tools or sending text.
+# Coverage: tests/test_event_journal_store.py::TestApprovalContinuations::test_deleted_approval_failure_settles_only_proven_terminal_delivery
+# and tests/test_response_runner_focused.py::test_deleted_approval_recovery_expires_cards_without_editing_or_executing.
+
+
+def deleted_delivery_is_terminal(
+    transaction: Transaction,
+    principal_id: str,
+    continuation: ApprovalContinuation,
+) -> bool:
+    """Prove the old deletion state without changing rows or taking transaction ownership."""
+    if continuation.state != "failing":
+        return False
+    delivery_id = continuation.source_event_ids[0]
+    if outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.FINAL) is not None:
+        return False
+    initial = outbox.load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.INITIAL)
+    return (
+        initial is not None
+        and initial.retired
+        and initial.room_id == continuation.room_id
+        and initial.acknowledged_event_id == continuation.response_event_id
+        and all(
+            is_tombstoned(transaction, principal_id, room_id=continuation.room_id, event_id=event_id)
+            for event_id in (*continuation.source_event_ids, continuation.response_event_id)
+        )
+    )

--- a/src/mindroom/event_journal/models.py
+++ b/src/mindroom/event_journal/models.py
@@ -448,6 +448,7 @@ class ResponseRecoveryState:
     redacted_sources: tuple[bool, ...]
     turn_records: tuple[TurnRecord | None, ...]
     source_tombstones: tuple[bool, ...] = ()
+    approval_owned: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -608,6 +608,17 @@ def response_delivery_id(transaction: Transaction, principal_id: str, *, room_id
     return None if row is None else str(row["delivery_id"])
 
 
+def approval_owns_delivery(transaction: Transaction, principal_id: str, delivery_id: str) -> bool:
+    """Read approval ownership without loading its persisted run payload."""
+    return (
+        transaction.fetchone(
+            "SELECT 1 FROM approval_continuation_sources WHERE principal_id = ? AND event_id = ?",
+            (principal_id, delivery_id),
+        )
+        is not None
+    )
+
+
 def deleted_initials(
     transaction: Transaction,
     principal_id: str,
@@ -635,6 +646,10 @@ def deleted_initials(
             WHERE final.principal_id = delivery.principal_id AND final.delivery_id = delivery.delivery_id
               AND final.stage = 'final' AND (final.acknowledged_event_id IS NOT NULL
                 OR (final.retired = 0 AND final.permanent_failure_reason IS NULL))
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM approval_continuation_sources AS source
+            WHERE source.principal_id = delivery.principal_id AND source.event_id = delivery.delivery_id
           ){cursor_clause}
         ORDER BY created_at_ns, delivery_id/*bytes*/ LIMIT 100
         """,  # noqa: S608 - fixed column list and cursor clause
@@ -646,6 +661,9 @@ def deleted_initials(
 def retire_deleted_initial(transaction: Transaction, principal_id: str, delivery_id: str) -> None:
     """Retain exact ACK identity while fencing sends after proven disappearance."""
     _lock_delivery_stages(transaction, principal_id, delivery_id)
+    if approval_owns_delivery(transaction, principal_id, delivery_id):
+        msg = "An approval continuation still owns this INITIAL"
+        raise RuntimeError(msg)
     final = load(transaction, principal_id, delivery_id=delivery_id, stage=DeliveryStage.FINAL)
     if final is not None and (
         final.acknowledged_event_id is not None or not (final.retired or final.permanently_failed)

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -255,6 +255,10 @@ class PrincipalStore:
                 )
             )
             return ResponseRecoveryState(
+                approval_owned=any(
+                    outbox.approval_owns_delivery(transaction, self._principal_id, event_id)
+                    for event_id in source_event_ids
+                ),
                 pending_sources=pending,
                 redacted_sources=tuple(
                     not is_pending

--- a/src/mindroom/response_delivery_recovery.py
+++ b/src/mindroom/response_delivery_recovery.py
@@ -74,7 +74,8 @@ class ResponseDeliveryRecovery:
         """Only genuinely orphaned work may acquire synthetic startup continuation."""
         state = await self.state(delivery)
         return not (
-            any(state.source_tombstones)
+            state.approval_owned
+            or any(state.source_tombstones)
             or self._final_owned(state)
             or any(state.pending_sources)
             or state.sources_settled_by_departure
@@ -91,7 +92,7 @@ class ResponseDeliveryRecovery:
     async def permits_supersession(self, delivery: MatrixDelivery) -> bool:
         """Only terminal or revoked INITIAL work may lose its canonical replay."""
         state = await self.state(delivery)
-        return (
+        return not state.approval_owned and (
             self.deleted(state)
             or self._final_owned(state)
             or state.sources_settled_by_departure
@@ -109,7 +110,7 @@ class ResponseDeliveryRecovery:
         if initial is None or initial.retired:
             return False
         state = await self.state(initial)
-        if not self.deleted(state) or self._final_owned(state):
+        if state.approval_owned or not self.deleted(state) or self._final_owned(state):
             return False
         for source_id, deleted in zip(
             (self.turn_store().get_turn_record(turn_id) or TurnRecord.create([turn_id])).source_event_ids,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1589,6 +1589,12 @@ class ResponseRunner:
             if requested is None:
                 return False
             failing = requested
+        initial = await self.deps.approval_store.load_matrix_delivery(
+            delivery_id=failing.source_event_ids[0],
+            stage=DeliveryStage.INITIAL,
+        )
+        if initial is not None and initial.retired:
+            return await self._approval_responses.settle_failure(failing, reason)
         update = await self._approval_interruption_update(failing, cancel_source=cancel_source)
         if update is None:
             return False

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -2600,13 +2600,26 @@ class ResponseRunner:
             signal_queued_message=False,
         )
 
-    async def _recover_nonready_approval(
+    async def _recover_nonready_approval(  # noqa: PLR0911 - explicit approval states have independent terminal outcomes
         self,
         owned: ApprovalContinuation,
         *,
         target: MessageTarget,
     ) -> tuple[bool, str | None]:
         """Recover a non-ready owner, leaving ready execution to the caller."""
+        if owned.state in {"waiting", "ready"}:
+            initial = await self.deps.approval_store.load_matrix_delivery(
+                delivery_id=owned.source_event_ids[0],
+                stage=DeliveryStage.INITIAL,
+            )
+            if initial is not None and initial.retired:
+                failing = await self._approval_responses.request_failure(
+                    owned,
+                    "Tool approval response was removed. Please send a new request.",
+                )
+                if failing is None:
+                    return True, None
+                owned = failing
         if owned.state == "waiting":
             if owned.runtime_generation is not None:
                 reason = "Tool approval card publication was interrupted and denied safely."

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1594,6 +1594,7 @@ class ResponseRunner:
             stage=DeliveryStage.INITIAL,
         )
         if initial is not None and initial.retired:
+            # The legacy approval-recovery boundary proves deletion during settlement.
             return await self._approval_responses.settle_failure(failing, reason)
         update = await self._approval_interruption_update(failing, cancel_source=cancel_source)
         if update is None:
@@ -2619,6 +2620,7 @@ class ResponseRunner:
                 stage=DeliveryStage.INITIAL,
             )
             if initial is not None and initial.retired:
+                # Fence old retired owners; legacy_approval_recovery owns the terminal proof.
                 failing = await self._approval_responses.request_failure(
                     owned,
                     "Tool approval response was removed. Please send a new request.",

--- a/tach.toml
+++ b/tach.toml
@@ -138,6 +138,7 @@ visibility = [
 [[modules]]
 path = "mindroom.event_journal"
 depends_on = [
+    "mindroom.event_journal.legacy_approval_recovery",
     "mindroom.history.types",
     "mindroom.interactive_models",
     "mindroom.legacy_approval_payloads",
@@ -157,6 +158,7 @@ visibility = [
     "mindroom.delivery_gateway",
     "mindroom.dispatch_replay_guard",
     "mindroom.event_journal_open",
+    "mindroom.event_journal.legacy_approval_recovery",
     "mindroom.journal_dispatch",
     "mindroom.matrix.conversation_hydration",
     "mindroom.matrix.conversation_reads",
@@ -173,6 +175,11 @@ visibility = [
     "mindroom.visible_response_reconciliation",
     "mindroom.orchestrator",
 ]
+
+[[modules]]
+path = "mindroom.event_journal.legacy_approval_recovery"
+depends_on = ["mindroom.event_journal"]
+visibility = ["mindroom.event_journal"]
 
 [[modules]]
 path = "mindroom.interactive_models"

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -1633,6 +1633,15 @@ class TestAgentBot(AgentBotTestBase):
             )
             assert conversation.messages == ()
             assert await first.approval_store.approval_continuation_for_source("$source") == persisted
+            # Startup delivery recovery must preserve the approval's response,
+            # including when the redaction callback has already settled.
+            await first._delivery_gateway.recover_deliveries()
+            initial = await first.approval_store.load_matrix_delivery(
+                delivery_id="$source",
+                stage=DeliveryStage.INITIAL,
+            )
+            assert initial is not None
+            assert not initial.retired
         if first_agent.db is not None:
             first_agent.db.close()
 

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -6364,6 +6364,155 @@ class TestApprovalContinuations:
         assert await alice.approval_continuation_for_source("$source-1") == continuation
         assert await alice.approval_continuation_for_source("$source-2") == continuation
 
+    @pytest.mark.parametrize("state", ["waiting", "ready", "claimed", "failing"])
+    async def test_deleted_source_cleanup_preserves_approval_owner(self, alice: PrincipalStore, state: str) -> None:
+        """Deleting source text cannot steal the response owned by an approval."""
+        await self.admit_sources(alice)
+        await alice.enqueue_matrix_delivery(
+            delivery_id="$source-1",
+            stage=DeliveryStage.INITIAL,
+            room_id=ROOM,
+            thread_id="$thread",
+            payload=text("Waiting for approval"),
+        )
+        await alice.create_approval_continuation(self.continuation(state=state))
+        for index in (1, 2):
+            await admit(alice, f"$redact-{index}", redacts=f"$source-{index}", kind=EventKind.REDACTION)
+
+        assert await alice.deleted_initial_deliveries(agent_name="agent") == ()
+        with pytest.raises(RuntimeError, match="approval"):
+            await alice.retire_deleted_initial(delivery_id="$source-1")
+        assert await alice.is_pending("$source-1")
+        initial = await alice.load_matrix_delivery(delivery_id="$source-1", stage=DeliveryStage.INITIAL)
+        assert initial is not None
+        assert not initial.retired
+
+    async def test_approval_cannot_acquire_retired_initial(self, alice: PrincipalStore) -> None:
+        """A response already retired by deletion cannot acquire a new paused run."""
+        await self.admit_sources(alice)
+        await alice.enqueue_matrix_delivery(
+            delivery_id="$source-1",
+            stage=DeliveryStage.INITIAL,
+            room_id=ROOM,
+            thread_id="$thread",
+            payload=text("Waiting"),
+        )
+        await alice.retire_deleted_initial(delivery_id="$source-1")
+
+        assert await alice.create_approval_continuation(self.continuation()) is None
+
+    @pytest.mark.parametrize("approval_first", [True, False])
+    async def test_approval_creation_serializes_with_source_redaction(
+        self,
+        rival_stores: RivalStores,
+        *,
+        approval_first: bool,
+    ) -> None:
+        """Neither admission order can create an approval owning a settled source."""
+        principal = rival_stores.first.principal("agent@alice")
+        await self.admit_sources(principal)
+        reached, release, racer_finished = threading.Event(), threading.Event(), threading.Event()
+
+        def pause() -> None:
+            reached.set()
+            assert release.wait(_WORKER_WAIT_SECONDS)
+
+        holding = EventJournalStore(
+            backend=_PausingBackend(
+                rival_stores.first.backend,
+                pause,
+                statement_matches=lambda sql: (
+                    "SELECT 1 AS present FROM journal_events" in sql
+                    if approval_first
+                    else "UPDATE journal_events" in sql and "NOT EXISTS" in sql
+                ),
+            ),
+        ).principal("agent@alice")
+        racing = rival_stores.second.principal("agent@alice")
+
+        async def redact(store: PrincipalStore) -> None:
+            await admit(store, "$redact", redacts="$source-1", kind=EventKind.REDACTION)
+
+        first = asyncio.create_task(
+            holding.create_approval_continuation(self.continuation()) if approval_first else redact(holding),
+        )
+        try:
+            await asyncio.to_thread(reached.wait, _WORKER_WAIT_SECONDS)
+            assert reached.is_set()
+            second = asyncio.create_task(
+                redact(racing) if approval_first else racing.create_approval_continuation(self.continuation()),
+            )
+            second.add_done_callback(lambda _: racer_finished.set())
+            await asyncio.to_thread(
+                _watch_until_queued_or_finished,
+                rival_stores.database_url,
+                rival_stores.racer_application_name,
+                racer_finished,
+            )
+        finally:
+            release.set()
+        await asyncio.gather(first, second)
+
+        assert (await principal.approval_continuation("approval-1") is not None) is approval_first
+        assert await principal.is_pending("$source-1") is approval_first
+
+    @pytest.mark.parametrize(
+        "proof",
+        ["complete", "source_only", "partial_sources", "active_initial", "wrong_response", "owed_final", "ready"],
+    )
+    async def test_deleted_approval_failure_settles_only_proven_terminal_delivery(
+        self,
+        alice: PrincipalStore,
+        journal_store: EventJournalStore,
+        proof: str,
+    ) -> None:
+        """Recover an already-retired approval without discarding live delivery debt."""
+        await self.admit_sources(alice)
+        await alice.enqueue_matrix_delivery(
+            delivery_id="$source-1",
+            stage=DeliveryStage.INITIAL,
+            room_id=ROOM,
+            thread_id="$thread",
+            payload=text("Waiting"),
+        )
+        await alice.claim_matrix_delivery(delivery_id="$source-1", stage=DeliveryStage.INITIAL)
+        await alice.acknowledge_matrix_delivery(
+            delivery_id="$source-1",
+            stage=DeliveryStage.INITIAL,
+            event_id="$different" if proof == "wrong_response" else "$waiting",
+            delivered_projections=(),
+        )
+        await alice.create_approval_continuation(self.continuation(state="ready" if proof == "ready" else "failing"))
+        if proof == "owed_final":
+            await alice.enqueue_matrix_delivery(
+                delivery_id="$source-1",
+                stage=DeliveryStage.FINAL,
+                room_id=ROOM,
+                thread_id="$thread",
+                payload=text("Frozen final"),
+            )
+        if proof != "active_initial":
+            # Reproduce persisted state created before approval-aware cleanup.
+            await journal_store.backend.write(
+                lambda tx: tx.execute(
+                    "UPDATE matrix_delivery_outbox SET retired = 1 WHERE delivery_id = ? AND stage = 'initial'",
+                    ("$source-1",),
+                ),
+            )
+        deleted = ["$source-1"]
+        if proof != "partial_sources":
+            deleted.append("$source-2")
+        if proof != "source_only":
+            deleted.append("$waiting")
+        for index, event_id in enumerate(deleted):
+            await admit(alice, f"$redact-{index}", redacts=event_id, kind=EventKind.REDACTION)
+
+        finished = await alice.finish_approval_continuation("approval-1")
+
+        assert finished is (proof == "complete")
+        assert await alice.is_pending("$source-1") is not finished
+        assert (await alice.approval_continuation("approval-1") is None) is finished
+
     async def test_continuation_round_trips_committed_presentation_and_visibility(
         self,
         alice: PrincipalStore,

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1849,11 +1849,21 @@ async def test_user_stop_retry_keeps_turn_owner_after_frozen_final_recovery(tmp_
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("state", ["ready", "failing"])
+@pytest.mark.parametrize(
+    ("state", "failure_reason"),
+    [
+        ("waiting", None),
+        ("ready", None),
+        ("claimed", None),
+        ("failing", None),
+        ("failing", response_runner._INTERRUPTED_APPROVAL_RECOVERY_REASON),
+    ],
+)
 @pytest.mark.parametrize("cards_expired", [True, False])
 async def test_deleted_approval_recovery_expires_cards_without_editing_or_executing(
     tmp_path: Path,
     state: str,
+    failure_reason: str | None,
     *,
     cards_expired: bool,
 ) -> None:
@@ -1889,6 +1899,7 @@ async def test_deleted_approval_recovery_expires_cards_without_editing_or_execut
         source_event_ids=("$source",),
         calls=(),
         state=state,
+        failure_reason=failure_reason,
     )
     assert await store.create_approval_continuation(continuation) is not None
     await bot._journal_store.backend.write(
@@ -1926,6 +1937,7 @@ async def test_deleted_approval_recovery_expires_cards_without_editing_or_execut
     with (
         patch("mindroom.approval_response.approval_manager.get_approval_store", return_value=manager),
         patch.object(DeliveryGateway, "edit_text", new=edit),
+        patch("mindroom.response_runner.fetch_latest_visible_body", new=AsyncMock(return_value=None)) as fetch_body,
     ):
         handled, _ = await runner._recover_nonready_approval(
             continuation,
@@ -1935,6 +1947,7 @@ async def test_deleted_approval_recovery_expires_cards_without_editing_or_execut
     assert handled
     expire.assert_awaited_once_with(continuation.approval_id)
     edit.assert_not_awaited()
+    fetch_body.assert_not_awaited()
     assert await store.is_pending("$source") is not cards_expired
     remaining = await store.approval_continuation(continuation.approval_id)
     assert (remaining is None) is cards_expired

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1849,6 +1849,100 @@ async def test_user_stop_retry_keeps_turn_owner_after_frozen_final_recovery(tmp_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["ready", "failing"])
+@pytest.mark.parametrize("cards_expired", [True, False])
+async def test_deleted_approval_recovery_expires_cards_without_editing_or_executing(
+    tmp_path: Path,
+    state: str,
+    *,
+    cards_expired: bool,
+) -> None:
+    """A retired deleted response settles only after cards, and never resumes tools."""
+    bot = _bot(tmp_path)
+    runner = unwrap_extracted_collaborator(bot._response_runner)
+    store = runner.deps.approval_store
+    await _admit_approval_source(store)
+    await store.enqueue_matrix_delivery(
+        delivery_id="$source",
+        stage=DeliveryStage.INITIAL,
+        room_id="!room:localhost",
+        thread_id="$thread",
+        payload={"body": "Waiting"},
+    )
+    await store.claim_matrix_delivery(delivery_id="$source", stage=DeliveryStage.INITIAL)
+    await store.acknowledge_matrix_delivery(
+        delivery_id="$source",
+        stage=DeliveryStage.INITIAL,
+        event_id="$waiting",
+        delivered_projections=(),
+    )
+    continuation = ApprovalContinuation(
+        approval_id="deleted-approval",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        source_event_ids=("$source",),
+        calls=(),
+        state=state,
+    )
+    assert await store.create_approval_continuation(continuation) is not None
+    await bot._journal_store.backend.write(
+        lambda tx: tx.execute(
+            "UPDATE matrix_delivery_outbox SET retired = 1 WHERE delivery_id = ? AND stage = 'initial'",
+            ("$source",),
+        ),
+    )
+    for index, event_id in enumerate(("$source", "$waiting")):
+        await store.admit(
+            InboundEvent(
+                event_id=f"$redact-{index}",
+                room_id=continuation.room_id,
+                thread_id=None,
+                kind=EventKind.REDACTION,
+                event_class=EventClass.CONTEXT_ONLY,
+                sender="@user:localhost",
+                origin_server_ts=2 + index,
+                source={"event_id": f"$redact-{index}", "redacts": event_id, "content": {}},
+            ),
+            ProjectedEvent(
+                event_id=f"$redact-{index}",
+                room_id=continuation.room_id,
+                thread_id=None,
+                sender="@user:localhost",
+                origin_server_ts=2 + index,
+                content={},
+                replaces_event_id=None,
+                redacts_event_id=event_id,
+            ),
+        )
+    expire = AsyncMock(return_value=cards_expired)
+    manager = SimpleNamespace(expire_continuation_cards=expire)
+    edit = AsyncMock(side_effect=AssertionError("deleted response edited"))
+    with (
+        patch("mindroom.approval_response.approval_manager.get_approval_store", return_value=manager),
+        patch.object(DeliveryGateway, "edit_text", new=edit),
+    ):
+        handled, _ = await runner._recover_nonready_approval(
+            continuation,
+            target=MessageTarget.resolve(continuation.room_id, "$thread", "$source"),
+        )
+
+    assert handled
+    expire.assert_awaited_once_with(continuation.approval_id)
+    edit.assert_not_awaited()
+    assert await store.is_pending("$source") is not cards_expired
+    remaining = await store.approval_continuation(continuation.approval_id)
+    assert (remaining is None) is cards_expired
+    if remaining is not None:
+        assert remaining.state == "failing"
+
+
+@pytest.mark.asyncio
 async def test_failing_continuation_recovers_frozen_success_before_failure_settlement(tmp_path: Path) -> None:
     """A failure fence racing a generated answer cannot retire that answer as a denial."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)


### PR DESCRIPTION
Deleting a message while its tool approval was pending could make response cleanup retire the approval's INITIAL delivery. The approval still owned its source, but every attempt to publish its terminal edit was refused, leaving recovery to retry forever.

Cleanup now recognizes approval ownership in its existing recovery snapshot and outbox checks. Approval creation and redaction admission use the existing room-membership lock, preventing creation from acquiring sources that deletion already settled.

For already-retired responses, a failing approval can settle after its cards expire only when no FINAL exists and exact tombstones prove deletion of its acknowledged response and every source. It sends no replacement text and records no tool success. Ready approvals with retired delivery targets cannot execute tools; interrupted approvals settle without trying to read deleted response text. Deleting source text alone still allows explicit approval through the retained card.

Historical deletion proof lives in `event_journal/legacy_approval_recovery.py`, with the standard format, release, handling, and coverage provenance. The replacement release is `v2026.9.64`, created automatically when this PR merges. Current owners retain card expiration, failure fencing, retries, locking, and settlement. Tach restricts the legacy helper to the journal, and the migration inventory and generated references identify its owner. The extraction preserves the executable repair logic and changes no persisted schema or payload format.

Validation: the full backend suite passed with 18,036 tests passed and 10 skipped (19 dependency/test-harness warnings). Regression coverage includes SQLite/PostgreSQL ownership and concurrency, restart consent, all persisted approval states, card-expiration failure, and preservation of owed FINAL delivery. All repository pre-commit hooks and Tach dependency/interface checks passed. The extracted repair function has an identical executable AST, and all existing migration inventory IDs are retained. Two fresh independent reviews approved commit `fb364e531` with no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Approval recovery now settles failed approvals consistently after their cards expire.
  - Approval-owned deliveries are protected from premature cleanup or retirement.
  - Retired or invalid source deliveries can no longer be acquired by new approvals.
  - Recovery avoids unnecessary visible interruption updates and prevents unsafe continuation or supersession.

- **Documentation**
  - Updated architecture and migration documentation to describe legacy approval recovery and its validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->