### PR TITLE
Add GPT-Live calls with normal agent delegation

### DIFF
--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -20,7 +20,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -2,6 +2,7 @@
 
 MindRoom agents can join Element Call voice calls in their rooms and talk with you in real time.
 The `realtime` backend provides OpenAI realtime speech-to-speech.
+The `live` backend uses OpenAI Live for speech and delegates substantive requests to the normal MindRoom agent.
 The `cascaded` backend combines independently configured speech-to-text and text-to-speech services with the agent's normal MindRoom response path.
 
 ## How it works
@@ -15,15 +16,17 @@ When a call starts in a room, the configured agent:
 2. Exchanges a Matrix OpenID token for a LiveKit JWT at the MatrixRTC authorization service (`lk-jwt-service`).
 3. Connects to the LiveKit SFU and publishes its own call membership state event, so it appears in the call roster.
 4. In encrypted rooms, distributes its media frame key over encrypted to-device messages and installs the other participants' keys, following the same per-sender key rotation policy as Element Call.
-5. Runs either the OpenAI realtime session or the cascaded speech pipeline until the managed session ends.
+5. Runs the selected voice backend until the managed session ends.
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
+Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.
 MindRoom keeps a managed call active only while its devices belong to one Matrix user, and uses that user's ID as the real requester for the room-scoped tool runtime.
 Multiple devices belonging to that same user are supported.
-Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in both backends because a voice call has no approval UI.
+Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in all backends because a voice call has no approval UI.
 
 The agent leaves the call and clears its membership state event when the caller leaves, a second distinct Matrix user joins, the voice session terminates, or the bot shuts down.
 
@@ -46,7 +49,9 @@ calls:
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
 `calls.profiles` defines reusable, complete voice pipelines.
 `calls.agents` maps each enabled agent to exactly one profile name.
-The `model` in a realtime profile is the provider-specific OpenAI realtime speech model ID.
+The `model` in a realtime or Live profile is the provider-specific OpenAI speech model ID.
+Live profiles require an explicit `credentials_service` and `voice`, and do not use separate STT or TTS services.
+The optional `agent_model` in a Live profile references a named entry from the top-level `models` mapping for delegated agent turns.
 Cascaded profiles require complete STT and TTS settings.
 OpenAI speech legs require either `credentials_service` or `api_key`; OpenAI-compatible speech legs require `host` and may omit credentials.
 The optional `model` in a cascaded profile references a named entry from the top-level `models` mapping.
@@ -91,6 +96,44 @@ An explicit room assignment to one calls-enabled agent takes precedence over per
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
 The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
+
+## OpenAI Live with agent delegation
+
+This example uses GPT-Live for speech and the configured `chat` model for the normal agent's delegated responses.
+The voice model uses its own named OpenAI credential service, independently of the agent's model provider and credentials.
+
+```yaml
+models:
+  chat:
+    provider: anthropic
+    id: claude-opus-5
+
+agents:
+  assistant:
+    display_name: Assistant
+    model: chat
+
+calls:
+  enabled: true
+  profiles:
+    openai-live:
+      backend: live
+      model: gpt-live-1
+      credentials_service: openai-live
+      voice: marin
+      agent_model: chat
+  agents:
+    assistant: openai-live
+```
+
+`agent_model` is optional; omitting it keeps normal room and agent model resolution.
+When set, it overrides that resolution for the calls-enabled agent and must name an entry in `models`.
+An unknown alias fails configuration loading.
+The `model` field selects the OpenAI Live speech model and is independent of `agent_model`.
+The named `credentials_service` must resolve an API key; a missing service does not fall back to another OpenAI key.
+Live needs no separate STT or TTS credentials.
+Media reconnects reuse the delegate's history for the current call; once the caller leaves, the next call starts a new delegate session.
+Configuration reload rebuilds the call runtime when delegate model definitions or room model routing change.
 
 ## Cascaded LLM model override
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,7 @@ lumalabs = [
 ]
 matrix_api = []
 matrix_calls = [
-  "livekit-agents[openai]>=1.6.4",
+  "livekit-agents[openai]>=1.8.1",
 ]
 matrix-e2ee = []
 matrix_message = []

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14887,6 +14887,7 @@ Attachment IDs in this fallback path use the same context-scoping rules describe
 
 MindRoom agents can join Element Call voice calls in their rooms and talk with you in real time.
 The `realtime` backend provides OpenAI realtime speech-to-speech.
+The `live` backend uses OpenAI Live for speech and delegates substantive requests to the normal MindRoom agent.
 The `cascaded` backend combines independently configured speech-to-text and text-to-speech services with the agent's normal MindRoom response path.
 
 ## How it works
@@ -14900,15 +14901,17 @@ When a call starts in a room, the configured agent:
 2. Exchanges a Matrix OpenID token for a LiveKit JWT at the MatrixRTC authorization service (`lk-jwt-service`).
 3. Connects to the LiveKit SFU and publishes its own call membership state event, so it appears in the call roster.
 4. In encrypted rooms, distributes its media frame key over encrypted to-device messages and installs the other participants' keys, following the same per-sender key rotation policy as Element Call.
-5. Runs either the OpenAI realtime session or the cascaded speech pipeline until the managed session ends.
+5. Runs the selected voice backend until the managed session ends.
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
+Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.
 MindRoom keeps a managed call active only while its devices belong to one Matrix user, and uses that user's ID as the real requester for the room-scoped tool runtime.
 Multiple devices belonging to that same user are supported.
-Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in both backends because a voice call has no approval UI.
+Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in all backends because a voice call has no approval UI.
 
 The agent leaves the call and clears its membership state event when the caller leaves, a second distinct Matrix user joins, the voice session terminates, or the bot shuts down.
 
@@ -14931,7 +14934,9 @@ calls:
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
 `calls.profiles` defines reusable, complete voice pipelines.
 `calls.agents` maps each enabled agent to exactly one profile name.
-The `model` in a realtime profile is the provider-specific OpenAI realtime speech model ID.
+The `model` in a realtime or Live profile is the provider-specific OpenAI speech model ID.
+Live profiles require an explicit `credentials_service` and `voice`, and do not use separate STT or TTS services.
+The optional `agent_model` in a Live profile references a named entry from the top-level `models` mapping for delegated agent turns.
 Cascaded profiles require complete STT and TTS settings.
 OpenAI speech legs require either `credentials_service` or `api_key`; OpenAI-compatible speech legs require `host` and may omit credentials.
 The optional `model` in a cascaded profile references a named entry from the top-level `models` mapping.
@@ -14976,6 +14981,44 @@ An explicit room assignment to one calls-enabled agent takes precedence over per
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
 The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
+
+## OpenAI Live with agent delegation
+
+This example uses GPT-Live for speech and the configured `chat` model for the normal agent's delegated responses.
+The voice model uses its own named OpenAI credential service, independently of the agent's model provider and credentials.
+
+```yaml
+models:
+  chat:
+    provider: anthropic
+    id: claude-opus-5
+
+agents:
+  assistant:
+    display_name: Assistant
+    model: chat
+
+calls:
+  enabled: true
+  profiles:
+    openai-live:
+      backend: live
+      model: gpt-live-1
+      credentials_service: openai-live
+      voice: marin
+      agent_model: chat
+  agents:
+    assistant: openai-live
+```
+
+`agent_model` is optional; omitting it keeps normal room and agent model resolution.
+When set, it overrides that resolution for the calls-enabled agent and must name an entry in `models`.
+An unknown alias fails configuration loading.
+The `model` field selects the OpenAI Live speech model and is independent of `agent_model`.
+The named `credentials_service` must resolve an API key; a missing service does not fall back to another OpenAI key.
+Live needs no separate STT or TTS credentials.
+Media reconnects reuse the delegate's history for the current call; once the caller leaves, the next call starts a new delegate session.
+Configuration reload rebuilds the call runtime when delegate model definitions or room model routing change.
 
 ## Cascaded LLM model override
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14905,7 +14905,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -20,7 +20,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -2,6 +2,7 @@
 
 MindRoom agents can join Element Call voice calls in their rooms and talk with you in real time.
 The `realtime` backend provides OpenAI realtime speech-to-speech.
+The `live` backend uses OpenAI Live for speech and delegates substantive requests to the normal MindRoom agent.
 The `cascaded` backend combines independently configured speech-to-text and text-to-speech services with the agent's normal MindRoom response path.
 
 ## How it works
@@ -15,15 +16,17 @@ When a call starts in a room, the configured agent:
 2. Exchanges a Matrix OpenID token for a LiveKit JWT at the MatrixRTC authorization service (`lk-jwt-service`).
 3. Connects to the LiveKit SFU and publishes its own call membership state event, so it appears in the call roster.
 4. In encrypted rooms, distributes its media frame key over encrypted to-device messages and installs the other participants' keys, following the same per-sender key rotation policy as Element Call.
-5. Runs either the OpenAI realtime session or the cascaded speech pipeline until the managed session ends.
+5. Runs the selected voice backend until the managed session ends.
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
+Live uses a short voice prompt and delegates questions, research, memory, and actions to the normal MindRoom agent, which retains its full instructions, knowledge, skills, hooks, and tools.
+The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.
 MindRoom keeps a managed call active only while its devices belong to one Matrix user, and uses that user's ID as the real requester for the room-scoped tool runtime.
 Multiple devices belonging to that same user are supported.
-Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in both backends because a voice call has no approval UI.
+Tools requiring confirmation, user input, external execution, or `tool_approval` are hidden in all backends because a voice call has no approval UI.
 
 The agent leaves the call and clears its membership state event when the caller leaves, a second distinct Matrix user joins, the voice session terminates, or the bot shuts down.
 
@@ -46,7 +49,9 @@ calls:
 Voice calls require the `matrix_calls` extra (`pip install "mindroom[matrix_calls]"` or `uv sync --extra matrix_calls`).
 `calls.profiles` defines reusable, complete voice pipelines.
 `calls.agents` maps each enabled agent to exactly one profile name.
-The `model` in a realtime profile is the provider-specific OpenAI realtime speech model ID.
+The `model` in a realtime or Live profile is the provider-specific OpenAI speech model ID.
+Live profiles require an explicit `credentials_service` and `voice`, and do not use separate STT or TTS services.
+The optional `agent_model` in a Live profile references a named entry from the top-level `models` mapping for delegated agent turns.
 Cascaded profiles require complete STT and TTS settings.
 OpenAI speech legs require either `credentials_service` or `api_key`; OpenAI-compatible speech legs require `host` and may omit credentials.
 The optional `model` in a cascaded profile references a named entry from the top-level `models` mapping.
@@ -91,6 +96,44 @@ An explicit room assignment to one calls-enabled agent takes precedence over per
 Calls-enabled agents advertise `📞 Voice calls` in their Matrix presence status only when their MatrixRTC runtime is available, so clients can show the call action only where it will be answered.
 Requester-private agents use the sole authorized caller's verified Matrix user ID to resolve their workspace, memory, credentials, history, knowledge, and tool execution scope.
 The same caller scope applies in configured rooms and authorized ad-hoc invite rooms.
+
+## OpenAI Live with agent delegation
+
+This example uses GPT-Live for speech and the configured `chat` model for the normal agent's delegated responses.
+The voice model uses its own named OpenAI credential service, independently of the agent's model provider and credentials.
+
+```yaml
+models:
+  chat:
+    provider: anthropic
+    id: claude-opus-5
+
+agents:
+  assistant:
+    display_name: Assistant
+    model: chat
+
+calls:
+  enabled: true
+  profiles:
+    openai-live:
+      backend: live
+      model: gpt-live-1
+      credentials_service: openai-live
+      voice: marin
+      agent_model: chat
+  agents:
+    assistant: openai-live
+```
+
+`agent_model` is optional; omitting it keeps normal room and agent model resolution.
+When set, it overrides that resolution for the calls-enabled agent and must name an entry in `models`.
+An unknown alias fails configuration loading.
+The `model` field selects the OpenAI Live speech model and is independent of `agent_model`.
+The named `credentials_service` must resolve an API key; a missing service does not fall back to another OpenAI key.
+Live needs no separate STT or TTS credentials.
+Media reconnects reuse the delegate's history for the current call; once the caller leaves, the next call starts a new delegate session.
+Configuration reload rebuilds the call runtime when delegate model definitions or room model routing change.
 
 ## Cascaded LLM model override
 

--- a/src/mindroom/config/calls.py
+++ b/src/mindroom/config/calls.py
@@ -27,6 +27,24 @@ class RealtimeCallProfile(BaseModel):
         return validate_service_name(value)
 
 
