### PR TITLE
Pin mindroom-nio 1.0.3 for typed membership errors

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -98,8 +98,9 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.2`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
+Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/docs/dev/matrix-event-journal-contracts.md
+++ b/docs/dev/matrix-event-journal-contracts.md
@@ -26,7 +26,7 @@ One shared boundary helper encodes `None` to the empty string and decodes it bac
 ### Durable sync batch boundary
 
 The Matrix client uses `nio.durable.open_durable_sync` with Classic or Simplified Sliding Sync.
-Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.2` package, with no Git source override.
+Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.3` package, with no Git source override.
 Account, device, consumer and stream ownership bind once when opening the session.
 Soft-logout renewal requests the existing device; it preserves the bound stream, membership positions, and attempted-delivery sending identity.
 Hard logout, missing device storage, or changed identity stops startup instead of attempting a stream replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==1.0.2",
+  "mindroom-nio[e2e]==1.0.3",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17246,8 +17246,9 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.2`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
+Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -94,8 +94,9 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.2`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
+Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -258,7 +258,7 @@ def test_wheel_force_include_does_not_bundle_avatar_assets() -> None:
 
 
 def test_runtime_dependency_requires_released_durable_nio() -> None:
-    """The wheel pins the released durable sync, history, and byte-accounting fixes."""
+    """The wheel pins the released durable sync, history, byte-accounting, and membership-error fixes."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
     requirement = Requirement(
@@ -271,6 +271,7 @@ def test_runtime_dependency_requires_released_durable_nio() -> None:
     assert Version("0.40.0") not in requirement.specifier
     assert Version("1.0.0") not in requirement.specifier
     assert Version("1.0.1") not in requirement.specifier
-    assert Version("1.0.2") in requirement.specifier
-    assert Version("1.0.3") not in requirement.specifier
+    assert Version("1.0.2") not in requirement.specifier
+    assert Version("1.0.3") in requirement.specifier
+    assert Version("1.0.4") not in requirement.specifier
     assert Version("2.0.0") not in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -4594,7 +4594,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.2" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.3" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4706,7 +4706,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4719,9 +4719,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/1d/f0e7605294a351c7563fdc584824fd3aa94f7a09efbfc7954b4141ece187/mindroom_nio-1.0.2.tar.gz", hash = "sha256:9294a5b971b24dcd3d93efe7f8fd1a149d2994fbe0e3c7d8a3fa1a33e9f2cb38", size = 211018, upload-time = "2026-09-10T12:09:07.226Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/b2/94e495d1d4e9bc0be574b3182de666238c1606c4278a51036820e2363928/mindroom_nio-1.0.3.tar.gz", hash = "sha256:72fe6cd80e30a9edf89c065bb8730ece7885ec469194b899e87ceb0c69f9037a", size = 211136, upload-time = "2026-09-10T19:19:43.65Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/25db1a752b5cb0bf91f8add00c436a7133fcba02d62efb866f33a412c2dc/mindroom_nio-1.0.2-py3-none-any.whl", hash = "sha256:5549affb9595e05462869968ce1e2f32b231c03faa3c02529343b314d32aaf80", size = 246199, upload-time = "2026-09-10T12:09:05.529Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f9/5b2e244cad717706f7fee62598b5e4e580dc302c253bc63c1317eb64798c/mindroom_nio-1.0.3-py3-none-any.whl", hash = "sha256:a71857229dcf46a365e198b58c5c96755f6c2e5c2ff6b62d07ef6f111aeba08b", size = 246308, upload-time = "2026-09-10T19:19:41.877Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Pin `mindroom-nio[e2e]` to the published 1.0.3 release. Durable joined-member queries now return typed membership errors and preserve Matrix error codes after retry exhaustion, as fixed in [mindroom-nio#63](https://github.com/mindroom-ai/mindroom-nio/pull/63).

Update the lockfile, current dependency documentation, generated references, and the existing package requirement test. No other dependency versions change.

Validation: 18,054 backend tests passed, 10 skipped, against the published 1.0.3 package. Packaging, import-boundary, and room-history checks and repository pre-commit hooks passed. Two independent reviews approved commit 62f3af4d3a6ad812d70d0c28bc70b087cdb3fe77 with no findings.
