### PR TITLE
Allow four concurrent knowledge reader processes

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -472,7 +472,7 @@ The storage path defaults to `mindroom_data/` next to your `config.yaml`, or can
 Published semantic searches and collection probes run in short-lived subprocesses.
 Embedding credentials and provider health stay in the application; query vectors, filters, and document data cross the typed read boundary.
 Each child exits after one operation, releasing its native Chroma memory.
-At most two read children run at once, with a 30-second timeout.
+At most four read children run at once, with a 30-second timeout.
 Async searches start the child while the parent obtains the query embedding, overlapping provider latency with child imports.
 Their deadline covers both embedding and native execution; synchronous searches and collection probes use the deadline for native execution.
 Queries spanning multiple bases search those bases sequentially so one query cannot exhaust the child limit.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14269,7 +14269,7 @@ The storage path defaults to `mindroom_data/` next to your `config.yaml`, or can
 Published semantic searches and collection probes run in short-lived subprocesses.
 Embedding credentials and provider health stay in the application; query vectors, filters, and document data cross the typed read boundary.
 Each child exits after one operation, releasing its native Chroma memory.
-At most two read children run at once, with a 30-second timeout.
+At most four read children run at once, with a 30-second timeout.
 Async searches start the child while the parent obtains the query embedding, overlapping provider latency with child imports.
 Their deadline covers both embedding and native execution; synchronous searches and collection probes use the deadline for native execution.
 Queries spanning multiple bases search those bases sequentially so one query cannot exhaust the child limit.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -468,7 +468,7 @@ The storage path defaults to `mindroom_data/` next to your `config.yaml`, or can
 Published semantic searches and collection probes run in short-lived subprocesses.
 Embedding credentials and provider health stay in the application; query vectors, filters, and document data cross the typed read boundary.
 Each child exits after one operation, releasing its native Chroma memory.
-At most two read children run at once, with a 30-second timeout.
+At most four read children run at once, with a 30-second timeout.
 Async searches start the child while the parent obtains the query embedding, overlapping provider latency with child imports.
 Their deadline covers both embedding and native execution; synchronous searches and collection probes use the deadline for native execution.
 Queries spanning multiple bases search those bases sequentially so one query cannot exhaust the child limit.

--- a/src/mindroom/knowledge/read_process.py
+++ b/src/mindroom/knowledge/read_process.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 # https://github.com/chroma-core/chroma/pull/7692 and verifying lock waits no longer stall the application.
 
 # Avoid turning simultaneous searches into unbounded native index copies.
-_read_slots = BoundedSemaphore(2)
+_read_slots = BoundedSemaphore(4)
 _CHILD_ENV_KEYS = (
     "PATH",
     "HOME",

--- a/tests/test_knowledge_read_process.py
+++ b/tests/test_knowledge_read_process.py
@@ -338,9 +338,9 @@ async def test_native_error_logs_redacted_child_diagnostics(
 
 @pytest.mark.asyncio
 async def test_saturated_reads_leave_executor_available(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Two blocked native reads must not let queued reads starve unrelated application work."""
+    """Four blocked native reads must not let queued reads starve unrelated application work."""
     release = Event()
-    active = [Event(), Event()]
+    active = [Event() for _ in range(4)]
     started: list[int] = []
 
     def blocked_child(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[bytes]:
@@ -352,10 +352,10 @@ async def test_saturated_reads_leave_executor_available(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(subprocess, "run", blocked_child)
     loop = asyncio.get_running_loop()
-    with ThreadPoolExecutor(max_workers=4) as executor:
+    with ThreadPoolExecutor(max_workers=6) as executor:
         loop.set_default_executor(executor)
         tasks = [
-            asyncio.create_task(asyncio.to_thread(read_chroma, ReadRequest("unused", "published"))) for _ in range(4)
+            asyncio.create_task(asyncio.to_thread(read_chroma, ReadRequest("unused", "published"))) for _ in range(6)
         ]
         try:
             for _ in range(200):

--- a/tests/test_knowledge_read_process.py
+++ b/tests/test_knowledge_read_process.py
@@ -242,7 +242,7 @@ async def test_cancelled_embedding_reaps_child_and_releases_capacity(
             await asyncio.Event().wait()
             return [1.0, 0.0]
 
-    for _ in range(3):
+    for _ in range(5):
         embedding_started.clear()
         task = asyncio.create_task(
             ChromaReadProxy("published", str(published_index), BlockingEmbedder()).async_search("alpha"),
@@ -252,7 +252,7 @@ async def test_cancelled_embedding_reaps_child_and_releases_capacity(
         with pytest.raises(asyncio.CancelledError):
             await task
         assert capture_read_processes[-1].poll() is not None
-    assert len(capture_read_processes) == 3
+    assert len(capture_read_processes) == 5
     assert await ChromaReadProxy("published", str(published_index), _Embedder()).async_search("alpha")
 
 
@@ -267,11 +267,11 @@ async def test_stalled_embedding_deadline_reaps_child(
         await asyncio.Event().wait()
         return ReadRequest(str(published_index), "published", "alpha", [1.0, 0.0])
 
-    for _ in range(3):
+    for _ in range(5):
         with pytest.raises(TimeoutError, match="Knowledge read timed out"):
             await read_process.read_chroma_async(prepare_request, timeout=0.05)
         assert capture_read_processes[-1].poll() is not None
-    assert len(capture_read_processes) == 3
+    assert len(capture_read_processes) == 5
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_read_process.py
+++ b/tests/test_knowledge_read_process.py
@@ -114,17 +114,18 @@ async def test_search_preserves_document_fields_and_filters(published_index: Pat
 async def test_merged_search_covers_more_sources_than_reader_slots(published_index: Path) -> None:
     """One query must search every assigned base despite the native child limit."""
     with Client(settings=Settings(is_persistent=True, persist_directory=str(published_index))) as client:
-        for name in ("second", "third"):
+        for name in ("second", "third", "fourth", "fifth"):
             collection = client.create_collection(name)
             collection.add(ids=[name], embeddings=[[1.0, 0.0]], documents=[name], metadatas=[{"team": "a"}])
 
     merged = _MultiKnowledgeVectorDb(
         vector_dbs=[
-            ChromaReadProxy(name, str(published_index), _Embedder()) for name in ("published", "second", "third")
+            ChromaReadProxy(name, str(published_index), _Embedder())
+            for name in ("published", "second", "third", "fourth", "fifth")
         ],
     )
-    documents = await merged.async_search(query="alpha", limit=3, filters={"team": "a"})
-    assert [document.id for document in documents] == ["a", "second", "third"]
+    documents = await merged.async_search(query="alpha", limit=5, filters={"team": "a"})
+    assert [document.id for document in documents] == ["a", "second", "third", "fourth", "fifth"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allow four concurrent isolated Chroma reads so overlapping document and file-memory lookups are less likely to be rejected as busy. The process-wide bound, 30-second timeout, fail-fast saturation behavior, and child cleanup remain in place.

Update the existing saturation regression to occupy four slots, reject two excess reads, and verify unrelated executor work stays responsive. Expand the multi-source regression to five bases and the cancellation/timeout regressions to five cycles so they still detect capacity exhaustion and leaks. Synchronize the knowledge documentation and generated references.

Validation: the revised saturation test failed with the previous two-reader limit, then passed with four. All 30 knowledge-reader and import-boundary tests passed in the Nix development shell; repository pre-commit hooks passed. Two independent reviews approved the final commit with no findings.