+class LiveCallProfile(BaseModel):
+    """One OpenAI Live voice session delegating tasks to a normal agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    backend: Literal["live"]
+    model: str = Field(description="OpenAI Live speech-to-speech model")
+    credentials_service: str = Field(description="Named credential service containing the Live API key")
+    voice: str = Field(description="Live model voice preset")
+    agent_model: str | None = Field(default=None, description="Configured LLM alias for delegated agent turns")
+
+    @field_validator("credentials_service")
+    @classmethod
+    def _validate_credentials_service(cls, value: str) -> str:
+        """Normalize the strict Live credential binding."""
+        return validate_service_name(value)
+
+
 class CascadedCallProfile(BaseModel):
     """One STT, normal agent turn, and TTS call profile."""
 
@@ -38,7 +56,7 @@ class CascadedCallProfile(BaseModel):
     tts: SpeechServiceConfig = Field(description="Text-to-speech service")
 
 
-CallProfile = Annotated[RealtimeCallProfile | CascadedCallProfile, Field(discriminator="backend")]
+CallProfile = Annotated[RealtimeCallProfile | LiveCallProfile | CascadedCallProfile, Field(discriminator="backend")]
 
 
 class CallsConfig(BaseModel):

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -35,7 +35,7 @@ from mindroom.config.access import RoomDefaultsConfig, validate_concrete_matrix_
 from mindroom.config.agent import AgentConfig, RoomConfig, TeamConfig  # noqa: TC001
 from mindroom.config.approval import ToolApprovalConfig
 from mindroom.config.auth import AuthorizationConfig
-from mindroom.config.calls import CallsConfig, CascadedCallProfile
+from mindroom.config.calls import CallsConfig, CascadedCallProfile, LiveCallProfile
 from mindroom.config.entity_view import ResolvedEntityView
 from mindroom.config.external_trigger_policy import ExternalTriggerPolicyConfig
 from mindroom.config.knowledge import KnowledgeBaseConfig
@@ -630,7 +630,7 @@ class Config(BaseModel):
 
     @model_validator(mode="after")
     def validate_call_agents(self) -> Config:
-        """Ensure call agents and cascaded model references are valid."""
+        """Ensure call agents and normal-agent model references are valid."""
         unknown_agents = sorted(set(self.calls.agents) - set(self.agents))
         if unknown_agents:
             msg = f"calls.agents references unknown agent(s): {', '.join(unknown_agents)}"
@@ -645,6 +645,17 @@ class Config(BaseModel):
         )
         if invalid_models:
             msg = "calls.profiles references unknown cascaded model(s): " + ", ".join(invalid_models)
+            raise ValueError(msg)
+
+        invalid_live_models = sorted(
+            f"{profile_name} -> {profile.agent_model}"
+            for profile_name, profile in self.calls.profiles.items()
+            if isinstance(profile, LiveCallProfile)
+            and profile.agent_model is not None
+            and profile.agent_model not in self.models
+        )
+        if invalid_live_models:
+            msg = "calls.profiles references unknown Live agent model(s): " + ", ".join(invalid_live_models)
             raise ValueError(msg)
 
         agents_by_room: dict[str, list[str]] = {}

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -47,10 +47,12 @@ from mindroom.matrix_rtc.events import (
 )
 from mindroom.matrix_rtc.focus import OpenIDToken, discover_livekit_service_url, request_sfu_grant
 from mindroom.matrix_rtc.key_transport import ToDeviceFrameKeyTransport
+from mindroom.matrix_rtc.live_voice_agent import LiveVoiceBridge
 from mindroom.matrix_rtc.transcript import CallTranscript
 from mindroom.matrix_rtc.voice_agent import (
     CascadedVoiceAgentOptions,
     CascadedVoiceBridge,
+    LiveVoiceAgentOptions,
     RealtimeVoiceBridge,
     SpeechServiceOptions,
     VoiceAgentOptions,
@@ -69,7 +71,7 @@ if TYPE_CHECKING:
     from collections.abc import Set as AbstractSet
 
     from mindroom.agent_reply_membership import AgentReplyMembershipIndex
-    from mindroom.config.calls import CallProfile, CascadedCallProfile, RealtimeCallProfile
+    from mindroom.config.calls import CallProfile, CascadedCallProfile, LiveCallProfile, RealtimeCallProfile
     from mindroom.config.main import Config
     from mindroom.config.voice import SpeechServiceConfig
     from mindroom.constants import RuntimePaths
@@ -89,6 +91,10 @@ def _default_cascaded_bridge_factory(local_identity: str, e2ee_enabled: bool) ->
     return CascadedVoiceBridge(local_identity=local_identity, e2ee_enabled=e2ee_enabled)
 
 
+def _default_live_bridge_factory(local_identity: str, e2ee_enabled: bool) -> LiveVoiceBridge:
+    return LiveVoiceBridge(local_identity=local_identity, e2ee_enabled=e2ee_enabled)
+
+
 _CALL_EVENT_TYPES = frozenset({CALL_MEMBER_EVENT_TYPE, RTC_NOTIFICATION_EVENT_TYPE})
 _MAX_PENDING_KEYS_PER_ROOM = 64
 _PENDING_KEY_TTL_MS = 120_000
@@ -102,6 +108,13 @@ _VOICE_STYLE_ADDENDUM = (
     "You are participating in a live voice call. Everything you say is spoken "
     "aloud: keep responses short, conversational, and natural, and never use markdown, "
     "lists, or other written formatting."
+)
+
+_LIVE_VOICE_INSTRUCTIONS = (
+    "You are the voice interface for a MindRoom agent. Speak briefly and naturally. "
+    "Delegate every substantive request to the agent, including questions, research, "
+    "memory, and actions. Relay its answer conversationally. Never claim to have "
+    "checked information or completed work until the agent returns the result."
 )
 
 
@@ -122,7 +135,7 @@ class _LogicalCallState:
     """State that survives media-session reconnects for one logical call."""
 
     requester_id: str
-    cascaded_session_id: str | None
+    agent_session_id: str | None
     join_blocked: bool = False
 
 
@@ -203,8 +216,13 @@ class CallManager:
         self._client = client
         self._runtime_paths = runtime_paths
         self._ssl_verify = ssl_verify
-        self._bridge_factory = bridge_factory or (
-            _default_cascaded_bridge_factory if self._call_config.backend == "cascaded" else _default_bridge_factory
+        self._bridge_factory = (
+            bridge_factory
+            or {
+                "realtime": _default_bridge_factory,
+                "cascaded": _default_cascaded_bridge_factory,
+                "live": _default_live_bridge_factory,
+            }[self._call_config.backend]
         )
         self._tool_support = tool_support
         self._get_invited_rooms_by_agent = get_invited_rooms_by_agent
@@ -724,7 +742,6 @@ class CallManager:
             tooling = await self._build_tooling(
                 room_id,
                 requester_id=requester_id,
-                cascaded=self._call_config.backend == "cascaded",
             )
             transcript = CallTranscript.start(
                 agent_name=self._agent_name,
@@ -1008,11 +1025,15 @@ class CallManager:
         room_id: str,
         *,
         requester_id: str,
-        cascaded: bool,
     ) -> CallAgentTooling:
         """Build agent tools with the sole caller as the Matrix requester."""
         logical_call = self._logical_calls[room_id]
-        session_id = logical_call.cascaded_session_id if cascaded else None
+        enable_responder = self._call_config.backend in {"cascaded", "live"}
+        active_model_name = None
+        if self._call_config.backend == "live":
+            active_model_name = cast("LiveCallProfile", self._call_config).agent_model
+        elif self._call_config.backend == "cascaded":
+            active_model_name = self._call_config.model
         return await build_call_tools(
             agent_name=self._agent_name,
             config=self._config,
@@ -1024,10 +1045,11 @@ class CallManager:
                 room_id,
                 requester_id,
             ),
-            session_id=session_id,
-            enable_responder=cascaded,
-            voice_instructions=_VOICE_STYLE_ADDENDUM if cascaded else None,
-            active_model_name=self._call_config.model if cascaded else None,
+            session_id=logical_call.agent_session_id,
+            enable_responder=enable_responder,
+            voice_instructions=_VOICE_STYLE_ADDENDUM if enable_responder else None,
+            active_model_name=active_model_name,
+            reconcile_spoken_response=self._call_config.backend != "live",
         )
 
     @asynccontextmanager
@@ -1054,9 +1076,9 @@ class CallManager:
     def _start_logical_call(self, room_id: str, requester_id: str) -> _LogicalCallState:
         """Create the state shared by every media attempt for one caller presence."""
         session_id = None
-        if self._call_config.backend == "cascaded":
+        if self._call_config.backend in {"cascaded", "live"}:
             session_id = f"{create_session_id(room_id, None)}:call:{uuid4().hex}"
-        logical_call = _LogicalCallState(requester_id=requester_id, cascaded_session_id=session_id)
+        logical_call = _LogicalCallState(requester_id=requester_id, agent_session_id=session_id)
         self._logical_calls[room_id] = logical_call
         return logical_call
 
@@ -1077,8 +1099,8 @@ class CallManager:
         warn_if_unavailable: bool = True,
     ) -> _ResolvedVoiceBackend | None:
         """Resolve backend-specific credentials without affecting call lifecycle."""
-        if self._call_config.backend == "realtime":
-            realtime_config = cast("RealtimeCallProfile", self._call_config)
+        if self._call_config.backend in {"realtime", "live"}:
+            realtime_config = cast("RealtimeCallProfile | LiveCallProfile", self._call_config)
             api_key = get_api_key_for_service(
                 realtime_config.credentials_service,
                 self._runtime_paths,
@@ -1141,6 +1163,24 @@ class CallManager:
                 voice=realtime_config.voice,
                 greeting_instructions="Briefly greet the caller and let them know you joined the call.",
                 tools=tooling.tools,
+                on_conversation_turn=transcript.record,
+                on_tools_executed=transcript.record_tool_use,
+                on_session_terminated=on_session_terminated,
+                on_session_error=on_session_error,
+            )
+        if self._call_config.backend == "live":
+            live_config = cast("LiveCallProfile", self._call_config)
+            if backend.realtime_api_key is None or tooling.responder is None:
+                msg = "Live call agent was not fully materialized"
+                raise RuntimeError(msg)
+            return LiveVoiceAgentOptions(
+                instructions=_LIVE_VOICE_INSTRUCTIONS,
+                model=live_config.model,
+                api_key=backend.realtime_api_key,
+                voice=live_config.voice,
+                respond=tooling.responder,
+                close_responder=tooling.close,
+                greeting_instructions="Briefly greet the caller and let them know you joined the call.",
                 on_conversation_turn=transcript.record,
                 on_tools_executed=transcript.record_tool_use,
                 on_session_terminated=on_session_terminated,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -379,6 +379,7 @@ async def build_call_tools(
     authorize_operation: _CallAuthorizationGuard,
     session_id: str | None = None,
     enable_responder: bool = False,
+    reconcile_spoken_response: bool = True,
     voice_instructions: str | None = None,
     active_model_name: str | None = None,
 ) -> CallAgentTooling:
@@ -460,13 +461,14 @@ async def build_call_tools(
             agent_cache=agent_cache,
             active_model_name=active_model_name,
             authorize_operation=authorize_operation,
+            reconcile_spoken_response=reconcile_spoken_response,
         )
         return CallAgentTooling(
             tools=(),
             instructions="",
             execution_identity=execution_identity,
             responder=responder,
-            finalize_spoken_response=response_tracker.finalize,
+            finalize_spoken_response=response_tracker.finalize if reconcile_spoken_response else None,
             close=functools.partial(_close_cascaded_call_resources, response_tracker, agent_cache),
         )
 
@@ -571,6 +573,7 @@ async def _run_call_agent(
     agent_cache: _CallAgentCache,
     active_model_name: str | None,
     authorize_operation: _CallAuthorizationGuard,
+    reconcile_spoken_response: bool = True,
 ) -> CallAgentResponse:
     """Run one finalized transcript only while its current caller remains authorized."""
     await response_tracker.wait_for_settlements()
@@ -593,6 +596,7 @@ async def _run_call_agent(
             response_tracker=response_tracker,
             agent_cache=agent_cache,
             active_model_name=active_model_name,
+            reconcile_spoken_response=reconcile_spoken_response,
         )
 
 
@@ -613,6 +617,7 @@ async def _run_authorized_call_agent(
     response_tracker: _CallResponseTracker,
     agent_cache: _CallAgentCache,
     active_model_name: str | None,
+    reconcile_spoken_response: bool = True,
 ) -> CallAgentResponse:
     """Run one admitted call transcript through the normal MindRoom agent."""
     from mindroom.ai import ResponseTurnContext, ai_response  # noqa: PLC0415 - heavy optional call path
@@ -698,8 +703,10 @@ async def _run_authorized_call_agent(
         if on_tools_executed is not None and tool_names:
             on_tools_executed(list(tool_names))
     state = _call_agent_run_state(recorder, session_id=session_id, fallback_run_id=fallback_run_id)
-    turn_id = response_tracker.register(state) if response else None
-    if not response and state.outcome == "interrupted":
+    # Live commentary can be paraphrased or omitted; only cascaded TTS owns a
+    # one-to-one mapping between this answer and the eventual spoken turn.
+    turn_id = response_tracker.register(state) if response and reconcile_spoken_response else None
+    if (not response or not reconcile_spoken_response) and state.outcome == "interrupted":
         await response_tracker.persist_unspoken(state, default_status=RunStatus.cancelled)
     return CallAgentResponse(text=response, tool_names=tool_names, turn_id=turn_id)
 

--- a/src/mindroom/matrix_rtc/live_voice_agent.py
+++ b/src/mindroom/matrix_rtc/live_voice_agent.py
@@ -1,0 +1,247 @@
+"""GPT-Live speech delegates authorized work to a normal MindRoom agent."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from mindroom.logging_config import get_logger
+from mindroom.matrix_rtc.voice_agent import CallVoiceAgentOptions, LiveVoiceAgentOptions, RealtimeVoiceBridge
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from livekit.agents import Agent
+    from livekit.agents.llm import ChatContext, RealtimeSessionReconnectedEvent
+    from livekit.plugins.openai.realtime import GPTLiveDelegation, GPTLiveSession
+
+logger = get_logger(__name__)
+_DELEGATION_ERROR = "Voice call error: the agent could not complete the delegated request. Please try again."
+
+
+def _commentary_chunks(text: str) -> Iterator[str]:
+    """Stay below Live's 500-token append limit using a conservative byte cap."""
+    start = 0
+    size = 0
+    for index, character in enumerate(text):
+        character_size = len(character.encode("utf-8"))
+        if size + character_size > 480:
+            yield text[start:index]
+            start = index
+            size = 0
+        size += character_size
+    if start < len(text):
+        yield text[start:]
+
+
+class _LiveDelegationRunner:
+    """Own and serialize client delegations, including authorization admission."""
+
+    def __init__(self, options: LiveVoiceAgentOptions, session: GPTLiveSession) -> None:
+        self._options = options
+        self._session = session
+        self._lock = asyncio.Lock()
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._delegation_ids: set[str] = set()
+        self._message_ids: set[str] = set()
+        self._pending_transcript = ""
+        self._generation = 0
+        self._closed = False
+
+    def submit(self, delegation: GPTLiveDelegation, context: ChatContext) -> None:
+        """Snapshot new speech synchronously before the SDK finalizes pending text."""
+        from livekit.agents.llm import ChatMessage  # noqa: PLC0415
+
+        if self._closed or delegation.id in self._delegation_ids:
+            return
+        self._delegation_ids.add(delegation.id)
+        messages = tuple(
+            (item.id, item.role, item.text_content)
+            for item in context.items
+            if isinstance(item, ChatMessage) and item.role in {"user", "assistant"} and item.text_content
+        )
+        task = asyncio.create_task(self._answer(delegation, messages, self._generation))
+        self._tasks.add(task)
+        task.add_done_callback(self._on_task_done)
+
+    def _prompt(self, messages: tuple[tuple[str, str, str], ...], pending: str) -> tuple[str, str]:
+        """Compute a delta against requests the delegate has already answered."""
+        lines: list[str] = []
+        previous_pending = self._pending_transcript
+        for identifier, role, content in messages:
+            if identifier in self._message_ids:
+                continue
+            text = content
+            if role == "user" and previous_pending and text.startswith(previous_pending):
+                text = text[len(previous_pending) :].strip()
+                previous_pending = ""
+            if text:
+                lines.append(f"{role}: {text}")
+        new_pending = pending
+        if previous_pending and new_pending.startswith(previous_pending):
+            new_pending = new_pending[len(previous_pending) :].strip()
+        if new_pending and (not lines or lines[-1] != f"user: {new_pending}"):
+            lines.append(f"user: {new_pending}")
+        prompt = (
+            "Handle the current voice request using your normal instructions and tools. "
+            "The following is new conversation context since the previous delegation; "
+            "earlier context is already in this call's history. Return a concise result for the voice assistant.\n\n"
+            + "\n".join(lines)
+        )
+        return prompt, pending or previous_pending
+
+    async def _answer(
+        self,
+        delegation: GPTLiveDelegation,
+        messages: tuple[tuple[str, str, str], ...],
+        generation: int,
+    ) -> None:
+        async with self._lock:
+            if self._closed or generation != self._generation:
+                return
+            prompt, pending = self._prompt(messages, delegation.pending_transcript.strip())
+            try:
+                response = await self._options.respond(prompt, self._options.on_tools_executed)
+                if self._closed or generation != self._generation:
+                    return
+                if response.text:
+                    self._message_ids.update(identifier for identifier, _, _ in messages)
+                    self._pending_transcript = pending
+                for chunk in _commentary_chunks(response.text):
+                    self._session.append_commentary(chunk, delegation_id=delegation.id)
+            except Exception as error:
+                logger.warning("call_live_delegation_failed", error_type=type(error).__name__)
+                if self._closed or generation != self._generation:
+                    return
+                if self._options.on_session_error is not None:
+                    self._options.on_session_error(_DELEGATION_ERROR)
+                self._session.append_commentary(_DELEGATION_ERROR, delegation_id=delegation.id)
+
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        self._tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            logger.warning("call_live_delegation_delivery_failed", error_type=type(task.exception()).__name__)
+
+    def on_reconnected(self) -> None:
+        """Invalidate connection-scoped IDs and cancel their unfinished work."""
+        self._generation += 1
+        self._delegation_ids.clear()
+        for task in self._tasks:
+            task.cancel()
+
+    def stop(self) -> None:
+        """Reject new work immediately when the provider session ends."""
+        self._closed = True
+        self.on_reconnected()
+
+    async def aclose(self) -> None:
+        """Cancel and settle delegation work before releasing the agent cache."""
+        self.stop()
+        if self._tasks:
+            await asyncio.gather(*self._tasks, return_exceptions=True)
+
+
+def _build_live_agent(options: LiveVoiceAgentOptions) -> Agent:  # noqa: C901 - SDK class is defined lazily
+    """Load the optional SDK only when a Live call starts."""
+    from livekit.agents import Agent  # noqa: PLC0415
+    from livekit.plugins.openai.realtime import GPTLiveSession  # noqa: PLC0415
+
+    class LiveCallAgent(Agent):
+        def __init__(self) -> None:
+            super().__init__(instructions=options.instructions, tools=[])
+            self._delegations: _LiveDelegationRunner | None = None
+            self._live_session: GPTLiveSession | None = None
+            self._provider_close_task: asyncio.Task[None] | None = None
+
+        async def on_enter(self) -> None:
+            session = self.duplex_session
+            if not isinstance(session, GPTLiveSession):
+                msg = "GPT-Live requires a GPTLiveSession"
+                raise TypeError(msg)
+            self._live_session = session
+            self._delegations = _LiveDelegationRunner(options, session)
+            session.on("delegation_created", self._on_delegation)
+            session.on("session_reconnected", self._on_reconnected)
+            session.on("openai_server_event_received", self._on_server_event)
+
+        def _on_delegation(self, event: GPTLiveDelegation) -> None:
+            if self._delegations is not None:
+                self._delegations.submit(event, self.chat_ctx)
+
+        def _on_reconnected(self, _event: RealtimeSessionReconnectedEvent) -> None:
+            if self._delegations is not None:
+                self._delegations.on_reconnected()
+
+        def _on_server_event(self, event: dict[str, Any]) -> None:
+            if event.get("type") != "session.closed" or self._provider_close_task is not None:
+                return
+            if self._delegations is not None:
+                self._delegations.stop()
+            if self._live_session is not None:
+                # Even with max_retry=0, the SDK reconnects after a graceful
+                # server close. Close its queue before that loop resumes so
+                # old delegation commentary cannot enter a fresh session.
+                self._provider_close_task = asyncio.create_task(self._live_session.aclose())
+            if options.on_session_terminated is not None:
+                options.on_session_terminated(True)
+
+        async def on_exit(self) -> None:
+            if self._live_session is not None:
+                self._live_session.off("delegation_created", self._on_delegation)
+                self._live_session.off("session_reconnected", self._on_reconnected)
+                self._live_session.off("openai_server_event_received", self._on_server_event)
+                self._live_session = None
+            if self._delegations is not None:
+                await self._delegations.aclose()
+            if self._provider_close_task is not None:
+                await asyncio.gather(self._provider_close_task, return_exceptions=True)
+
+    return LiveCallAgent()
+
+
+class LiveVoiceBridge(RealtimeVoiceBridge):
+    """MatrixRTC media and GPT-Live speech with client-side delegation."""
+
+    def __init__(self, *, local_identity: str, e2ee_enabled: bool) -> None:
+        super().__init__(local_identity=local_identity, e2ee_enabled=e2ee_enabled)
+        self._live_agent: Agent | None = None
+
+    async def start_agent(self, options: CallVoiceAgentOptions) -> None:
+        """Start GPT-Live with the same authorized media path as other calls."""
+        from livekit import rtc  # noqa: PLC0415
+        from livekit.agents import AgentSession, APIConnectOptions, room_io  # noqa: PLC0415
+        from livekit.plugins.openai.realtime import GPTLiveModel  # noqa: PLC0415
+
+        if self._room is None:
+            msg = "connect() must succeed before start_agent()"
+            raise RuntimeError(msg)
+        if not isinstance(options, LiveVoiceAgentOptions):
+            msg = "LiveVoiceBridge requires live agent options"
+            raise TypeError(msg)
+        if options.close_responder is not None:
+            self._owned_speech_resource_closers += (options.close_responder,)
+        model = GPTLiveModel(
+            model=options.model,
+            api_key=options.api_key,
+            base_url="https://api.openai.com/v1",
+            voice=options.voice,
+            delegation="client",
+            # CallManager retries with a fresh provider queue and the same
+            # agent history. SDK retries can replay connection-scoped IDs.
+            conn_options=APIConnectOptions(max_retry=0),
+        )
+        self._owned_speech_resource_closers += (model.aclose,)
+        session = AgentSession(llm=model)
+        self._live_agent = _build_live_agent(options)
+        await self._start_session(session, self._live_agent, options, rtc_module=rtc, room_io_module=room_io)
+        if options.greeting_instructions:
+            session.generate_reply(instructions=options.greeting_instructions)
+
+    async def aclose(self) -> None:
+        """Settle delegates before the parent closes the normal agent cache."""
+        agent, self._live_agent = self._live_agent, None
+        try:
+            if agent is not None:
+                await agent.on_exit()
+        finally:
+            await super().aclose()

