### PR TITLE
Decouple knowledge saturation test from reader capacity

### DIFF
--- a/tests/test_knowledge_collections.py
+++ b/tests/test_knowledge_collections.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from threading import Barrier
+from threading import Barrier, BoundedSemaphore
 from typing import TYPE_CHECKING, Never
 
 import pytest
@@ -282,14 +282,17 @@ def test_concurrent_cold_lookups_keep_returned_readers_queryable(
 @pytest.mark.parametrize("cached", [False, True])
 def test_busy_published_lookup_reports_unavailable_then_recovers(
     published_lookup: tuple[Config, RuntimePaths],
+    monkeypatch: pytest.MonkeyPatch,
     cached: bool,
 ) -> None:
     """Reader saturation stays a per-base availability result, including cached handles."""
+    # Exercise saturation independently of the production reader capacity.
+    monkeypatch.setattr("mindroom.knowledge.read_process._read_slots", BoundedSemaphore(1))
     config, runtime_paths = published_lookup
     if cached:
         assert resolve_knowledge_base_access("docs", config, runtime_paths).knowledge is not None
 
-    with _read_slot(), _read_slot():
+    with _read_slot():
         busy = resolve_knowledge_base_access("docs", config, runtime_paths)
         assert busy.knowledge is None
         assert busy.availability is KnowledgeAvailability.REFRESH_FAILED


### PR DESCRIPTION
The published-lookup saturation test assumed that holding two reader slots exhausted the pool. Increasing the production limit to four left both cached and uncached cases unsaturated, causing the test failures after #2005.

Give this test its own real one-slot semaphore and occupy that slot before checking unavailable/recovered behavior. The existing reader-process saturation test continues to verify the four-reader production limit. No production code changes.

Validation: reproduced both failures before the fix; all 679 knowledge, file-memory knowledge, knowledge API, and import-boundary tests now pass in the Nix development shell. Repository pre-commit hooks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for busy knowledge lookups by simulating reader saturation.
  * Updated the recovery test to validate unavailable responses and subsequent recovery with a single reader slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->