### PR TITLE
Prevent event-loop stalls from export validation and URL redaction

### DIFF
--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -31,7 +31,13 @@ _MAX_DEPTH = 32
 # URI grammar rather than of HTTP, and the schemes that carry the most damaging
 # ones here are database URLs: `postgresql://user:password@host/db` reaches logs
 # and audit records through exactly the same paths an API URL does.
-_URL_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9+.-]*://[^\s'\"<>]+")
+# Start once per scheme-character run, avoiding quadratic suffix rescans.
+# Preserve leading non-letters while still redacting embedded URLs such as
+# ``123https://user:password@host`` that the unanchored scan recognized.
+_URL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9+.-])(?P<prefix>[0-9+.-]*+)"
+    r"(?P<url>[A-Za-z][A-Za-z0-9+.-]*+://[^\s'\"<>]+)",
+)
 _BEARER_TOKEN_PATTERN = re.compile(
     r"(?P<prefix>(?:authorization(?:\s+header)?(?:\s*:)?\s+)?bearer(?:\s+token)?\s+)"
     r"(?P<token>[A-Za-z0-9._~+/=-]+)",
@@ -473,10 +479,10 @@ def _redact_url_match(match: re.Match[str]) -> str:
     content. Absorbing it into the query re-encodes it to ``%5C`` and strips
     the escape, which corrupts the surrounding encoding.
     """
-    matched_url = match.group(0)
+    matched_url = match.group("url")
     url = matched_url.rstrip("\\")
     trailing_backslashes = matched_url[len(url) :]
-    return _redact_url(url) + trailing_backslashes
+    return match.group("prefix") + _redact_url(url) + trailing_backslashes
 
 
 def _redact_sensitive_text(value: str, *, max_length: int | None) -> str:

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -139,23 +139,23 @@ def _validated_targets(
         accumulator.target = replace(accumulator.target, output_dir=output_dir)
         candidates.append((accumulator, resolved_output_dir))
 
-    overlaps: dict[int, list[Path]] = {}
-    for index, (_, resolved_output_dir) in enumerate(candidates):
-        for other_index in range(index + 1, len(candidates)):
-            other_accumulator, other_resolved_output_dir = candidates[other_index]
-            if not (
-                resolved_output_dir == other_resolved_output_dir
-                or resolved_output_dir.is_relative_to(other_resolved_output_dir)
-                or other_resolved_output_dir.is_relative_to(resolved_output_dir)
-            ):
-                continue
-            overlaps.setdefault(index, []).append(other_accumulator.target.output_dir)
-            overlaps.setdefault(other_index, []).append(candidates[index][0].target.output_dir)
+    overlaps: dict[int, list[int]] = {}
+    ancestors: list[tuple[int, Path]] = []
+    # Path ordering groups descendants after their ancestors. Each disjoint
+    # root leaves the stack once, avoiding all-pairs checks on every export.
+    for index, (_, resolved_output_dir) in sorted(enumerate(candidates), key=lambda item: item[1][1]):
+        while ancestors and not resolved_output_dir.is_relative_to(ancestors[-1][1]):
+            ancestors.pop()
+        for other_index, _ in ancestors:
+            overlaps.setdefault(index, []).append(other_index)
+            overlaps.setdefault(other_index, []).append(index)
+        ancestors.append((index, resolved_output_dir))
 
     prepared: list[ThreadExportAccumulator] = []
     for index, (accumulator, resolved_output_dir) in enumerate(candidates):
         if overlapping := overlaps.get(index):
-            conflicting = ", ".join(str(path) for path in overlapping)
+            overlapping_output_dirs = [candidates[other][0].target.output_dir for other in sorted(overlapping)]
+            conflicting = ", ".join(str(path) for path in overlapping_output_dirs)
             accumulator.failed_items.append(
                 failure_for_target(
                     f"output directory resolving to {resolved_output_dir} "
@@ -166,7 +166,7 @@ def _validated_targets(
                 "Skipping thread export target with overlapping output directory",
                 output_dir=str(accumulator.target.output_dir),
                 resolved_output_dir=str(resolved_output_dir),
-                overlapping_output_dirs=[str(path) for path in overlapping],
+                overlapping_output_dirs=[str(path) for path in overlapping_output_dirs],
             )
             continue
         try:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -128,12 +128,13 @@ def test_url_redaction_preserves_text_before_a_credential_bearing_scheme(prefix:
 def test_url_redaction_does_not_rescan_every_suffix_of_non_url_text(run: str) -> None:
     """A long scheme-like run before a real URL must not occupy the GIL for seconds."""
     value = f"{run} https://example.test/path?token=synthetic-secret"
-    start = time.perf_counter()
+    # Exclude time when a loaded runner deschedules this thread.
+    start = time.thread_time()
 
     assert redact_sensitive_data({"content": value}) == {
         "content": f"{run} https://example.test/path?token={REDACTED}",
     }
-    assert time.perf_counter() - start < 1.0
+    assert time.thread_time() - start < 1.0
 
 
 def test_redact_url_in_escaped_shell_command_keeps_json_arguments_valid() -> None:

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -115,6 +115,27 @@ def test_a_scheme_carrying_no_credentials_is_left_alone() -> None:
     assert redact_sensitive_text("postgresql://db.example:5432/journal") == "postgresql://db.example:5432/journal"
 
 
+@pytest.mark.parametrize("prefix", ["", "123", "+.-", "123+.-", "prefix=", "λ"])
+@pytest.mark.parametrize("scheme", ["https", "postgresql", "git+ssh"])
+def test_url_redaction_preserves_text_before_a_credential_bearing_scheme(prefix: str, scheme: str) -> None:
+    """A URL can follow digits or punctuation without losing its credential protection."""
+    value = f"{prefix}{scheme}://user:hunter2@example.test/path"
+
+    assert redact_sensitive_text(value) == f"{prefix}{scheme}://user:***@example.test/path"
+
+
+@pytest.mark.parametrize("run", ["x" * 64_000, "9x" * 32_000], ids=["letters", "mixed"])
+def test_url_redaction_does_not_rescan_every_suffix_of_non_url_text(run: str) -> None:
+    """A long scheme-like run before a real URL must not occupy the GIL for seconds."""
+    value = f"{run} https://example.test/path?token=synthetic-secret"
+    start = time.perf_counter()
+
+    assert redact_sensitive_data({"content": value}) == {
+        "content": f"{run} https://example.test/path?token={REDACTED}",
+    }
+    assert time.perf_counter() - start < 1.0
+
+
 def test_redact_url_in_escaped_shell_command_keeps_json_arguments_valid() -> None:
     """URL redaction must not eat the backslash escaping the quote after the URL.
 

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -302,6 +302,80 @@ async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tm
 
 
 @pytest.mark.asyncio
+async def test_disjoint_target_validation_uses_linear_ancestry_checks(tmp_path: Path) -> None:
+    """A growing set of workspaces must not trigger all-pairs ancestry checks."""
+    config = thread_export_config(tmp_path)
+    targets = tuple(
+        ThreadExportTarget(tmp_path / f"agent-{index}" / "workspace" / "thread_exports") for index in range(64)
+    )
+    ancestry_checks = 0
+    original_is_relative_to = Path.is_relative_to
+
+    def counted_is_relative_to(path: Path, other: Path) -> bool:
+        nonlocal ancestry_checks
+        ancestry_checks += 1
+        return original_is_relative_to(path, other)
+
+    with patch.object(Path, "is_relative_to", counted_is_relative_to):
+        stats = await export_threads_to_sources(
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            sources=(),
+            targets=targets,
+            full_pass=False,
+        )
+
+    assert len(stats) == len(targets)
+    assert all(item.failures == 0 for item in stats)
+    assert ancestry_checks <= 2 * len(targets)
+    assert all((target.output_dir / _ROOT_MARKER_FILENAME).is_file() for target in targets)
+
+
+@pytest.mark.asyncio
+async def test_mixed_target_overlaps_preserve_every_conflict_in_input_order(tmp_path: Path) -> None:
+    """Nested, duplicate and sibling roots retain complete ordered diagnostics."""
+    config = thread_export_config(tmp_path)
+    root = tmp_path / "exports"
+    output_dirs = (
+        root / "branch" / "leaf",
+        tmp_path / "exports-neighbor",
+        root / "sibling",
+        root,
+        root / "branch",
+        root,
+        tmp_path / "unique",
+    )
+    expected_conflicts = {
+        0: (3, 4, 5),
+        2: (3, 5),
+        3: (0, 2, 4, 5),
+        4: (0, 3, 5),
+        5: (0, 2, 3, 4),
+    }
+
+    stats = await export_threads_to_sources(
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        sources=(),
+        targets=tuple(ThreadExportTarget(output_dir) for output_dir in output_dirs),
+        full_pass=False,
+    )
+
+    assert tuple(item.output_dir for item in stats) == output_dirs
+    for index, item in enumerate(stats):
+        if index not in expected_conflicts:
+            assert item.failures == 0
+            assert (item.output_dir / _ROOT_MARKER_FILENAME).is_file()
+            continue
+        assert item.failures == 1
+        conflicting = ", ".join(str(output_dirs[other]) for other in expected_conflicts[index])
+        assert item.failed_items[0].error == (
+            f"output directory resolving to {output_dirs[index]} overlaps another enabled target: {conflicting}"
+        )
+    assert not root.exists()
+
+
+@pytest.mark.asyncio
 async def test_aliased_target_output_directories_are_all_skipped(tmp_path: Path) -> None:
     """A symlinked agent workspace must preserve the corpus both aliases resolve to."""
     config = thread_export_config(tmp_path)


### PR DESCRIPTION
Thread-export validation compared every pair of output directories, and URL redaction retried every suffix of long scheme-like text. Both paths could consume enough Python/GIL time to stall the shared asyncio loop; background export work also amplified repeated SQLite/GIL handoffs during synchronous durable preparation.

Replace the all-pairs scan with sorted ancestor tracking, preserving path isolation and complete conflict diagnostics in input order. Make URL matching scan each scheme-character run once, preserving credential redaction for URLs embedded after digits or punctuation.

Controlled synthetic reproductions on Python 3.13:

| Reproduction | Before | After |
| --- | ---: | ---: |
| Durable preparation for 200 encrypted rooms while validating 1,000 disjoint export targets, three runs | 4.27–7.65 s | 88–90 ms |
| Maximum event-loop heartbeat gap while redacting a 64 KB scheme-like run followed by a credential-bearing URL | 3.37 s | 3.9 ms |

The export reproduction uses real filesystem operations and the same 1,820 SQL calls before and after. These results cover the two reproduced stalls; they are not a concurrent-call capacity measurement.

Validation: regression tests cover scaling, ordered overlap diagnostics, embedded credential-bearing URLs, and long scheme-like input. Independent review found no issues; 5,000 synthetic path sets and 22,143 URL substitutions preserved the previous results. Full suite: 18,109 passed, 22 skipped (`uv run pytest -q -n 6 --no-cov --tb=short`). All hooks passed with `uv run pre-commit run --all-files`.

## Summary by Sourcery

Prevent synchronous export validation and URL redaction from monopolizing the event loop while preserving existing conflict reporting and sensitive-data protection.

Bug Fixes:
- Prevent event-loop stalls caused by inefficient export-target overlap validation and URL redaction on long scheme-like input.
- Preserve credential redaction for URLs embedded after digits or punctuation.

Enhancements:
- Replace quadratic export-directory comparisons with scalable ancestor-based validation while retaining complete, input-ordered conflict diagnostics.
- Optimize URL matching to scan scheme-like text without repeatedly rescanning suffixes.

Tests:
- Add regression coverage for linear export-target validation, ordered overlap diagnostics, embedded credential-bearing URLs, and long scheme-like input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL credential redaction across HTTPS, PostgreSQL, and Git SSH links while preserving preceding text.
  - Improved handling of long, scheme-like text to maintain responsive processing.
  - Improved output-directory validation for nested, duplicate, and overlapping destinations, with clearer conflict reporting.

- **Tests**
  - Added coverage for credential redaction and complex URL formats.
  - Added validation coverage for disjoint, nested, duplicate, and overlapping output directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->