--- a/src/mindroom/matrix_rtc/live_voice_agent.py
+++ b/src/mindroom/matrix_rtc/live_voice_agent.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mindroom.logging_config import get_logger
@@ -17,6 +19,14 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _DELEGATION_ERROR = "Voice call error: the agent could not complete the delegated request. Please try again."
+
+
+def _exception_frames(error: BaseException) -> list[str]:
+    """Retain stack locations without exception text, source lines, or locals."""
+    return [
+        f"{Path(frame.filename).name}:{frame.lineno} ({frame.name})"
+        for frame in traceback.extract_tb(error.__traceback__)
+    ]
 
 
 def _commentary_chunks(text: str) -> Iterator[str]:
@@ -110,7 +120,11 @@ class _LiveDelegationRunner:
                 for chunk in _commentary_chunks(response.text):
                     self._session.append_commentary(chunk, delegation_id=delegation.id)
             except Exception as error:
-                logger.warning("call_live_delegation_failed", error_type=type(error).__name__)
+                logger.warning(
+                    "call_live_delegation_failed",
+                    error_type=type(error).__name__,
+                    traceback_frames=_exception_frames(error),
+                )
                 if self._closed or generation != self._generation:
                     return
                 if self._options.on_session_error is not None:
@@ -119,8 +133,12 @@ class _LiveDelegationRunner:
 
     def _on_task_done(self, task: asyncio.Task[None]) -> None:
         self._tasks.discard(task)
-        if not task.cancelled() and task.exception() is not None:
-            logger.warning("call_live_delegation_delivery_failed", error_type=type(task.exception()).__name__)
+        if not task.cancelled() and (error := task.exception()) is not None:
+            logger.warning(
+                "call_live_delegation_delivery_failed",
+                error_type=type(error).__name__,
+                traceback_frames=_exception_frames(error),
+            )
 
     def on_reconnected(self) -> None:
         """Invalidate connection-scoped IDs and cancel their unfinished work."""

--- a/src/mindroom/matrix_rtc/live_voice_agent.py
+++ b/src/mindroom/matrix_rtc/live_voice_agent.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _DELEGATION_ERROR = "Voice call error: the agent could not complete the delegated request. Please try again."
+_EMPTY_DELEGATION_RESPONSE = "No response is available from the agent for this request."
 
 
 def _exception_frames(error: BaseException) -> list[str]:
@@ -75,7 +76,7 @@ class _LiveDelegationRunner:
         task.add_done_callback(self._on_task_done)
 
     def _prompt(self, messages: tuple[tuple[str, str, str], ...], pending: str) -> tuple[str, str]:
-        """Compute a delta against requests the delegate has already answered."""
+        """Compute a delta against requests already dispatched to the delegate."""
         lines: list[str] = []
         previous_pending = self._pending_transcript
         for identifier, role, content in messages:
@@ -110,14 +111,15 @@ class _LiveDelegationRunner:
             if self._closed or generation != self._generation:
                 return
             prompt, pending = self._prompt(messages, delegation.pending_transcript.strip())
+            # An attempted request can complete tools without returning text,
+            # or fail after side effects. Never label it as new context again.
+            self._message_ids.update(identifier for identifier, _, _ in messages)
+            self._pending_transcript = pending
             try:
                 response = await self._options.respond(prompt, self._options.on_tools_executed)
                 if self._closed or generation != self._generation:
                     return
-                if response.text:
-                    self._message_ids.update(identifier for identifier, _, _ in messages)
-                    self._pending_transcript = pending
-                for chunk in _commentary_chunks(response.text):
+                for chunk in _commentary_chunks(response.text or _EMPTY_DELEGATION_RESPONSE):
                     self._session.append_commentary(chunk, delegation_id=delegation.id)
             except Exception as error:
                 logger.warning(

--- a/src/mindroom/matrix_rtc/voice_agent.py
+++ b/src/mindroom/matrix_rtc/voice_agent.py
@@ -304,7 +304,24 @@ class CascadedVoiceAgentOptions:
     on_session_error: Callable[[str], None] | None = None
 
 
-type CallVoiceAgentOptions = VoiceAgentOptions | CascadedVoiceAgentOptions
+@dataclass(frozen=True)
+class LiveVoiceAgentOptions:
+    """GPT-Live speech with delegation to the normal MindRoom agent."""
+
+    instructions: str
+    model: str
+    api_key: str
+    voice: str
+    respond: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]]
+    close_responder: Callable[[], Awaitable[None]] | None = None
+    greeting_instructions: str | None = None
+    on_conversation_turn: Callable[[str, str], None] | None = None
+    on_tools_executed: Callable[[list[str]], None] | None = None
+    on_session_terminated: Callable[[bool], None] | None = None
+    on_session_error: Callable[[str], None] | None = None
+
+
+type CallVoiceAgentOptions = VoiceAgentOptions | CascadedVoiceAgentOptions | LiveVoiceAgentOptions
 
 
 class RealtimeVoiceBridge:

--- a/tach.toml
+++ b/tach.toml
@@ -3043,6 +3043,7 @@ depends_on = [
     "mindroom.matrix_rtc.events",
     "mindroom.matrix_rtc.focus",
     "mindroom.matrix_rtc.key_transport",
+    "mindroom.matrix_rtc.live_voice_agent",
     "mindroom.matrix_rtc.transcript",
     "mindroom.matrix_rtc.voice_agent",
     "mindroom.model_defaults",
@@ -3069,6 +3070,13 @@ depends_on = [
     "mindroom.tool_approval",
     "mindroom.tool_system.declarations",
     "mindroom.tool_system.runtime_context",
+]
+
+[[modules]]
+path = "mindroom.matrix_rtc.live_voice_agent"
+depends_on = [
+    "mindroom.logging_config",
+    "mindroom.matrix_rtc.voice_agent",
 ]
 
 [[modules]]

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -20,7 +20,7 @@ import mindroom.orchestrator as orchestrator_module
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig, RoomConfig, TeamConfig
-from mindroom.config.calls import CallsConfig, CascadedCallProfile, RealtimeCallProfile
+from mindroom.config.calls import CallsConfig, CascadedCallProfile, LiveCallProfile, RealtimeCallProfile
 from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
@@ -86,7 +86,21 @@ def _calls_for(
     )
 
 
-def _cascaded_calls_for(agent_name: str, *, model: str | None) -> CallsConfig:
+def _delegated_calls_for(agent_name: str, *, model: str | None, backend: str) -> CallsConfig:
+    if backend == "live":
+        return CallsConfig(
+            enabled=True,
+            profiles={
+                "voice": LiveCallProfile(
+                    backend="live",
+                    model="gpt-live-1",
+                    credentials_service="openai_live",
+                    voice="marin",
+                    agent_model=model,
+                ),
+            },
+            agents={agent_name: "voice"},
+        )
     speech_service = SpeechServiceConfig(
         provider="openai_compatible",
         model="local-speech",
@@ -2113,8 +2127,9 @@ def test_config_update_plan_restarts_call_agent_when_worker_routing_changes() ->
     assert plan.entities_to_restart == {"general"}
 
 
-def test_config_update_plan_restarts_cascaded_call_agent_when_referenced_model_changes() -> None:
-    """An active cascaded call rebuilds when its named model definition changes."""
+@pytest.mark.parametrize("backend", ["cascaded", "live"])
+def test_config_update_plan_restarts_delegated_call_agent_when_referenced_model_changes(backend: str) -> None:
+    """An active delegated call rebuilds when its named model definition changes."""
     old_config = _runtime_bound_config(
         Config(
             agents={"general": AgentConfig(display_name="General Agent")},
@@ -2122,7 +2137,7 @@ def test_config_update_plan_restarts_cascaded_call_agent_when_referenced_model_c
                 "default": ModelConfig(provider="openai", id="default-model"),
                 "call": ModelConfig(provider="openai", id="old-model"),
             },
-            calls=_cascaded_calls_for("general", model="call"),
+            calls=_delegated_calls_for("general", model="call", backend=backend),
             router=RouterConfig(model="default"),
         ),
     )
@@ -2133,7 +2148,7 @@ def test_config_update_plan_restarts_cascaded_call_agent_when_referenced_model_c
                 "default": ModelConfig(provider="openai", id="default-model"),
                 "call": ModelConfig(provider="openai", id="new-model"),
             },
-            calls=_cascaded_calls_for("general", model="call"),
+            calls=_delegated_calls_for("general", model="call", backend=backend),
             router=RouterConfig(model="default"),
         ),
     )
@@ -2181,8 +2196,9 @@ def test_config_update_plan_restarts_realtime_call_agent_when_agent_model_change
     assert plan.entities_to_restart == {"general"}
 
 
-def test_config_update_plan_restarts_implicit_cascaded_call_agent_when_room_model_changes() -> None:
-    """Implicit cascaded model selection rebuilds when configured room routing changes."""
+@pytest.mark.parametrize("backend", ["cascaded", "live"])
+def test_config_update_plan_restarts_implicit_delegated_call_agent_when_room_model_changes(backend: str) -> None:
+    """Implicit delegated model selection rebuilds when configured room routing changes."""
     models = {
         "default": ModelConfig(provider="openai", id="default-model"),
         "focused": ModelConfig(provider="openai", id="focused-model"),
@@ -2193,7 +2209,7 @@ def test_config_update_plan_restarts_implicit_cascaded_call_agent_when_room_mode
             agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
             models=models,
             room_models={"lobby": "focused"},
-            calls=_cascaded_calls_for("general", model=None),
+            calls=_delegated_calls_for("general", model=None, backend=backend),
             router=RouterConfig(model="default"),
         ),
     )
@@ -2202,7 +2218,7 @@ def test_config_update_plan_restarts_implicit_cascaded_call_agent_when_room_mode
             agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
             models=models,
             room_models={"lobby": "fast"},
-            calls=_cascaded_calls_for("general", model=None),
+            calls=_delegated_calls_for("general", model=None, backend=backend),
             router=RouterConfig(model="default"),
         ),
     )

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -12,11 +12,12 @@ import aiohttp
 import httpx
 import nio
 import pytest
+from pydantic import ValidationError
 
 from mindroom.agent_reply_membership import AgentReplyMembershipIndex
 from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig
-from mindroom.config.calls import CallsConfig, CascadedCallProfile, RealtimeCallProfile
+from mindroom.config.calls import CallsConfig, CascadedCallProfile, LiveCallProfile, RealtimeCallProfile
 from mindroom.config.main import Config
 from mindroom.config.memory import MemoryConfig
 from mindroom.config.models import ModelConfig
@@ -42,10 +43,12 @@ from mindroom.matrix_rtc.events import (
     membership_state_key,
 )
 from mindroom.matrix_rtc.focus import SfuGrant
+from mindroom.matrix_rtc.live_voice_agent import LiveVoiceBridge
 from mindroom.matrix_rtc.voice_agent import (
     CallVoiceAgentOptions,
     CascadedVoiceAgentOptions,
     CascadedVoiceBridge,
+    LiveVoiceAgentOptions,
     RealtimeVoiceBridge,
     VoiceAgentOptions,
 )
@@ -370,6 +373,30 @@ def _manager(
     )
 
 
+def _live_config(*, agent_model: str | None = None) -> Config:
+    """Configure Live credentials independently from the normal agent model."""
+    config = _config()
+    if agent_model is not None:
+        config.models[agent_model] = ModelConfig(provider="anthropic", id="claude-sonnet-5")
+    config.calls = CallsConfig.model_validate(
+        {
+            "enabled": True,
+            "profiles": {
+                "live": {
+                    "backend": "live",
+                    "model": "gpt-live-1",
+                    "credentials_service": "openai_live",
+                    "voice": "marin",
+                    "agent_model": agent_model,
+                },
+            },
+            "agents": {"helper": "live"},
+            "livekit_service_url": SERVICE_URL,
+        },
+    )
+    return config
+
+
 def _room(*, encrypted: bool = False, room_id: str = ROOM_ID) -> nio.MatrixRoom:
     room = nio.MatrixRoom(room_id=room_id, own_user_id=BOT_USER)
     room.encrypted = encrypted
@@ -428,6 +455,7 @@ def _stub_join_externals(monkeypatch: pytest.MonkeyPatch) -> None:
             tools=(),
             instructions="You are Helper.",
             execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+            responder=AsyncMock(return_value=CallAgentResponse("answer")),
         )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
@@ -699,6 +727,89 @@ async def test_manager_selects_cascaded_backend_with_independent_speech_services
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("agent_model", [None, "delegate"])
+async def test_manager_selects_live_backend_with_normal_agent_delegate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    agent_model: str | None,
+) -> None:
+    """Live gets its own credential and preserves the selected delegate and authorization."""
+    tooling_kwargs: dict[str, object] = {}
+    close_responder = AsyncMock()
+
+    async def respond(
+        transcript: str,
+        _on_tools_executed: Callable[[list[str]], None] | None,
+    ) -> CallAgentResponse:
+        return CallAgentResponse(f"Completed: {transcript}")
+
+    async def fake_tools(**kwargs: object) -> CallAgentTooling:
+        tooling_kwargs.update(kwargs)
+        return CallAgentTooling(
+            tools=(),
+            instructions="Detailed private agent workspace instructions.",
+            execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
+            responder=respond,
+            close=close_responder,
+        )
+
+    services: list[str] = []
+
+    def get_key(service: str, _runtime_paths: RuntimePaths) -> str | None:
+        services.append(service)
+        return {"openai_live": "sk-live", "openai": "sk-other"}.get(service)
+
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", get_key)
+    client = _client()
+    client.room_get_state.return_value = _state_response(_remote_member_event())
+    bridge = FakeBridge()
+    manager = _manager(client, bridge, tmp_path, _live_config(agent_model=agent_model))
+
+    await manager.on_room_event(_room(), _member_unknown_event())
+
+    options = bridge.agent_options
+    assert isinstance(options, LiveVoiceAgentOptions)
+    assert options.model == "gpt-live-1"
+    assert options.api_key == "sk-live"
+    assert options.voice == "marin"
+    assert options.respond is respond
+    assert options.close_responder is close_responder
+    assert "Detailed private agent workspace instructions." not in options.instructions
+    assert await options.respond("Check status", None) == CallAgentResponse("Completed: Check status")
+    assert services == ["openai_live"]
+    assert tooling_kwargs["enable_responder"] is True
+    assert tooling_kwargs["active_model_name"] == agent_model
+    assert tooling_kwargs["reconcile_spoken_response"] is False
+    assert str(tooling_kwargs["session_id"]).startswith(f"{ROOM_ID}:call:")
+    assert tooling_kwargs["requester_id"] == "@alice:example.org"
+    assert callable(tooling_kwargs["authorize_operation"])
+    assert options.on_conversation_turn is not None
+    assert options.on_tools_executed is not None
+    assert options.on_session_error is not None
+    assert options.on_session_terminated is not None
+    await manager.shutdown()
+
+
+def test_live_backend_requires_its_named_credential(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A generic OpenAI key cannot silently satisfy the explicit Live binding."""
+    services: list[str] = []
+
+    def get_key(service: str, _runtime_paths: RuntimePaths) -> str | None:
+        services.append(service)
+        return "sk-other" if service == "openai" else None
+
+    monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", get_key)
+    manager = _manager(_client(), FakeBridge(), tmp_path, _live_config())
+
+    assert manager.voice_backend_available is False
+    assert services == ["openai_live"]
+
+
+@pytest.mark.asyncio
 async def test_cascaded_agent_start_failure_tears_down_and_retries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -925,6 +1036,7 @@ def test_default_bridge_factory_uses_assigned_profile_backend(tmp_path: Path) ->
         agents={
             "helper": AgentConfig(display_name="Helper"),
             "other": AgentConfig(display_name="Other"),
+            "speaker": AgentConfig(display_name="Speaker"),
         },
         models={},
         calls=CallsConfig(
@@ -937,10 +1049,17 @@ def test_default_bridge_factory_uses_assigned_profile_backend(tmp_path: Path) ->
                     voice="marin",
                 ),
                 "cascaded": CascadedCallProfile(backend="cascaded", stt=stt, tts=tts),
+                "live": LiveCallProfile(
+                    backend="live",
+                    model="gpt-live-1",
+                    credentials_service="openai_live",
+                    voice="marin",
+                ),
             },
             agents={
                 "helper": "realtime",
                 "other": "cascaded",
+                "speaker": "live",
             },
         ),
     )
@@ -971,9 +1090,23 @@ def test_default_bridge_factory_uses_assigned_profile_backend(tmp_path: Path) ->
 
     realtime_bridge = realtime_manager._bridge_factory("@helper:example.org:BOTDEV", False)
     cascaded_bridge = cascaded_manager._bridge_factory("@other:example.org:BOTDEV", False)
+    live_manager = CallManager(
+        agent_name="speaker",
+        config=config,
+        client=_client(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        ssl_verify=True,
+        tool_support=object(),  # type: ignore[arg-type]
+        get_invited_rooms_by_agent=dict,
+        agent_reply_memberships=AgentReplyMembershipIndex(),
+        response_admission_gate=ResponseAdmissionGate(),
+        wait_for_admission_or_shutdown=_admission_available,
+    )
+    live_bridge = live_manager._bridge_factory("@speaker:example.org:BOTDEV", False)
 
     assert isinstance(realtime_bridge, RealtimeVoiceBridge)
     assert isinstance(cascaded_bridge, CascadedVoiceBridge)
+    assert isinstance(live_bridge, LiveVoiceBridge)
     assert realtime_manager._call_config.backend == "realtime"
     assert realtime_manager._call_config.model == "gpt-realtime-custom"
     assert realtime_manager._call_config.voice == "marin"
@@ -1093,12 +1226,13 @@ async def test_manager_ignores_calls_outside_agent_rooms(tmp_path: Path) -> None
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("enforce_turn_authorization")
-async def test_manager_rejects_unauthorized_call_members(tmp_path: Path) -> None:
+@pytest.mark.parametrize("backend", ["realtime", "live"])
+async def test_manager_rejects_unauthorized_call_members(tmp_path: Path, backend: str) -> None:
     """A participant must pass normal room authorization before the agent joins."""
     client = _client()
     client.room_get_state.return_value = _state_response(_remote_member_event())
     bridge = FakeBridge()
-    config = _config()
+    config = _live_config() if backend == "live" else _config()
     _set_helper_access(config)
     manager = _manager(client, bridge, tmp_path, config)
 
@@ -1158,13 +1292,14 @@ async def test_manager_accepts_call_member_authorized_by_grant_room(tmp_path: Pa
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("enforce_turn_authorization")
-async def test_manager_leaves_active_call_when_cross_room_grant_is_revoked(tmp_path: Path) -> None:
+@pytest.mark.parametrize("backend", ["realtime", "live"])
+async def test_manager_leaves_active_call_when_cross_room_grant_is_revoked(tmp_path: Path, backend: str) -> None:
     """A grant-room departure must end an active call without another call-room event."""
     grant_room_id = "!grant:example.org"
     client = _client()
     client.room_get_state.return_value = _state_response(_remote_member_event())
     bridge = FakeBridge()
-    config = _config()
+    config = _live_config() if backend == "live" else _config()
     config.agents["helper"].rooms = [ROOM_ID, "grant"]
     _set_helper_access(config, members_of_rooms=["grant"])
     runtime_paths = test_runtime_paths(tmp_path)
@@ -3136,9 +3271,11 @@ async def test_call_events_cannot_bypass_pending_join_backoff(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_cascaded_retries_reuse_logical_call_session_id(
+@pytest.mark.parametrize("backend", ["cascaded", "live"])
+async def test_delegated_call_retries_reuse_logical_call_session_id(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    backend: str,
 ) -> None:
     """Media reconnects retain chat history until the remote call empties."""
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager._RECONCILE_RETRY_DELAYS_S", (0.0,))
@@ -3155,11 +3292,12 @@ async def test_cascaded_retries_reuse_logical_call_session_id(
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
     client = _client()
     client.room_get_state.return_value = _state_response(_remote_member_event())
-    manager = _manager(client, FakeBridge(), tmp_path, _cascaded_config())
+    config = _live_config() if backend == "live" else _cascaded_config()
+    manager = _manager(client, FakeBridge(), tmp_path, config)
     results = iter(("retry", "joined", "joined"))
 
     async def fake_join(room: nio.MatrixRoom, members: list[CallMember]) -> str:
-        await manager._build_tooling(room.room_id, requester_id=members[0].user_id, cascaded=True)
+        await manager._build_tooling(room.room_id, requester_id=members[0].user_id)
         return next(results)
 
     manager._join = fake_join  # type: ignore[method-assign]
@@ -3920,6 +4058,74 @@ def test_calls_config_rejects_unknown_cascaded_model() -> None:
                 agents={"helper": "voice"},
             ),
         )
+
+
+def test_live_calls_validate_delegate_model_separately_from_voice_model() -> None:
+    """Live accepts a provider model while its delegate must name a configured alias."""
+    calls = {
+        "profiles": {
+            "voice": {
+                "backend": "live",
+                "model": "gpt-live-1",
+                "credentials_service": "openai_live",
+                "voice": "marin",
+                "agent_model": "delegate",
+            },
+        },
+        "agents": {"helper": "voice"},
+    }
+    config = Config.model_validate(
+        {
+            "agents": {"helper": {"display_name": "Helper"}},
+            "models": {"delegate": {"provider": "anthropic", "id": "claude-sonnet-5"}},
+            "calls": calls,
+        },
+    )
+    assert config.calls.model_dump(exclude_defaults=True) == calls
+
+    calls["profiles"]["voice"]["agent_model"] = "missing"
+    with pytest.raises(ValueError, match=r"voice -> missing"):
+        Config.model_validate(
+            {"agents": {"helper": {"display_name": "Helper"}}, "models": {}, "calls": calls},
+        )
+
+
+@pytest.mark.parametrize("missing_field", ["credentials_service", "voice"])
+def test_live_calls_require_explicit_credentials_and_voice(missing_field: str) -> None:
+    """Live cannot select credentials or a voice implicitly."""
+    profile = {
+        "backend": "live",
+        "model": "gpt-live-1",
+        "credentials_service": "openai_live",
+        "voice": "marin",
+    }
+    profile.pop(missing_field)
+    with pytest.raises(ValidationError) as error:
+        CallsConfig.model_validate({"profiles": {"voice": profile}})
+    assert [(item["loc"], item["type"]) for item in error.value.errors()] == [
+        (("profiles", "voice", "live", missing_field), "missing"),
+    ]
+
+
+@pytest.mark.parametrize("service", ["", "../openai", "openai/live"])
+def test_live_calls_reject_invalid_credential_service(service: str) -> None:
+    """Live credential bindings use the same strict service names as realtime."""
+    with pytest.raises(ValidationError) as error:
+        CallsConfig.model_validate(
+            {
+                "profiles": {
+                    "voice": {
+                        "backend": "live",
+                        "model": "gpt-live-1",
+                        "credentials_service": service,
+                        "voice": "marin",
+                    },
+                },
+            },
+        )
+    assert [(item["loc"], item["type"]) for item in error.value.errors()] == [
+        (("profiles", "voice", "live", "credentials_service"), "value_error"),
+    ]
 
 
 def test_openai_compatible_speech_config_requires_endpoint() -> None:

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -882,9 +882,11 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
 
 
 @pytest.mark.asyncio
-async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_functions(  # noqa: PLR0915
+@pytest.mark.parametrize("reconcile_spoken_response", [True, False], ids=["cascaded", "live"])
+async def test_call_responder_uses_normal_agent_turn_and_filters_unsafe_functions(  # noqa: C901, PLR0915
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    reconcile_spoken_response: bool,
 ) -> None:
     """Cascaded transcripts reuse ai_response with full identity and a function-level call policy."""
     config = _config()
@@ -982,6 +984,11 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
         "mindroom.matrix_rtc.call_tools.persist_interrupted_replay",
         lambda **kwargs: persisted_interruptions.append(kwargs),
     )
+    if not reconcile_spoken_response:
+        monkeypatch.setattr(
+            "mindroom.matrix_rtc.call_tools._CallResponseTracker.register",
+            MagicMock(side_effect=AssertionError("Live results must not wait for speech reconciliation")),
+        )
     tooling = await build_call_tools(
         agent_name=AGENT,
         config=config,
@@ -992,6 +999,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
         authorize_operation=authorize_operation,
         session_id="!room:example.org:call:one",
         enable_responder=True,
+        reconcile_spoken_response=reconcile_spoken_response,
         voice_instructions="Speak briefly.",
         active_model_name="call_fast",
     )
@@ -1004,7 +1012,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
 
     assert response.text == "It is sunny."
     assert response.tool_names == ("weather",)
-    assert response.turn_id is not None
+    assert (response.turn_id is not None) == reconcile_spoken_response
     assert recorded_tool_uses == [["weather"]]
     authorization_allowed = False
     denied = await tooling.responder("Run another turn", recorded_tool_uses.append)
@@ -1035,25 +1043,32 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
         runtime_paths=runtime_paths,
         execution_identity=execution_identity,
     )
-    assert tooling.finalize_spoken_response is not None
-    finalize = tooling.finalize_spoken_response(response.turn_id, "It is", True)
-    assert finalize is not None
-    await finalize
-    assert persisted_interruptions == [
-        {
-            "scope_context": SimpleNamespace(),
-            "session_id": "!room:example.org:call:one",
-            "run_id": "call-run-1",
-            "user_message": "What is the weather?",
-            "user_message_is_structured": False,
-            "partial_text": "It is",
-            "completed_tools": tuple(completed_tools),
-            "interrupted_tools": (),
-            "run_metadata": {"model": "same-chat-model"},
-            "is_team": False,
-            "original_status": RunStatus.cancelled,
-        },
-    ]
+    if reconcile_spoken_response:
+        assert tooling.finalize_spoken_response is not None
+        finalize = tooling.finalize_spoken_response(response.turn_id, "It is", True)
+        assert finalize is not None
+        await finalize
+    else:
+        assert tooling.finalize_spoken_response is None
+    assert persisted_interruptions == (
+        [
+            {
+                "scope_context": SimpleNamespace(),
+                "session_id": "!room:example.org:call:one",
+                "run_id": "call-run-1",
+                "user_message": "What is the weather?",
+                "user_message_is_structured": False,
+                "partial_text": "It is",
+                "completed_tools": tuple(completed_tools),
+                "interrupted_tools": (),
+                "run_metadata": {"model": "same-chat-model"},
+                "is_team": False,
+                "original_status": RunStatus.cancelled,
+            },
+        ]
+        if reconcile_spoken_response
+        else []
+    )
 
     async def cancel_before_playout(_turn: ResponseTurnContext, **cancel_kwargs: object) -> str:
         run_id_callback = cast("Callable[[str], None]", cancel_kwargs["run_id_callback"])
@@ -1089,12 +1104,16 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
 
     monkeypatch.setattr("mindroom.ai.ai_response", return_error_without_run_id)
     error_response = await tooling.responder("Trigger an error", recorded_tool_uses.append)
-    assert error_response.turn_id is not None
-    persist_error = tooling.finalize_spoken_response(error_response.turn_id, "provider failed", False)
-    assert persist_error is not None
-    await persist_error
+    if reconcile_spoken_response:
+        assert error_response.turn_id is not None
+        assert tooling.finalize_spoken_response is not None
+        persist_error = tooling.finalize_spoken_response(error_response.turn_id, "provider failed", False)
+        assert persist_error is not None
+        await persist_error
+    else:
+        assert error_response.turn_id is None
     assert str(persisted_interruptions[-1]["run_id"]).startswith("!room:example.org:call:one:turn:")
-    assert persisted_interruptions[-1]["partial_text"] == "provider failed"
+    assert persisted_interruptions[-1]["partial_text"] == ("provider failed" if reconcile_spoken_response else "")
     assert persisted_interruptions[-1]["original_status"] is RunStatus.error
 
     tool_filter = cast("Callable[[Function], bool]", kwargs["tool_function_filter"])

--- a/tests/test_matrix_rtc_live_voice_agent.py
+++ b/tests/test_matrix_rtc_live_voice_agent.py
@@ -1,0 +1,200 @@
+"""GPT-Live delegation preserves caller context and owns background work."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from livekit.agents.llm import ChatContext
+from livekit.plugins.openai.realtime import GPTLiveDelegation, GPTLiveSession
+
+from mindroom.matrix_rtc.call_tools import CallAgentResponse
+from mindroom.matrix_rtc.live_voice_agent import _LiveDelegationRunner
+from mindroom.matrix_rtc.voice_agent import LiveVoiceAgentOptions
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class CommentarySink:
+    """Capture the provider-bound commentary without opening a connection."""
+
+    def __init__(self) -> None:
+        self.results: list[tuple[str, str | None]] = []
+
+    def append_commentary(self, text: str, *, delegation_id: str | None = None) -> None:
+        """Record one outgoing provider message."""
+        self.results.append((text, delegation_id))
+
+
+def _options(respond: object, **kwargs: object) -> LiveVoiceAgentOptions:
+    return LiveVoiceAgentOptions(
+        instructions="Delegate tasks to the backend.",
+        model="gpt-live-1",
+        api_key="test-key",
+        voice="marin",
+        respond=respond,  # type: ignore[arg-type]
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_delegations_capture_new_context_and_pending_speech_once() -> None:
+    """Finalizing a previously pending utterance cannot repeat it next turn."""
+    respond = AsyncMock(return_value=CallAgentResponse("Sunny."))
+    sink = CommentarySink()
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", sink))
+    context = ChatContext.empty()
+    context.add_message(role="user", content="I am in Paris.")
+    runner.submit(GPTLiveDelegation("one", "What is the weather?"), context)
+    # The SDK finalizes this after emitting delegation_created.
+    context.add_message(role="user", content="What is the weather?")
+    await asyncio.gather(*runner._tasks)
+    context.add_message(role="assistant", content="It is sunny.")
+    runner.submit(GPTLiveDelegation("two", "And tomorrow?"), context)
+    runner.submit(GPTLiveDelegation("two", "And tomorrow?"), context)
+    await asyncio.gather(*runner._tasks)
+
+    assert respond.await_count == 2
+    first, second = [call.args[0] for call in respond.await_args_list]
+    assert first.count("What is the weather?") == 1
+    assert "I am in Paris." in first
+    assert "What is the weather?" not in second
+    assert "I am in Paris." not in second
+    assert "It is sunny." in second
+    assert "And tomorrow?" in second
+    assert sink.results == [("Sunny.", "one"), ("Sunny.", "two")]
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_serializes_responder_admission_and_cancels_queued_work() -> None:
+    """Only the active delegation enters the caller authorization boundary."""
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    requests: list[str] = []
+
+    async def respond(text: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        requests.append(text)
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+        return CallAgentResponse("unreachable")
+
+    sink = CommentarySink()
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", sink))
+    runner.submit(GPTLiveDelegation("one", "First task"), ChatContext.empty())
+    await started.wait()
+    runner.submit(GPTLiveDelegation("two", "Second task"), ChatContext.empty())
+    await runner.aclose()
+    runner.submit(GPTLiveDelegation("three", "Late task"), ChatContext.empty())
+
+    assert cancelled.is_set()
+    assert len(requests) == 1
+    assert not runner._tasks
+    assert sink.results == []
+
+
+@pytest.mark.asyncio
+async def test_live_reconnect_discards_results_from_old_connection() -> None:
+    """Even a responder swallowing cancellation cannot send an obsolete ID."""
+    started = asyncio.Event()
+
+    async def respond(_text: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            return CallAgentResponse("stale result")
+        return CallAgentResponse("unreachable")
+
+    sink = CommentarySink()
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", sink))
+    runner.submit(GPTLiveDelegation("old", "Check status"), ChatContext.empty())
+    await started.wait()
+    runner.on_reconnected()
+    await asyncio.gather(*runner._tasks)
+
+    assert sink.results == []
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_pending_speech_growth_only_delegates_new_words() -> None:
+    """Multiple delegations during one unfinished utterance share its prefix."""
+    respond = AsyncMock(return_value=CallAgentResponse("Done."))
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", CommentarySink()))
+    runner.submit(GPTLiveDelegation("one", "Check weather"), ChatContext.empty())
+    runner.submit(GPTLiveDelegation("two", "Check weather and trains"), ChatContext.empty())
+    await asyncio.gather(*runner._tasks)
+    assert "Check weather" in respond.await_args_list[0].args[0]
+    assert "Check weather" not in respond.await_args_list[1].args[0]
+    assert "and trains" in respond.await_args_list[1].args[0]
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_reconnect_retains_context_from_cancelled_queue() -> None:
+    """A snapshot queued behind a cancelled request has never reached history."""
+    started = asyncio.Event()
+
+    async def wait_for_cancel(_text: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        started.set()
+        await asyncio.Event().wait()
+        return CallAgentResponse("unreachable")
+
+    respond = AsyncMock(side_effect=wait_for_cancel)
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", CommentarySink()))
+    runner.submit(GPTLiveDelegation("one", "First"), ChatContext.empty())
+    await started.wait()
+    context = ChatContext.empty()
+    context.add_message(role="user", content="Also check train times.")
+    runner.submit(GPTLiveDelegation("queued", ""), context)
+    runner.on_reconnected()
+    await asyncio.gather(*runner._tasks, return_exceptions=True)
+    respond.side_effect = None
+    respond.return_value = CallAgentResponse("Done.")
+    runner.submit(GPTLiveDelegation("new", "Please continue."), context)
+    await asyncio.gather(*runner._tasks)
+    assert "Also check train times." in respond.await_args.args[0]
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_splits_large_unicode_results_without_losing_content() -> None:
+    """Provider commentary stays below the per-append token cap."""
+    result = "Status: 晴れです。 " * 200
+    sink = CommentarySink()
+    respond = AsyncMock(return_value=CallAgentResponse(result))
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", sink))
+    runner.submit(GPTLiveDelegation("one", "Give details"), ChatContext.empty())
+    await asyncio.gather(*runner._tasks)
+
+    assert "".join(text for text, _ in sink.results) == result
+    assert all(len(text.encode("utf-8")) <= 480 for text, _ in sink.results)
+    assert all(identifier == "one" for _, identifier in sink.results)
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_delegation_failure_returns_safe_notice_and_next_turn_works() -> None:
+    """A provider exception neither leaks its payload nor poisons the queue."""
+    respond = AsyncMock(side_effect=[ValueError("private-token"), CallAgentResponse("Done.")])
+    notices: list[str] = []
+    sink = CommentarySink()
+    runner = _LiveDelegationRunner(
+        _options(respond, on_session_error=notices.append),
+        cast("GPTLiveSession", sink),
+    )
+    runner.submit(GPTLiveDelegation("one", "First"), ChatContext.empty())
+    runner.submit(GPTLiveDelegation("two", "Second"), ChatContext.empty())
+    await asyncio.gather(*runner._tasks)
+
+    assert len(notices) == 1
+    assert "private-token" not in str(notices) + str(sink.results)
+    assert sink.results[-1] == ("Done.", "two")
+    await runner.aclose()

--- a/tests/test_matrix_rtc_live_voice_agent.py
+++ b/tests/test_matrix_rtc_live_voice_agent.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 from livekit.agents.llm import ChatContext
 from livekit.plugins.openai.realtime import GPTLiveDelegation, GPTLiveSession
+from structlog.testing import capture_logs
 
 from mindroom.matrix_rtc.call_tools import CallAgentResponse
 from mindroom.matrix_rtc.live_voice_agent import _LiveDelegationRunner
@@ -190,11 +191,15 @@ async def test_live_delegation_failure_returns_safe_notice_and_next_turn_works()
         _options(respond, on_session_error=notices.append),
         cast("GPTLiveSession", sink),
     )
-    runner.submit(GPTLiveDelegation("one", "First"), ChatContext.empty())
-    runner.submit(GPTLiveDelegation("two", "Second"), ChatContext.empty())
-    await asyncio.gather(*runner._tasks)
+    with capture_logs() as logs:
+        runner.submit(GPTLiveDelegation("one", "First"), ChatContext.empty())
+        runner.submit(GPTLiveDelegation("two", "Second"), ChatContext.empty())
+        await asyncio.gather(*runner._tasks)
 
     assert len(notices) == 1
-    assert "private-token" not in str(notices) + str(sink.results)
+    assert "private-token" not in str(notices) + str(sink.results) + str(logs)
+    failure = next(entry for entry in logs if entry["event"] == "call_live_delegation_failed")
+    assert failure["error_type"] == "ValueError"
+    assert any("live_voice_agent.py:" in frame for frame in failure["traceback_frames"])
     assert sink.results[-1] == ("Done.", "two")
     await runner.aclose()

--- a/tests/test_matrix_rtc_live_voice_agent.py
+++ b/tests/test_matrix_rtc_live_voice_agent.py
@@ -71,6 +71,51 @@ async def test_live_delegations_capture_new_context_and_pending_speech_once() ->
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("pending", [False, True], ids=["finalized", "pending"])
+@pytest.mark.parametrize(
+    "first_result",
+    [CallAgentResponse("", tool_names=("send_message",)), RuntimeError("failed after an action")],
+    ids=["empty-result", "partial-failure"],
+)
+async def test_live_dispatched_request_cannot_replay_an_action(
+    first_result: CallAgentResponse | Exception,
+    pending: bool,
+) -> None:
+    """An attempted request may have side effects even without a response text."""
+    respond = AsyncMock(side_effect=[first_result, CallAgentResponse("Done.")])
+    runner = _LiveDelegationRunner(_options(respond), cast("GPTLiveSession", CommentarySink()))
+    context = ChatContext.empty()
+    if not pending:
+        context.add_message(role="user", content="Send the update.")
+    runner.submit(GPTLiveDelegation("one", "Send the update." if pending else ""), context)
+    if pending:
+        context.add_message(role="user", content="Send the update.")
+    context.add_message(role="user", content="What is the weather?")
+    runner.submit(GPTLiveDelegation("two", ""), context)
+    await asyncio.gather(*runner._tasks)
+
+    assert "Send the update." in respond.await_args_list[0].args[0]
+    assert "Send the update." not in respond.await_args_list[1].args[0]
+    assert "What is the weather?" in respond.await_args_list[1].args[0]
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_empty_result_still_answers_without_claiming_completion() -> None:
+    """An empty result also represents denied work, so it cannot claim success."""
+    sink = CommentarySink()
+    runner = _LiveDelegationRunner(
+        _options(AsyncMock(return_value=CallAgentResponse(""))),
+        cast("GPTLiveSession", sink),
+    )
+    runner.submit(GPTLiveDelegation("one", "Perform a task."), ChatContext.empty())
+    await asyncio.gather(*runner._tasks)
+
+    assert sink.results == [("No response is available from the agent for this request.", "one")]
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
 async def test_live_serializes_responder_admission_and_cancels_queued_work() -> None:
     """Only the active delegation enters the caller authorization boundary."""
     started = asyncio.Event()

--- a/tests/test_matrix_rtc_live_voice_sdk.py
+++ b/tests/test_matrix_rtc_live_voice_sdk.py
@@ -1,0 +1,287 @@
+"""Exercise GPT-Live through the installed SDK with in-memory provider transport."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+from livekit.plugins.openai.realtime import GPTLiveSession
+
+from mindroom.matrix_rtc.call_tools import CallAgentResponse
+from mindroom.matrix_rtc.live_voice_agent import LiveVoiceBridge
+from mindroom.matrix_rtc.voice_agent import LiveVoiceAgentOptions, RealtimeVoiceBridge
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from livekit.agents import Agent, AgentSession
+
+
+class _ProviderSocket:
+    """Model the server handshake and capture actual serialized client commands."""
+
+    def __init__(self) -> None:
+        self.incoming: asyncio.Queue[aiohttp.WSMessage] = asyncio.Queue()
+        self.outgoing: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.sent: list[dict[str, Any]] = []
+        self.closed = False
+        self.closed_event = asyncio.Event()
+
+    def feed(self, event: dict[str, Any]) -> None:
+        """Deliver a raw provider event through the SDK's receive loop."""
+        self.incoming.put_nowait(aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, json.dumps(event), ""))
+
+    async def receive(self) -> aiohttp.WSMessage:
+        """Wait until the test or handshake produces another server event."""
+        return await self.incoming.get()
+
+    async def send_str(self, data: str) -> None:
+        """Accept a serialized SDK command and answer lifecycle commands."""
+        event = json.loads(data)
+        self.sent.append(event)
+        self.outgoing.put_nowait(event)
+        if event["type"] == "session.start":
+            self.feed({"type": "session.started", "session": {"id": "session-test"}})
+        elif event["type"] == "session.close":
+            self.feed({"type": "session.closed", "reason": "close_requested"})
+
+    async def close(self) -> None:
+        """Record that the SDK closed its socket."""
+        self.closed = True
+        self.closed_event.set()
+
+    async def next_event(self, event_type: str) -> dict[str, Any]:
+        """Wait briefly for one named command, ignoring unrelated commands."""
+        async with asyncio.timeout(2):
+            while True:
+                event = await self.outgoing.get()
+                if event["type"] == event_type:
+                    return event
+
+
+class _ProviderHTTP:
+    """Replace the external HTTP client while preserving SDK client ownership."""
+
+    def __init__(self) -> None:
+        self.socket = _ProviderSocket()
+        self.sockets = [self.socket]
+        self.connected_again = asyncio.Event()
+        self.closed = False
+        self.connection: tuple[str, dict[str, str]] | None = None
+
+    async def ws_connect(self, *, url: str, headers: dict[str, str]) -> _ProviderSocket:
+        """Capture the endpoint and credentials selected by the real model."""
+        if self.connection is not None:
+            self.sockets.append(_ProviderSocket())
+            self.connected_again.set()
+        self.connection = (url, headers)
+        return self.sockets[-1]
+
+    async def close(self) -> None:
+        """Record release of the model-owned HTTP client."""
+        self.closed = True
+
+
+@pytest.fixture
+def provider(monkeypatch: pytest.MonkeyPatch) -> _ProviderHTTP:
+    """Keep model/session logic real and replace external transport only."""
+    client = _ProviderHTTP()
+    monkeypatch.setattr(aiohttp, "ClientSession", lambda: client)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://other-provider.example.org/v1")
+
+    async def start_headless(
+        bridge: RealtimeVoiceBridge,
+        session: AgentSession,
+        agent: Agent,
+        options: LiveVoiceAgentOptions,
+        **_kwargs: object,
+    ) -> None:
+        # The shared media bridge has separate room/roster tests. Run the actual
+        # AgentSession here without an SFU or audio hardware.
+        bridge._session = session
+        bridge._register_session_listeners(session, options)
+        await session.start(agent)
+
+    monkeypatch.setattr(RealtimeVoiceBridge, "_start_session", start_headless)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_live_sdk_routes_delegation_and_closes_owned_work(provider: _ProviderHTTP) -> None:
+    """Wrong delegation mode or listener wiring prevents a real provider-bound reply."""
+    prompts: list[str] = []
+    transcript: list[tuple[str, str]] = []
+    order: list[str] = []
+    second_started = asyncio.Event()
+
+    async def respond(prompt: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            return CallAgentResponse("The task is complete.")
+        second_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            order.append("delegate_cancelled")
+        return CallAgentResponse("unreachable")
+
+    async def close_responder() -> None:
+        order.append("responder_closed")
+
+    options = LiveVoiceAgentOptions(
+        instructions="Delegate substantive requests to the configured agent.",
+        model="gpt-live-1",
+        api_key="test-api-key",
+        voice="vesper",
+        respond=respond,
+        close_responder=close_responder,
+        on_conversation_turn=lambda speaker, text: transcript.append((speaker, text)),
+    )
+    bridge = LiveVoiceBridge(local_identity="@bot:example.org:DEVICE", e2ee_enabled=False)
+    room = SimpleNamespace(disconnect=AsyncMock())
+    bridge._room = room
+    try:
+        await bridge.start_agent(options)
+        start = await provider.socket.next_event("session.start")
+        assert start["session"]["model"] == "gpt-live-1"
+        assert start["session"]["audio"]["output"]["voice"] == "vesper"
+        assert start["session"]["instructions"] == options.instructions
+        assert start["session"]["delegation"] == {"type": "client"}
+        assert provider.connection is not None
+        url, headers = provider.connection
+        assert url == "wss://api.openai.com/v1/live/sessions"
+        assert headers["Authorization"] == "Bearer test-api-key"
+
+        agent = cast("Agent", bridge._live_agent)
+        assert isinstance(agent.duplex_session, GPTLiveSession)
+        provider.socket.feed(
+            {"type": "session.input_transcript.delta", "delta": "Check status.", "start_ms": 0, "end_ms": 100},
+        )
+        provider.socket.feed({"type": "session.delegation.created", "delegation": {"id": "first", "target": "client"}})
+        reply = await provider.socket.next_event("session.commentary.append")
+        assert reply["delegation_id"] == "first"
+        assert reply["content"] == "The task is complete."
+        assert "Check status." in prompts[0]
+
+        provider.socket.feed(
+            {"type": "session.input_transcript.delta", "delta": "Check again.", "start_ms": 2000, "end_ms": 2100},
+        )
+        provider.socket.feed({"type": "session.delegation.created", "delegation": {"id": "second", "target": "client"}})
+        await asyncio.wait_for(second_started.wait(), timeout=2)
+        assert ("user", "Check status.") in transcript
+    finally:
+        await asyncio.wait_for(bridge.aclose(), timeout=3)
+
+    assert order == ["delegate_cancelled", "responder_closed"]
+    assert provider.socket.closed
+    assert provider.closed
+    room.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_live_sdk_configuration_failure_releases_owned_resources(
+    provider: _ProviderHTTP,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected SDK startup must not retain its HTTP client or cached responder."""
+
+    async def reject_configuration(_session: GPTLiveSession, _instructions: str) -> None:
+        message = "provider configuration rejected"
+        raise RuntimeError(message)
+
+    monkeypatch.setattr(GPTLiveSession, "_update_instructions", reject_configuration)
+    close_responder = AsyncMock()
+    options = LiveVoiceAgentOptions(
+        instructions="Delegate requests.",
+        model="gpt-live-1",
+        api_key="test-api-key",
+        voice="marin",
+        respond=AsyncMock(),
+        close_responder=close_responder,
+    )
+    bridge = LiveVoiceBridge(local_identity="@bot:example.org:DEVICE", e2ee_enabled=False)
+    room = SimpleNamespace(disconnect=AsyncMock())
+    bridge._room = room
+    try:
+        with pytest.raises(RuntimeError, match="provider configuration rejected"):
+            await bridge.start_agent(options)
+    finally:
+        await asyncio.wait_for(bridge.aclose(), timeout=3)
+
+    assert provider.socket.closed
+    assert provider.closed
+    close_responder.assert_awaited_once()
+    room.disconnect.assert_awaited_once()
+    assert bridge._session is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("service_closed", [False, True], ids=["socket-loss", "session-expired"])
+async def test_live_sdk_disconnect_returns_control_without_reusing_delegations(
+    provider: _ProviderHTTP,
+    service_closed: bool,
+) -> None:
+    """Reconnect must belong to the call manager, never reuse old provider delegation IDs."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = asyncio.Event()
+    terminated = asyncio.Event()
+    terminal_retries: list[bool] = []
+
+    async def respond(_prompt: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        started.set()
+        # A backend that finishes despite cancellation still cannot deliver
+        # a result tagged with an obsolete provider delegation ID.
+        with contextlib.suppress(asyncio.CancelledError):
+            await release.wait()
+        finished.set()
+        return CallAgentResponse("Late result from the disconnected session.")
+
+    def on_terminated(retryable: bool) -> None:
+        terminal_retries.append(retryable)
+        terminated.set()
+
+    options = LiveVoiceAgentOptions(
+        instructions="Delegate requests.",
+        model="gpt-live-1",
+        api_key="test-api-key",
+        voice="marin",
+        respond=respond,
+        on_session_terminated=on_terminated,
+    )
+    bridge = LiveVoiceBridge(local_identity="@bot:example.org:DEVICE", e2ee_enabled=False)
+    bridge._room = SimpleNamespace(disconnect=AsyncMock())
+    observers: list[asyncio.Task[bool]] = []
+    try:
+        await bridge.start_agent(options)
+        await provider.socket.next_event("session.start")
+        provider.socket.feed({"type": "session.input_transcript.delta", "delta": "Check status."})
+        provider.socket.feed(
+            {"type": "session.delegation.created", "delegation": {"id": "obsolete", "target": "client"}},
+        )
+        await asyncio.wait_for(started.wait(), timeout=2)
+        if service_closed:
+            provider.socket.feed({"type": "session.closed", "reason": "expired"})
+        provider.socket.incoming.put_nowait(aiohttp.WSMessage(aiohttp.WSMsgType.CLOSE, 1000, ""))
+        await asyncio.wait_for(provider.socket.closed_event.wait(), timeout=2)
+        release.set()
+        await asyncio.wait_for(finished.wait(), timeout=2)
+
+        observers = [asyncio.create_task(terminated.wait()), asyncio.create_task(provider.connected_again.wait())]
+        await asyncio.wait(observers, timeout=2, return_when=asyncio.FIRST_COMPLETED)
+        assert terminated.is_set(), "SDK must report terminal disconnect before opening another provider session"
+        assert terminal_retries == [True]
+        assert len(provider.sockets) == 1
+        assert not any(event.get("delegation_id") == "obsolete" for socket in provider.sockets for event in socket.sent)
+    finally:
+        release.set()
+        for observer in observers:
+            observer.cancel()
+        await asyncio.gather(*observers, return_exceptions=True)
+        await asyncio.wait_for(bridge.aclose(), timeout=3)

--- a/tests/test_matrix_rtc_live_voice_sdk.py
+++ b/tests/test_matrix_rtc_live_voice_sdk.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock
 
 import aiohttp
 import pytest
+from livekit import rtc
 from livekit.plugins.openai.realtime import GPTLiveSession
 
 from mindroom.matrix_rtc.call_tools import CallAgentResponse
@@ -21,6 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from livekit.agents import Agent, AgentSession
+    from livekit.agents.llm import InputTranscriptionCompleted
 
 
 class _ProviderSocket:
@@ -182,6 +184,75 @@ async def test_live_sdk_routes_delegation_and_closes_owned_work(provider: _Provi
     assert provider.socket.closed
     assert provider.closed
     room.disconnect.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("finalize_retry", [False, True], ids=["pending-retry", "finalized-retry"])
+async def test_live_sdk_identical_spoken_retry_survives_delegate_failure(
+    provider: _ProviderHTTP,
+    finalize_retry: bool,
+) -> None:
+    """A new utterance may repeat a failed request without losing its words."""
+    prompts: list[str] = []
+    transcript: list[tuple[str, str]] = []
+    retry_transcribed = asyncio.Event()
+
+    async def respond(prompt: str, _on_tools: Callable[[list[str]], None] | None) -> CallAgentResponse:
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            message = "delegated request failed"
+            raise RuntimeError(message)
+        return CallAgentResponse("Done.")
+
+    def on_transcribed(event: InputTranscriptionCompleted) -> None:
+        if not event.is_final:
+            retry_transcribed.set()
+
+    options = LiveVoiceAgentOptions(
+        instructions="Delegate requests.",
+        model="gpt-live-1",
+        api_key="test-api-key",
+        voice="marin",
+        respond=respond,
+        on_conversation_turn=lambda speaker, text: transcript.append((speaker, text)),
+    )
+    bridge = LiveVoiceBridge(local_identity="@bot:example.org:DEVICE", e2ee_enabled=False)
+    bridge._room = SimpleNamespace(disconnect=AsyncMock())
+    try:
+        await bridge.start_agent(options)
+        await provider.socket.next_event("session.start")
+        provider.socket.feed(
+            {"type": "session.input_transcript.delta", "delta": "Send the update.", "start_ms": 0, "end_ms": 100},
+        )
+        provider.socket.feed({"type": "session.delegation.created", "delegation": {"id": "first", "target": "client"}})
+        failure = await provider.socket.next_event("session.commentary.append")
+        assert failure["delegation_id"] == "first"
+        assert "could not complete" in failure["content"]
+
+        agent = cast("Agent", bridge._live_agent)
+        session = agent.duplex_session
+        assert isinstance(session, GPTLiveSession)
+        session.on("input_audio_transcription_completed", on_transcribed)
+        # The gap makes the SDK finalize the original before starting the
+        # identical retry. Both its transcript and delegation wiring stay real.
+        provider.socket.feed(
+            {"type": "session.input_transcript.delta", "delta": "Send the update.", "start_ms": 2000, "end_ms": 2100},
+        )
+        await asyncio.wait_for(retry_transcribed.wait(), timeout=2)
+        if finalize_retry:
+            session.push_audio(
+                rtc.AudioFrame(data=bytes(48000), sample_rate=24000, num_channels=1, samples_per_channel=24000),
+            )
+        assert transcript.count(("user", "Send the update.")) == 1 + int(finalize_retry)
+        provider.socket.feed({"type": "session.delegation.created", "delegation": {"id": "retry", "target": "client"}})
+        reply = await provider.socket.next_event("session.commentary.append")
+
+        assert reply["delegation_id"] == "retry"
+        assert reply["content"] == "Done."
+        assert len(prompts) == 2
+        assert all(prompt.count("Send the update.") == 1 for prompt in prompts)
+    finally:
+        await asyncio.wait_for(bridge.aclose(), timeout=3)
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3326,11 +3326,11 @@ wheels = [
 
 [[package]]
 name = "json-repair"
-version = "0.59.10"
+version = "0.60.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/7c/e95bb03068572146eba37e8175c760f470ea0a6097310e16bbf2bc6e6457/json_repair-0.59.10.tar.gz", hash = "sha256:2e4b85537c752d8a513ea28fdad891e5ede32c83de745366b97f648b8c34ede7", size = 49133, upload-time = "2026-05-14T06:41:51.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/87/49b20c6b81493d55c311f711ed87319d0fbad8bd0bbfbe36e52103af36bd/json_repair-0.59.10-py3-none-any.whl", hash = "sha256:5468fa3eaadcc9b4a5646776bc4176e2fe5f374b5848a15f468cce3b60e3db0e", size = 47742, upload-time = "2026-05-14T06:41:49.812Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
 ]
 
 [[package]]
@@ -3521,7 +3521,7 @@ wheels = [
 
 [[package]]
 name = "livekit"
-version = "1.1.12"
+version = "1.1.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3529,18 +3529,18 @@ dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2c/3e8412615a2f4b9abdd1dec54138f8810b58e1e5c366443c098d52ef1957/livekit-1.1.12.tar.gz", hash = "sha256:a8e3aa59a7299b136a2a5442f90a9c8a5a8188afe94ffeeb85873d6ceaabf939", size = 369150, upload-time = "2026-06-24T19:50:49.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/06/ed2cda99ce0c7f10f6599588b296d2bde08ec1235a97416e9986629ce131/livekit-1.1.18.tar.gz", hash = "sha256:1097b8613fa4625e3fb0bd4fe5b09a3b04b39151c08b78498831dfc57235d1d1", size = 386573, upload-time = "2026-09-08T01:50:55.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/6f/b2a1486f9f217043dbf52ed93bf6a77febd4d86615b02cddd7758a225f52/livekit-1.1.12-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:7fe82d7f2ef76ef6f7d856581f4519c2870fcffe3c33a8b2e74315d7c0bbdadc", size = 10140961, upload-time = "2026-06-24T19:50:38.69Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/de/656428ad72ce5b6911be2f084ead1e9c3b04d46015981de7e94177628a8d/livekit-1.1.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3c33d6b6df872447d3295443eb4886b84b6d6045ce8b3627504ee840ddf908fb", size = 8965085, upload-time = "2026-06-24T19:50:40.945Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ce/572f3f15571625ee9f99f103f2a13503797ed80636d70ce0dd58034e5e1d/livekit-1.1.12-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0f452415ec4c7c789bd99bc098dc19710f49249993b13335e5741de50fa423dc", size = 9974856, upload-time = "2026-06-24T19:50:43.329Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d7/5a798f8ef40889c8236a05d1a3985a77114c2c8f4584ac118987d6f8d9d5/livekit-1.1.12-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:19611fb5fa6bd1e6366acc7526aecab1c8fa2afe9e579f73d34df575c667aa53", size = 11359455, upload-time = "2026-06-24T19:50:45.654Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/45/f28e25888babc83a43769f428545c9ee781366a0ef22b4b479318c0f95bc/livekit-1.1.12-py3-none-win_amd64.whl", hash = "sha256:4e81a366a6c7a83b435d9de15760da70d4c13748b61eb8d5f000c9d279c8a39e", size = 10710076, upload-time = "2026-06-24T19:50:47.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b1/be04d760136480aa2d27f8247adc6d0a1e25395b146f04267fb8e716fe6a/livekit-1.1.18-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:8337e956e9816814572c964e7553d66e4845bc3299cb5aeab8a0d671e293ed32", size = 10471856, upload-time = "2026-09-08T01:50:41.85Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/60/a0bf23774eecfc012b60bae84f329537053a0e0952d6f43dc6154d01ac5b/livekit-1.1.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8557d6438da4b8968263b44920e7ab606a9ea34bc49fb8fd89054eb3e5cc162d", size = 9292804, upload-time = "2026-09-08T01:50:44.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/68/4b5e996660185f2db937a356c9e72981eab42c846f24ba992b997fa9f973/livekit-1.1.18-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:e9305aa097fe75f533db3205ab15868730e467130ffdda7d4adc3840f30b282a", size = 10584633, upload-time = "2026-09-08T01:50:47.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/5e/a0220ddf5e53bb3ee4f4969e9ca5e3a3e9567c584b66cd71355a45c069a8/livekit-1.1.18-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:dc2461b668ffa66ca504d05c88af7ea640372f53672ae367145412e374d6aff0", size = 11809468, upload-time = "2026-09-08T01:50:50.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/47/22455e01c76b271f7d9399546c2becabe4bf0f58a43e79859bb0ca4fc426/livekit-1.1.18-py3-none-win_amd64.whl", hash = "sha256:a61d4fd39392e7d28a7dbbe3b68be7b600115ed32501f5b016579846de945913", size = 10972019, upload-time = "2026-09-08T01:50:52.912Z" },
 ]
 
 [[package]]
 name = "livekit-agents"
-version = "1.6.4"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3576,9 +3576,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/a1/e681926fd3ddd3323a50b638e5c9f8d5cea68db0eaafcc040dbf65b5efeb/livekit_agents-1.6.4.tar.gz", hash = "sha256:deb1b47a1ab637c93ab675980bb4532fb01244604b41eda9d6e3ca268a52e794", size = 2561744, upload-time = "2026-06-24T20:49:24.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/f1/cc1fcbc24da6f90cf38809c5ceafff1a1d1c1527a32431ce9b00e64deb95/livekit_agents-1.8.1.tar.gz", hash = "sha256:9319b4a7cf3891db4c1de9edd98fad4918919beadb2ceff5b3fbd34ae67384b5", size = 2712687, upload-time = "2026-09-10T18:59:30.729Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/bb/c50992829fadd273fed66ae761f87ed4296fdd37eba0d0bc8c79cdddd896/livekit_agents-1.6.4-py3-none-any.whl", hash = "sha256:5341849645f768ed8bd1d276688f2b6ea0e72574e2aab7206d4e18c5628a97cd", size = 2669501, upload-time = "2026-06-24T20:49:22.119Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2c/29419a913c57b863eba93cbb41df2f3e58b57c3d8f790c6f97be81203ef7/livekit_agents-1.8.1-py3-none-any.whl", hash = "sha256:3e9e4e732ecebcf0512d5eec25621a365c3572289d1f136396d8a1c5ea78e2ac", size = 2832498, upload-time = "2026-09-10T18:59:28.67Z" },
 ]
 
 [package.optional-dependencies]
@@ -3595,7 +3595,7 @@ openai = [
 
 [[package]]
 name = "livekit-api"
-version = "1.1.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' or sys_platform != 'win32'" },
@@ -3605,9 +3605,9 @@ dependencies = [
     { name = "pyjwt" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/03/00e0ec173f247e1f7ea63cb5591d5680a64c7a74ea4d5d558e5aed6cc399/livekit_api-1.1.1.tar.gz", hash = "sha256:70c7b80eecbc297b40756ebd76e4f52d00b0348fb7d212a21c1f69cc57fd9c83", size = 15196, upload-time = "2026-06-24T01:36:19.686Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/0d/ff9502faa5e9785563e9648313a030fab65ed7f6ff8cf52d7bc6c9e01c97/livekit_api-1.2.1.tar.gz", hash = "sha256:eee78dba493b736bc8422660debc7cf89340f1b80c63890a36a18d99c938045c", size = 21780, upload-time = "2026-08-27T14:06:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c0/d5f3ff74ab5db2d06f173801ec934885d11a754b9fb9ad768c8ede0a6c89/livekit_api-1.1.1-py3-none-any.whl", hash = "sha256:ce8c327676c366e66cf68782934368dd0ba92b9d48f578275227e255c890fe88", size = 19471, upload-time = "2026-06-24T01:36:18.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c8/bc29cf16427fc446aa4487c552503cef42eebfcb920902bb54b7180e40d3/livekit_api-1.2.1-py3-none-any.whl", hash = "sha256:aa15b0a194c9e8167d4261bc61381682df23f98bc6d77760fcded93d2ce4b4ca", size = 27586, upload-time = "2026-08-27T14:06:56.286Z" },
 ]
 
 [[package]]
@@ -3639,50 +3639,50 @@ wheels = [
 
 [[package]]
 name = "livekit-local-inference"
-version = "0.2.6"
+version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/aa/7d6cfa6a2fe6baee8a443820d61b0e7df0cc7b9246762cab8f47c17ddcd3/livekit_local_inference-0.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb11919621cc542148ebed92408f0567b758057881c7e40d852d9738415a8eae", size = 34835713, upload-time = "2026-06-24T16:55:07.043Z" },
-    { url = "https://files.pythonhosted.org/packages/be/57/e284fb2663bceb78f24496edf6d9468c861797fd24e655381c17fafe300f/livekit_local_inference-0.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:274ea4046e24377e0744056db051c53976d04bd159c12f8c482246d44089ae79", size = 35100531, upload-time = "2026-06-24T16:55:10.65Z" },
-    { url = "https://files.pythonhosted.org/packages/76/6f/9a580a0d3f0c4bb63e7ab627467aeaf66980d21ea52e5946eb054e6f8150/livekit_local_inference-0.2.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425469dff5505b35a3fab587993b320c829826d041a85c17c53475f64b99f444", size = 34823583, upload-time = "2026-06-24T16:55:13.728Z" },
-    { url = "https://files.pythonhosted.org/packages/72/3d/c4a73813247faa704e9eef1cbf52ebc0f8070ad08b295419033ec3bcea5c/livekit_local_inference-0.2.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0cc28d6e2e1431940b37a8c6d931e4dac914806e2c874a05513db6b65a01d7e", size = 34868325, upload-time = "2026-06-24T16:55:16.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/44/4f5a633f962142480a54eff1e4aea96848e4b54972c617da65e234d51b7d/livekit_local_inference-0.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:5dc4a0574dc2e4a0745e8fcf29c26ca9f3983b885e63ada9761d26311a778d7b", size = 34906570, upload-time = "2026-06-24T16:55:19.914Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ae/5080f01d9c412a0702972efbfc8e4aca48f81baca494027aefcff5e4c8cc/livekit_local_inference-0.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:63beb204b64cdcbb3bc5b1caa1dbff2a9049998b6f897cf6b68285bb6b15926e", size = 34835783, upload-time = "2026-06-24T16:55:22.927Z" },
-    { url = "https://files.pythonhosted.org/packages/25/17/53ee00d6abf7b9c7ad9036356c38f40634aa83f74b8484f40678a92264ad/livekit_local_inference-0.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:26e397fe543abac838c12101267e46974afd268b6475642fdf116391eee8bd43", size = 35100553, upload-time = "2026-06-24T16:55:26.351Z" },
-    { url = "https://files.pythonhosted.org/packages/df/68/1fbbc4d22cbe28800380cdb1c51b8fadbf81bfacb0e966326fc7ee5c1298/livekit_local_inference-0.2.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:188457491cd59ed201d08ec3012fbc2a35d1fa5ac7bd4f4501553b16f5fc7d5b", size = 34823608, upload-time = "2026-06-24T16:55:29.4Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/7a/f62bc8dbdd6a4f32abe056bff1c4c4ad7ef30c780a43564594c72af120c2/livekit_local_inference-0.2.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10e1866f23ff6ee694a360e8a032078de3df189d100a748295c30fd1013aef34", size = 34868352, upload-time = "2026-06-24T16:55:32.611Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/86/cd258845ad0b52e3ba68f776f3bc40eebf03d1dde31b2bdcd4d0a1fcb46a/livekit_local_inference-0.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:69bc8976d8feef5a9c31e2c7bbd10d84e5494e1ecf85aedc75ebecef04fc9c08", size = 34906535, upload-time = "2026-06-24T16:55:35.78Z" },
-    { url = "https://files.pythonhosted.org/packages/33/1d/d17f9ca55285689a47d69534cd31543a96e64282be7ab9513590957e00e8/livekit_local_inference-0.2.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:bc4b3363dd307cf0b38203ef93d1750469db3bb1f99659ed40537fe473689761", size = 34836123, upload-time = "2026-06-24T16:55:38.902Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/3c/8b8921b77daed54c012588aa3419c56ebd71d975e292f4cc4b36baeec892/livekit_local_inference-0.2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:635904e6aef00fe2544bd55f1a526368fe7687f569a8d39c8f317b51e3539fe6", size = 35100892, upload-time = "2026-06-24T16:55:41.807Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/9a/7cdf1a77d5fd80e06533d4f2584c45d2c978f1249338969f814502db45ad/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80dc582413d816c86a0620410c2bfc3234e782a49d2b07b4bed0ff6285bdf4a1", size = 34824215, upload-time = "2026-06-24T16:55:45.02Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f2/0207071f236f639cf9515838ce98cfc3a8c1b19db8e6f46350e7231f2200/livekit_local_inference-0.2.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c148ec2735e903dc00e37dc2580e0417f67ec7ee4be119dca7844b104afbfe9", size = 34868380, upload-time = "2026-06-24T16:55:48.119Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/c194db20c8e9272cadf0913d42392cda5eec5e78a14820a3fa678e42e4b6/livekit_local_inference-0.2.6-cp314-cp314-win_amd64.whl", hash = "sha256:4140e4fd60dd7b7d69a55e1d454d5d893f8ffe026c30e0d7cd31fa42b10d5621", size = 34914243, upload-time = "2026-06-24T16:55:51.322Z" },
+    { url = "https://files.pythonhosted.org/packages/79/59/4a120c700508179d01af5525911acc044e2996d5fc86619896020b4fc41d/livekit_local_inference-0.2.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:86b64885254d554ca35483059e295bcf0281d7470b58301862e0367568633615", size = 34838988, upload-time = "2026-08-18T09:46:36.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/1a/0384f23dae195dca39fec32fb77fa5bf68bb022ca1648e9c1908b1228667/livekit_local_inference-0.2.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d66a509223e6e1f2ae77c52081969cafb49bd63d7bf4d50153f5bcdf52172865", size = 35096362, upload-time = "2026-08-18T09:46:38.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/29/18d7c360642e519124c8e5ae422dac36e22d74696a476edcc48fc6217d36/livekit_local_inference-0.2.7-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8fc1803a65654cc5061274a1aee067c584e2f0fd4ead85659f8f26ec06880f8", size = 34835065, upload-time = "2026-08-18T09:46:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/37/61/0b073e893274e461019516f8610029ceab74c06b9f6496b34be9ed704039/livekit_local_inference-0.2.7-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:449411e6cf01057e761588d6c19f1978d0ff652235d43de1780aa0b866b1435d", size = 34876716, upload-time = "2026-08-18T09:46:44.7Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/230770d450305c53cad880445d046c7f84c26507b61c50fe185ea15a29ca/livekit_local_inference-0.2.7-cp312-cp312-win_amd64.whl", hash = "sha256:5a497ed9dc7f11666b2226cf195c85bd12f511ad7d57dbd7857bec4c573b9031", size = 34877098, upload-time = "2026-08-18T09:46:47.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ff/01233367f526c67df021d5ee5ad0e7d229553ad7e90d5ae02d5afbdc7abb/livekit_local_inference-0.2.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5b23b2fca99fbf05d349b8c1c1e499d9154997214db15b6784a999783f63169a", size = 34839008, upload-time = "2026-08-18T09:46:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/45/9c70db9dc4581d9f2eecc04386bba3c8e74b6f438d2d6acb11aeaf66f96e/livekit_local_inference-0.2.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:866036cf42fce282404ecdad90bb2b814bc78aab245bc7be740e3cff528a36e8", size = 35096385, upload-time = "2026-08-18T09:46:53.359Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7d/0a981a4c7504fc4323a277d04705799fa48fbc036d368e47d5780c737341/livekit_local_inference-0.2.7-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f304cca187033b257cc8baf67f8799f5f467fa5f5984cdc3948591eb2027761b", size = 34835081, upload-time = "2026-08-18T09:46:55.883Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cc/858e2792eba28aa3baae1939488319f3bbef38c911cc0640f020bb0fe708/livekit_local_inference-0.2.7-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:454c451a4df153f5a9c8c7ba20e842dd5c77993103fd1c03194856d351be87dd", size = 34876656, upload-time = "2026-08-18T09:46:58.567Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/07/b85d8f18fd46f335a559f6d39f8acf07663510d1add19d1f31814ef7daf0/livekit_local_inference-0.2.7-cp313-cp313-win_amd64.whl", hash = "sha256:c16e86495346d8c349910ac8530de1e3532a6d1bac95ece0bc416c88f2a5c20f", size = 34877068, upload-time = "2026-08-18T09:47:01.317Z" },
+    { url = "https://files.pythonhosted.org/packages/92/78/fd54ef156b91123f7bfe3c04d4163619275c9b5b802f9c084fbff49913fa/livekit_local_inference-0.2.7-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4a10f4e2322a4a4dae679be292dece7bb7a94ac55c27ab9b6d7ed2c5ff1ce68f", size = 34839377, upload-time = "2026-08-18T09:47:03.831Z" },
+    { url = "https://files.pythonhosted.org/packages/77/f1/e1bef0798a102382afd9f041bcf16d96ea6e99ae4ad6956b292be7016cd5/livekit_local_inference-0.2.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dbb2c1d3b52d68914f6b469467cf1cdc56dcca06c7fb494995e692398f66d6e5", size = 35096694, upload-time = "2026-08-18T09:47:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2e/7b4ec0de0e5f1ef4c2f441a3047dda950c11d819fb1804e0a13c6ef68317/livekit_local_inference-0.2.7-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f122e205899c5393ef4a710beedfece7a166649afa5ccbdc3cca61f2df113efa", size = 34835765, upload-time = "2026-08-18T09:47:08.974Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c9/5cee5031e9ac2b545f6a68d2442bb02a3a6564f298d91f321448c1b59944/livekit_local_inference-0.2.7-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a97bc2932b73f72c5246cb8350cf2cd7d21fc6237053fc7c1ac645352ed0f3f", size = 34876770, upload-time = "2026-08-18T09:47:11.379Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/72/c2c956d1797bd944449fd90945ceea5dded222a54b2df8c967c77440298f/livekit_local_inference-0.2.7-cp314-cp314-win_amd64.whl", hash = "sha256:168c2f2dd55ee6dd94fd7caae0ff73e4875e25aa418df819905fd339de1de4cd", size = 34882427, upload-time = "2026-08-18T09:47:13.983Z" },
 ]
 
 [[package]]
 name = "livekit-plugins-openai"
-version = "1.6.4"
+version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "livekit-agents", extra = ["codecs", "images"] },
     { name = "openai", extra = ["realtime"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/63/d27b63ccf068c2a0cbfdede4e2173e3295ae8b795b36c150baf35c7ca97c/livekit_plugins_openai-1.6.4.tar.gz", hash = "sha256:d9e3f537f38e61fa36a44061d87fc4c7ad3e2a89cf2c7bb9d1d7fed0042bb068", size = 45310, upload-time = "2026-06-24T20:50:48.173Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/ed/009af02300c1e92b079e191607a8ec9f46a05444bfceec1f2e6040be02fe/livekit_plugins_openai-1.8.1.tar.gz", hash = "sha256:5a47f38f7a32710d35b1318375e34570a09369b239d0b387240dfd233b252a91", size = 70829, upload-time = "2026-09-10T19:00:34.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/a0/2ac8471ee3a09d297a34fb2a7cb10581bfdb1454f84020be16634193f91c/livekit_plugins_openai-1.6.4-py3-none-any.whl", hash = "sha256:5667a52e5158e9594c3b71a7da37961a0daf5bd2648f0055854bc1837372a47b", size = 52120, upload-time = "2026-06-24T20:50:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e2/70859510c158c2fc1ed67cc67e89cd9b55c00a5d652ddfbec68aafbcf50a/livekit_plugins_openai-1.8.1-py3-none-any.whl", hash = "sha256:16d9e1c1feaa06afde967853f3d28709bf5109a561e4ac3381641f1622a823e9", size = 79255, upload-time = "2026-09-10T19:00:33.342Z" },
 ]
 
 [[package]]
 name = "livekit-protocol"
-version = "1.1.19"
+version = "1.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/85/10aee7d87cf716ab06075836590616cb91d453251dac683cae73fe4b7122/livekit_protocol-1.1.19.tar.gz", hash = "sha256:81709e8bc47cdaf0cc5ba937bd9ec24a095e4978c58fb3d5e69b9888b9930be4", size = 118325, upload-time = "2026-07-08T17:21:10.707Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/49/733f3655717bd1bdccfbb4ab958ac7f51d7e17d37e61b98de2f6b2e0c107/livekit_protocol-1.1.26.tar.gz", hash = "sha256:de8d291abb2efd026fbe23394ee4c05358195f09102d3c13335978ba04d7bdb8", size = 123833, upload-time = "2026-08-28T17:15:50.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/20/98150dc45b9e92ab81a8eba74cdf544015b9291c4281252e2e76a7338462/livekit_protocol-1.1.19-py3-none-any.whl", hash = "sha256:fe5a8411c6cb886e55b2564d729f275af5d77ec191dd2ca95ffac3db16979a8a", size = 145513, upload-time = "2026-07-08T17:21:09.303Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/b9a9a04b921b1aaef9312c3a16523cd4ddb508dcc4be18ca0e300b750b7e/livekit_protocol-1.1.26-py3-none-any.whl", hash = "sha256:37db1272487518df2ce3e13624a5217d1e158c6832fe01166bb3fb1875a8ddd9", size = 150535, upload-time = "2026-08-28T17:15:48.535Z" },
 ]
 
 [[package]]
@@ -4585,7 +4585,7 @@ requires-dist = [
     { name = "json5", specifier = ">=0.13" },
     { name = "jsonschema", specifier = ">=4.26" },
     { name = "linkup-sdk", marker = "extra == 'linkup'", specifier = ">=0.2.8" },
-    { name = "livekit-agents", extras = ["openai"], marker = "extra == 'matrix-calls'", specifier = ">=1.6.4" },
+    { name = "livekit-agents", extras = ["openai"], marker = "extra == 'matrix-calls'", specifier = ">=1.8.1" },
     { name = "lumaai", marker = "extra == 'lumalabs'" },
     { name = "lxml-html-clean", marker = "extra == 'newspaper'" },
     { name = "markdown-it-py", specifier = ">=4" },
@@ -5405,7 +5405,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.44.0"
+version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -5417,9 +5417,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/9a/8c75e8c8a5b407a0586faeb2afac91674ff955c191ecc1d6d3b6669f6788/openai-2.54.0.tar.gz", hash = "sha256:e3e6f8bc1ba30ddf381ace1a14340eed381cb984a1a59bd0f34b5be3b5d49cfa", size = 1100285, upload-time = "2026-08-11T18:46:59.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a8/bb76c7356de8ad57f59d5ff993d434df0607f07f08bcc9c9a5c275e399c0/openai-2.54.0-py3-none-any.whl", hash = "sha256:89089789197ccdb87f173a03145ed1598d00795220c93e96cf712b1cbf5e5f2b", size = 1660351, upload-time = "2026-08-11T18:46:56.684Z" },
 ]
 
 [package.optional-dependencies]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -333,6 +333,7 @@ _.load_or_create_ingestion_consumer  # inactive checkpoint contract (src/mindroo
 _.bind_ingestion_stream  # inactive checkpoint contract (src/mindroom/event_journal/store.py)
 AudioInput  # type-only SDK interface for the custom MatrixRTC audio stream
 _.on_attached  # LiveKit AgentInput callback (src/mindroom/matrix_rtc/voice_agent.py)
+_.on_enter  # LiveKit Agent lifecycle callback (src/mindroom/matrix_rtc/live_voice_agent.py)
 _.on_detached  # LiveKit AgentInput callback (src/mindroom/matrix_rtc/voice_agent.py)
 _.validate_extra_kwargs  # Pydantic validator (src/mindroom/config/voice.py)
 _.validate_host  # Pydantic validator (src/mindroom/config/voice.py)


### PR DESCRIPTION
Add a `live` MatrixRTC call backend using GPT-Live-1 through LiveKit 1.8.1. Voice sessions delegate substantive requests to the normal MindRoom agent, preserving requester authorization, tools, model resolution, and history. Profiles select an explicit OpenAI credential and voice, with an optional `agent_model` alias for delegated work.

The bridge snapshots incremental voice context, serializes delegated turns, and cancels work when a call ends. MindRoom owns reconnects with fresh provider sessions so obsolete delegation replies cannot cross connections. Backend results remain separate from the spoken transcript.

Validation: the full suite passed with 18,085 tests and 22 skips. All 18 Live tests, including two additional identical-retry regressions, passed; all repository pre-commit hooks passed. Real LiveKit SDK tests with in-memory transport cover delegation, strict OpenAI endpoint selection, startup failure, cancellation, retries, and abrupt or graceful disconnects. Independent architecture review found no material changes needed.

A real OpenAI smoke test using synthetic speech verified the greeting, client delegation to a MindRoom-created GPT-Terra agent, a calculator tool call, and spoken output of 703 for 37 × 19. The test used headless media input; production Matrix/SFU calls were not part of this provider test.

## Summary by Sourcery

Add GPT-Live voice calls that delegate substantive requests to the normal authorized MindRoom agent while safely managing session lifecycle and reconnects.

New Features:
- Add an OpenAI Live voice-call backend that delegates substantive requests to the normal MindRoom agent.
- Support explicit Live voice credentials and voice selection, with optional configured model aliases for delegated agent turns.
- Preserve authorized caller context, agent history, tools, and model resolution across voice delegations and media reconnects.

Bug Fixes:
- Prevent stale, cancelled, or failed delegation results from crossing provider reconnects or being replayed.
- Keep delegated backend results separate from spoken-response reconciliation and safely handle provider shutdowns.

Enhancements:
- Upgrade the LiveKit Agents OpenAI dependency to version 1.8.1.
- Serialize Live delegations and manage cancellation, session generations, and resource cleanup across call lifecycle events.

Documentation:
- Document the Live backend configuration, credential requirements, model selection, delegation behavior, and reconnect semantics.

Tests:
- Add configuration, call-manager, delegation, and real LiveKit SDK transport coverage for authorization, endpoint selection, startup failure, cancellation, and disconnect handling.

Chores:
- Update generated voice-call documentation references and module dependency metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenAI Live voice calls alongside existing voice backends.
  * Live calls can delegate substantive requests to a configured MindRoom agent.
  * Added configuration for Live voice, credentials, voice selection, and optional delegated agent models.
  * Added validation for Live call profiles and delegated model references.
* **Documentation**
  * Added setup guidance, configuration examples, session behavior, and model-resolution details for OpenAI Live calls.
* **Bug Fixes**
  * Improved handling of spoken-response reconciliation and interrupted or failed voice-call turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
