### PR TITLE
Show managed shared agents on the Connections page

### DIFF
--- a/docs/deployment/trusted-upstream-auth.md
+++ b/docs/deployment/trusted-upstream-auth.md
@@ -113,7 +113,8 @@ Shared agents appear when the user is listed in `agents.<name>.credential_manage
 Reply access alone does not grant shared connection management.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
-Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
+Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.
+Disconnecting an account affects every agent using that credential scope.
 Existing requester-only provider rules still apply.
 Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.

--- a/docs/deployment/trusted-upstream-auth.md
+++ b/docs/deployment/trusted-upstream-auth.md
@@ -78,8 +78,8 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Personal Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lets each authenticated user connect only the OAuth services they want for their personal agent.
-Services come from that agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
+The portal groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Each card loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
@@ -107,9 +107,13 @@ agents:
         defer: true
 ```
 
-Portal access requires an explicit matching `access.users` grant or configured administrator authority.
+Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
 Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-The server resolves canonical Matrix aliases and the configured private scope; the browser cannot choose another user, agent, or credential target.
+Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
+Reply access alone does not grant shared connection management.
+The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
+The browser selects an authorized agent; it cannot override the credential owner or execution scope.
+Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.

--- a/docs/deployment/trusted-upstream-auth.md
+++ b/docs/deployment/trusted-upstream-auth.md
@@ -115,6 +115,7 @@ The server resolves canonical Matrix aliases and rechecks agent and provider aut
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
+Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.
 

--- a/frontend/src/connections/Connections.test.tsx
+++ b/frontend/src/connections/Connections.test.tsx
@@ -12,6 +12,7 @@ import { Connections } from "./Connections";
 
 const service = {
   provider: "mail",
+  is_shared: false,
   display_name: "Mail",
   description: "Read your email.",
   tools: ["mail"],
@@ -395,7 +396,7 @@ describe("shared agent connections", () => {
               agent_name: "research",
               agent_display_name: "Research Team",
               is_shared: true,
-              services: [service],
+              services: [{ ...service, is_shared: true }],
             },
           ],
         }),
@@ -434,4 +435,29 @@ describe("shared agent connections", () => {
       within(personal).getByRole("button", { name: "Connect Mail" }),
     ).toBeEnabled();
   });
+});
+
+it("describes a requester-only connection on a shared agent as personal", async () => {
+  installApi({
+    "/api/connections": async () =>
+      json({
+        agents: [
+          {
+            agent_name: "research",
+            agent_display_name: "Research Team",
+            is_shared: true,
+            services: [service],
+          },
+        ],
+      }),
+    "/api/connections/agents/research/mail/status": async () =>
+      json({ ...status, connected: true }),
+  });
+  render(<Connections />);
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Disconnect Mail" }),
+  );
+  const dialog = screen.getByRole("dialog");
+  expect(dialog).toHaveTextContent(/your saved connection/i);
+  expect(dialog).not.toHaveTextContent(/anyone using this connection/i);
 });

--- a/frontend/src/connections/Connections.test.tsx
+++ b/frontend/src/connections/Connections.test.tsx
@@ -26,18 +26,26 @@ const status = {
 const json = (value: unknown, code = 200) =>
   new Response(JSON.stringify(value), { status: code });
 
+const catalog = (services: (typeof service)[]) => ({
+  agents: [
+    {
+      agent_name: "personal",
+      agent_display_name: "Personal assistant",
+      is_shared: false,
+      services,
+    },
+  ],
+});
+
 function installApi(overrides: Record<string, () => Promise<Response>> = {}) {
   vi.mocked(fetch).mockImplementation(async (input, options) => {
     const path = String(input);
     if (overrides[path]) return overrides[path]();
-    if (path === "/api/connections")
-      return json({
-        agent_display_name: "Personal assistant",
-        services: [service],
-      });
+    if (path === "/api/connections") return json(catalog([service]));
     if (path === "/api/connections/mcp/clients")
       return json({ enabled: false, clients: [] });
-    if (path === "/api/connections/mail/status") return json(status);
+    if (path === "/api/connections/agents/personal/mail/status")
+      return json(status);
     if (path.endsWith("/disconnect")) {
       expect(options).toMatchObject({ method: "POST", body: "{}" });
       return json({ status: "disconnected", provider: "mail" });
@@ -71,7 +79,7 @@ describe("personal connections", () => {
     ).toEqual(
       [
         "/api/connections",
-        "/api/connections/mail/status",
+        "/api/connections/agents/personal/mail/status",
         "/api/connections/mcp/clients",
       ].sort(),
     );
@@ -81,18 +89,17 @@ describe("personal connections", () => {
     let finishMail!: (response: Response) => void;
     installApi({
       "/api/connections": async () =>
-        json({
-          agent_display_name: "Personal assistant",
-          services: [
+        json(
+          catalog([
             service,
             { ...service, provider: "calendar", display_name: "Calendar" },
-          ],
-        }),
-      "/api/connections/mail/status": () =>
+          ]),
+        ),
+      "/api/connections/agents/personal/mail/status": () =>
         new Promise((resolve) => {
           finishMail = resolve;
         }),
-      "/api/connections/calendar/status": async () =>
+      "/api/connections/agents/personal/calendar/status": async () =>
         json({
           ...status,
           provider: "calendar",
@@ -140,13 +147,13 @@ describe("personal connections", () => {
   it("requires confirmation before disconnecting, then refreshes status", async () => {
     let connected = true;
     installApi({
-      "/api/connections/mail/status": async () =>
+      "/api/connections/agents/personal/mail/status": async () =>
         json({
           ...status,
           connected,
           account_label: connected ? "user@example.com" : null,
         }),
-      "/api/connections/mail/disconnect": async () => {
+      "/api/connections/agents/personal/mail/disconnect": async () => {
         connected = false;
         return json({ status: "disconnected", provider: "mail" });
       },
@@ -167,9 +174,9 @@ describe("personal connections", () => {
   it("offers reset confirmation for unreadable credentials before reconnecting", async () => {
     let resetRequired = true;
     installApi({
-      "/api/connections/mail/status": async () =>
+      "/api/connections/agents/personal/mail/status": async () =>
         json({ ...status, reset_required: resetRequired }),
-      "/api/connections/mail/disconnect": async () => {
+      "/api/connections/agents/personal/mail/disconnect": async () => {
         resetRequired = false;
         return json({ status: "disconnected", provider: "mail" });
       },
@@ -199,9 +206,9 @@ describe("personal connections", () => {
       .mockReturnValue(popup as unknown as Window);
     let connected = false;
     installApi({
-      "/api/connections/mail/status": async () =>
+      "/api/connections/agents/personal/mail/status": async () =>
         json({ ...status, connected }),
-      "/api/connections/mail/connect": async () => {
+      "/api/connections/agents/personal/mail/connect": async () => {
         expect(open).toHaveBeenCalledOnce();
         return json({
           provider: "mail",
@@ -239,8 +246,7 @@ describe("personal connections", () => {
 
   it("shows an empty state for no configured services", async () => {
     installApi({
-      "/api/connections": async () =>
-        json({ agent_display_name: "Personal assistant", services: [] }),
+      "/api/connections": async () => json(catalog([])),
     });
     render(<Connections />);
     expect(
@@ -276,7 +282,7 @@ describe("personal connections", () => {
 
   it("keeps an unavailable provider disabled", async () => {
     installApi({
-      "/api/connections/mail/status": async () =>
+      "/api/connections/agents/personal/mail/status": async () =>
         json({ ...status, can_connect: false }),
     });
     render(<Connections />);
@@ -294,7 +300,8 @@ describe("personal connections", () => {
     };
     vi.spyOn(window, "open").mockReturnValue(popup as unknown as Window);
     installApi({
-      "/api/connections/mail/connect": () => new Promise(() => {}),
+      "/api/connections/agents/personal/mail/connect": () =>
+        new Promise(() => {}),
     });
     const { unmount } = render(<Connections />);
     fireEvent.click(
@@ -302,5 +309,129 @@ describe("personal connections", () => {
     );
     unmount();
     await waitFor(() => expect(popup.close).toHaveBeenCalledOnce());
+  });
+});
+
+describe("shared agent connections", () => {
+  it("refreshes other agents using the same account after disconnect", async () => {
+    let connected = true;
+    const sharedStatus = async () => json({ ...status, connected });
+    installApi({
+      "/api/connections": async () =>
+        json({
+          agents: [
+            ...catalog([service]).agents,
+            {
+              agent_name: "research",
+              agent_display_name: "Research Team",
+              is_shared: true,
+              services: [service],
+            },
+          ],
+        }),
+      "/api/connections/agents/personal/mail/status": sharedStatus,
+      "/api/connections/agents/research/mail/status": sharedStatus,
+      "/api/connections/agents/research/mail/disconnect": async () => {
+        connected = false;
+        return json({ status: "disconnected", provider: "mail" });
+      },
+    });
+    render(<Connections />);
+    const personal = await screen.findByRole("region", {
+      name: "Personal assistant",
+    });
+    const shared = await screen.findByRole("region", { name: "Research Team" });
+    expect(
+      await within(personal).findByRole("button", { name: "Disconnect Mail" }),
+    ).toBeEnabled();
+    fireEvent.click(
+      await within(shared).findByRole("button", { name: "Disconnect Mail" }),
+    );
+    fireEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", {
+        name: "Disconnect",
+      }),
+    );
+    expect(
+      await within(shared).findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    expect(
+      await within(personal).findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+  });
+
+  it("does not load personal MCP clients for a shared-only manager", async () => {
+    installApi({
+      "/api/connections": async () =>
+        json({
+          agents: [
+            {
+              agent_name: "research",
+              agent_display_name: "Research Team",
+              is_shared: true,
+              services: [service],
+            },
+          ],
+        }),
+      "/api/connections/agents/research/mail/status": async () => json(status),
+    });
+    render(<Connections />);
+    expect(
+      await screen.findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    expect(
+      vi.mocked(fetch).mock.calls.map(([url]) => String(url)),
+    ).not.toContain("/api/connections/mcp/clients");
+  });
+
+  it("keeps the same provider separate per agent and identifies shared disconnects", async () => {
+    let sharedConnected = true;
+    installApi({
+      "/api/connections": async () =>
+        json({
+          agents: [
+            ...catalog([service]).agents,
+            {
+              agent_name: "research",
+              agent_display_name: "Research Team",
+              is_shared: true,
+              services: [service],
+            },
+          ],
+        }),
+      "/api/connections/agents/research/mail/status": async () =>
+        json({
+          ...status,
+          connected: sharedConnected,
+          account_label: sharedConnected ? "team@example.org" : null,
+        }),
+      "/api/connections/agents/research/mail/disconnect": async () => {
+        sharedConnected = false;
+        return json({ status: "disconnected", provider: "mail" });
+      },
+    });
+    render(<Connections />);
+    const personal = await screen.findByRole("region", {
+      name: "Personal assistant",
+    });
+    const shared = await screen.findByRole("region", { name: "Research Team" });
+    expect(
+      await within(personal).findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    expect(within(shared).getByText("Shared agent")).toBeInTheDocument();
+    fireEvent.click(
+      await within(shared).findByRole("button", { name: "Disconnect Mail" }),
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveTextContent("Research Team");
+    expect(dialog).toHaveTextContent(/anyone using this connection/i);
+    fireEvent.click(within(dialog).getByRole("button", { name: "Disconnect" }));
+    expect(
+      await within(shared).findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    expect(sharedConnected).toBe(false);
+    expect(
+      within(personal).getByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
   });
 });

--- a/frontend/src/connections/Connections.tsx
+++ b/frontend/src/connections/Connections.tsx
@@ -29,9 +29,15 @@ interface ConnectionService {
   tools: string[];
 }
 
-interface ConnectionList {
+interface AgentConnections {
+  agent_name: string;
   agent_display_name: string;
+  is_shared: boolean;
   services: ConnectionService[];
+}
+
+interface ConnectionList {
+  agents: AgentConnections[];
 }
 
 interface ConnectionStatus {
@@ -42,7 +48,17 @@ interface ConnectionStatus {
   account_label: string | null;
 }
 
-function ConnectionCard({ service }: { service: ConnectionService }) {
+function ConnectionCard({
+  agent,
+  service,
+  refreshVersion,
+  onConnectionChange,
+}: {
+  agent: AgentConnections;
+  service: ConnectionService;
+  refreshVersion: number;
+  onConnectionChange: () => void;
+}) {
   const [status, setStatus] = useState<ConnectionStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -50,7 +66,7 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const statusRequest = useRef<AbortController | null>(null);
   const operation = useRef<AbortController | null>(null);
-  const basePath = `/api/connections/${encodeURIComponent(service.provider)}`;
+  const basePath = `/api/connections/agents/${encodeURIComponent(agent.agent_name)}/${encodeURIComponent(service.provider)}`;
 
   const loadStatus = useCallback(async () => {
     statusRequest.current?.abort();
@@ -76,11 +92,10 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
 
   useEffect(() => {
     void loadStatus();
-    return () => {
-      statusRequest.current?.abort();
-      operation.current?.abort();
-    };
-  }, [loadStatus]);
+    return () => statusRequest.current?.abort();
+  }, [loadStatus, refreshVersion]);
+
+  useEffect(() => () => operation.current?.abort(), []);
 
   const connect = async () => {
     const controller = new AbortController();
@@ -98,7 +113,7 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
           ),
         controller.signal,
       );
-      if (!controller.signal.aborted) await loadStatus();
+      if (!controller.signal.aborted) onConnectionChange();
     } catch (cause) {
       if (!controller.signal.aborted)
         setError(
@@ -123,7 +138,7 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
         controller.signal,
         "POST",
       );
-      if (!controller.signal.aborted) await loadStatus();
+      if (!controller.signal.aborted) onConnectionChange();
     } catch (cause) {
       if (!controller.signal.aborted)
         setError(
@@ -241,8 +256,9 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
               {service.display_name}?
             </DialogTitle>
             <DialogDescription>
-              This removes your saved connection. Your assistant will lose
-              access until you connect again.
+              {agent.is_shared
+                ? `This removes the saved connection used by ${agent.agent_display_name}. Anyone using this connection will lose access until you connect again.`
+                : "This removes your saved connection. Your assistant will lose access until you connect again."}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -262,6 +278,8 @@ function ConnectionCard({ service }: { service: ConnectionService }) {
 export function Connections() {
   const [connections, setConnections] = useState<ConnectionList | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [refreshVersion, setRefreshVersion] = useState(0);
+  const refreshConnections = () => setRefreshVersion((version) => version + 1);
   useEffect(() => {
     const controller = new AbortController();
     void requestConnection<ConnectionList>(
@@ -291,15 +309,13 @@ export function Connections() {
             Your connections
           </h1>
           <p className="text-muted-foreground">
-            Connect the services your personal assistant can use for you.
+            Connect services for your personal assistant and shared agents you
+            manage.
           </p>
-          {connections && (
-            <p className="text-sm font-medium">
-              {connections.agent_display_name}
-            </p>
-          )}
         </header>
-        <ConnectedClients />
+        {connections?.agents.some((agent) => !agent.is_shared) && (
+          <ConnectedClients />
+        )}
         {error && (
           <Alert variant="destructive">
             <AlertDescription>{error}</AlertDescription>
@@ -308,18 +324,43 @@ export function Connections() {
         {!connections && !error && (
           <p role="status">Loading your connections…</p>
         )}
-        {connections?.services.length === 0 && (
-          <Card>
-            <CardContent className="pt-6 text-muted-foreground">
-              No services are available for your assistant yet.
-            </CardContent>
-          </Card>
-        )}
-        <div className="grid gap-5 sm:grid-cols-2">
-          {connections?.services.map((service) => (
-            <ConnectionCard key={service.provider} service={service} />
-          ))}
-        </div>
+        {connections?.agents.map((agent) => (
+          <section
+            key={agent.agent_name}
+            aria-labelledby={`agent-${agent.agent_name}`}
+            className="space-y-4"
+          >
+            <div className="flex items-center gap-3">
+              <h2
+                id={`agent-${agent.agent_name}`}
+                className="text-xl font-semibold"
+              >
+                {agent.agent_display_name}
+              </h2>
+              <Badge variant="secondary">
+                {agent.is_shared ? "Shared agent" : "Personal agent"}
+              </Badge>
+            </div>
+            {agent.services.length === 0 && (
+              <Card>
+                <CardContent className="pt-6 text-muted-foreground">
+                  No services are available for this agent yet.
+                </CardContent>
+              </Card>
+            )}
+            <div className="grid gap-5 sm:grid-cols-2">
+              {agent.services.map((service) => (
+                <ConnectionCard
+                  key={service.provider}
+                  agent={agent}
+                  service={service}
+                  refreshVersion={refreshVersion}
+                  onConnectionChange={refreshConnections}
+                />
+              ))}
+            </div>
+          </section>
+        ))}
       </div>
     </main>
   );

--- a/frontend/src/connections/Connections.tsx
+++ b/frontend/src/connections/Connections.tsx
@@ -24,6 +24,7 @@ import { requestConnection } from "./request";
 
 interface ConnectionService {
   provider: string;
+  is_shared: boolean;
   display_name: string;
   description: string;
   tools: string[];
@@ -256,7 +257,7 @@ function ConnectionCard({
               {service.display_name}?
             </DialogTitle>
             <DialogDescription>
-              {agent.is_shared
+              {service.is_shared
                 ? `This removes the saved connection used by ${agent.agent_display_name}. Anyone using this connection will lose access until you connect again.`
                 : "This removes your saved connection. Your assistant will lose access until you connect again."}
             </DialogDescription>

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18868,8 +18868,8 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Personal Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lets each authenticated user connect only the OAuth services they want for their personal agent.
-Services come from that agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
+The portal groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Each card loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
@@ -18897,9 +18897,13 @@ agents:
         defer: true
 ```
 
-Portal access requires an explicit matching `access.users` grant or configured administrator authority.
+Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
 Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-The server resolves canonical Matrix aliases and the configured private scope; the browser cannot choose another user, agent, or credential target.
+Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
+Reply access alone does not grant shared connection management.
+The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
+The browser selects an authorized agent; it cannot override the credential owner or execution scope.
+Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18903,7 +18903,8 @@ Shared agents appear when the user is listed in `agents.<name>.credential_manage
 Reply access alone does not grant shared connection management.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
-Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
+Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.
+Disconnecting an account affects every agent using that credential scope.
 Existing requester-only provider rules still apply.
 Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18905,6 +18905,7 @@ The server resolves canonical Matrix aliases and rechecks agent and provider aut
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
+Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.
 

--- a/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
@@ -109,7 +109,8 @@ Shared agents appear when the user is listed in `agents.<name>.credential_manage
 Reply access alone does not grant shared connection management.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
-Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
+Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.
+Disconnecting an account affects every agent using that credential scope.
 Existing requester-only provider rules still apply.
 Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.

--- a/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
@@ -111,6 +111,7 @@ The server resolves canonical Matrix aliases and rechecks agent and provider aut
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
+Disconnect confirmations follow the connection's credential scope, including personal connections on shared agents.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.
 

--- a/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
@@ -74,8 +74,8 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Personal Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lets each authenticated user connect only the OAuth services they want for their personal agent.
-Services come from that agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
+The portal groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Each card loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
@@ -103,9 +103,13 @@ agents:
         defer: true
 ```
 
-Portal access requires an explicit matching `access.users` grant or configured administrator authority.
+Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
 Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-The server resolves canonical Matrix aliases and the configured private scope; the browser cannot choose another user, agent, or credential target.
+Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
+Reply access alone does not grant shared connection management.
+The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
+The browser selects an authorized agent; it cannot override the credential owner or execution scope.
+Shared connections use the agent's configured credential scope, so disconnecting a shared account affects everyone using it.
 Existing requester-only provider rules still apply.
 Account linking and disconnect reuse the same OAuth state, callback, token store, and reset lifecycle used by tools.
 Operators still configure OAuth clients; shared service accounts are not displayed as personal connections.

--- a/src/mindroom/api/connections.py
+++ b/src/mindroom/api/connections.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict
 
 from mindroom.api import config_lifecycle, oauth
 from mindroom.api.auth import require_personal_connections_user
-from mindroom.api.personal_agent import resolve_personal_agent
+from mindroom.api.personal_agent import PersonalAgentAccessDeniedError, resolve_personal_agent
 from mindroom.authorization import is_sender_allowed_for_agent_credential_management
 from mindroom.oauth.registry import load_oauth_providers_for_snapshot
 from mindroom.oauth.service import oauth_provider_service_account_configured
@@ -31,6 +31,7 @@ class ConnectionService(BaseModel):
     """One available account connection, without credential storage details."""
 
     provider: str
+    is_shared: bool
     display_name: str
     description: str
     tools: list[str]
@@ -92,9 +93,8 @@ async def _connections(request: Request, response: Response) -> _Connections:
     agent_names: list[str] = []
     try:
         personal = resolve_personal_agent(snapshot, requester_id, channel="matrix")
-    except HTTPException as exc:
-        if exc.status_code != 403:
-            raise
+    except PersonalAgentAccessDeniedError:
+        pass
     else:
         agent_names.append(personal.agent_name)
     agent_names.extend(
@@ -123,7 +123,8 @@ def _agent_connections(
 ) -> AgentConnections:
     """Group an authorized agent's available OAuth tools by provider."""
     services: dict[str, ConnectionService] = {}
-    for tool_name in config.resolve_entity(agent_name).available_tools:
+    entity = config.resolve_entity(agent_name)
+    for tool_name in entity.available_tools:
         tool = metadata.get(tool_name)
         if tool is None or tool.auth_provider is None or tool.auth_provider not in providers:
             continue
@@ -132,6 +133,7 @@ def _agent_connections(
             provider.id,
             ConnectionService(
                 provider=provider.id,
+                is_shared=not provider.requester_scoped_credentials and entity.execution_scope in {None, "shared"},
                 display_name=provider.display_name,
                 description=tool.description,
                 tools=[],

--- a/src/mindroom/api/connections.py
+++ b/src/mindroom/api/connections.py
@@ -1,4 +1,4 @@
-"""Personal OAuth connections for an operator-selected private agent."""
+"""OAuth connections for a personal agent and authorized shared agents."""
 
 from __future__ import annotations
 
@@ -12,13 +12,16 @@ from pydantic import BaseModel, ConfigDict
 from mindroom.api import config_lifecycle, oauth
 from mindroom.api.auth import require_personal_connections_user
 from mindroom.api.personal_agent import resolve_personal_agent
+from mindroom.authorization import is_sender_allowed_for_agent_credential_management
 from mindroom.oauth.registry import load_oauth_providers_for_snapshot
 from mindroom.oauth.service import oauth_provider_service_account_configured
 from mindroom.tool_system.catalog import resolved_tool_metadata_for_runtime
 
 if TYPE_CHECKING:
+    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.oauth import OAuthProvider
+    from mindroom.tool_system.catalog import ToolMetadata
 
 router = APIRouter(prefix="/api/connections", tags=["connections"])
 _PRIVATE_HEADERS = {"Cache-Control": "private, no-store", "Referrer-Policy": "no-referrer"}
@@ -33,11 +36,19 @@ class ConnectionService(BaseModel):
     tools: list[str]
 
 
-class ConnectionsCatalog(BaseModel):
-    """Services available to the authenticated user's private agent."""
+class AgentConnections(BaseModel):
+    """Allowed services for one personal or managed shared agent."""
 
+    agent_name: str
     agent_display_name: str
+    is_shared: bool
     services: list[ConnectionService]
+
+
+class ConnectionsCatalog(BaseModel):
+    """Agents whose connections the authenticated user may manage."""
+
+    agents: list[AgentConnections]
 
 
 class ConnectionStatus(BaseModel):
@@ -55,14 +66,13 @@ class _EmptyMutation(BaseModel):
 
 
 @dataclass(frozen=True)
-class _PersonalConnections:
-    agent_name: str
+class _Connections:
     runtime_paths: RuntimePaths
     catalog: ConnectionsCatalog
     providers: dict[str, OAuthProvider]
 
 
-async def _personal_connections(request: Request, response: Response) -> _PersonalConnections:
+async def _connections(request: Request, response: Response) -> _Connections:
     response.headers.update(_PRIVATE_HEADERS)
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     agent_name = (snapshot.runtime_paths.env_value("MINDROOM_CONNECTIONS_AGENT") or "").strip()
@@ -75,11 +85,43 @@ async def _personal_connections(request: Request, response: Response) -> _Person
         raise HTTPException(404, "Personal connections are not enabled", headers=_PRIVATE_HEADERS)
     if request.query_params:
         raise HTTPException(400, "Connection target overrides are not accepted", headers=_PRIVATE_HEADERS)
-    personal = resolve_personal_agent(snapshot, cast("str", auth_user["matrix_user_id"]), channel="matrix")
-    config = personal.config
-    agent = config.agents[personal.agent_name]
+    config = snapshot.runtime_config
+    if config is None:
+        raise HTTPException(503, "Connections are unavailable", headers=_PRIVATE_HEADERS)
+    requester_id = cast("str", auth_user["matrix_user_id"])
+    agent_names: list[str] = []
+    try:
+        personal = resolve_personal_agent(snapshot, requester_id, channel="matrix")
+    except HTTPException as exc:
+        if exc.status_code != 403:
+            raise
+    else:
+        agent_names.append(personal.agent_name)
+    agent_names.extend(
+        name
+        for name, agent in config.agents.items()
+        if agent.private is None
+        and is_sender_allowed_for_agent_credential_management(requester_id, name, config, snapshot.runtime_paths)
+    )
+    if not agent_names:
+        raise HTTPException(403, "No connections are available for this account", headers=_PRIVATE_HEADERS)
     providers = load_oauth_providers_for_snapshot(snapshot)
     metadata = resolved_tool_metadata_for_runtime(snapshot.runtime_paths, config, tolerate_plugin_load_errors=True)
+    agents = [_agent_connections(name, config, providers, metadata) for name in agent_names]
+    return _Connections(
+        runtime_paths=snapshot.runtime_paths,
+        catalog=ConnectionsCatalog(agents=agents),
+        providers=providers,
+    )
+
+
+def _agent_connections(
+    agent_name: str,
+    config: Config,
+    providers: dict[str, OAuthProvider],
+    metadata: dict[str, ToolMetadata],
+) -> AgentConnections:
+    """Group an authorized agent's available OAuth tools by provider."""
     services: dict[str, ConnectionService] = {}
     for tool_name in config.resolve_entity(agent_name).available_tools:
         tool = metadata.get(tool_name)
@@ -97,25 +139,26 @@ async def _personal_connections(request: Request, response: Response) -> _Person
         )
         if tool_name not in service.tools:
             service.tools.append(tool_name)
-    return _PersonalConnections(
+    agent = config.agents[agent_name]
+    return AgentConnections(
         agent_name=agent_name,
-        runtime_paths=snapshot.runtime_paths,
-        catalog=ConnectionsCatalog(agent_display_name=agent.display_name, services=list(services.values())),
-        providers={provider_id: providers[provider_id] for provider_id in services},
+        agent_display_name=agent.display_name,
+        is_shared=agent.private is None,
+        services=list(services.values()),
     )
 
 
-_PersonalContext = Annotated[_PersonalConnections, Depends(_personal_connections)]
+_ConnectionsContext = Annotated[_Connections, Depends(_connections)]
 
 
-def _require_provider(context: _PersonalConnections, provider_id: str) -> OAuthProvider:
-    provider = context.providers.get(provider_id)
-    if provider is None:
-        raise HTTPException(404, "Connection is not available", headers=_PRIVATE_HEADERS)
-    return provider
+def _require_provider(context: _Connections, agent_name: str, provider_id: str) -> OAuthProvider:
+    for agent in context.catalog.agents:
+        if agent.agent_name == agent_name and any(service.provider == provider_id for service in agent.services):
+            return context.providers[provider_id]
+    raise HTTPException(404, "Connection is not available", headers=_PRIVATE_HEADERS)
 
 
-def _require_same_origin(request: Request, context: _PersonalConnections) -> None:
+def _require_same_origin(request: Request, context: _Connections) -> None:
     public_url = context.runtime_paths.env_value("MINDROOM_PUBLIC_URL") or str(request.base_url)
     parsed = urlsplit(public_url)
     if parsed.scheme != "https" or not parsed.netloc:
@@ -126,17 +169,17 @@ def _require_same_origin(request: Request, context: _PersonalConnections) -> Non
 
 
 @router.get("")
-async def catalog(context: _PersonalContext) -> ConnectionsCatalog:
+async def catalog(context: _ConnectionsContext) -> ConnectionsCatalog:
     """List allowed services without waiting for any upstream account status."""
     return context.catalog
 
 
-@router.get("/{provider_id}/status")
-async def status(provider_id: str, request: Request, context: _PersonalContext) -> ConnectionStatus:
-    """Load only this user's status for one allowed provider."""
-    _require_provider(context, provider_id)
+@router.get("/agents/{agent_name}/{provider_id}/status")
+async def status(agent_name: str, provider_id: str, request: Request, context: _ConnectionsContext) -> ConnectionStatus:
+    """Load status for one authorized agent and provider."""
+    _require_provider(context, agent_name, provider_id)
     try:
-        result = await oauth.status(provider_id, request, agent_name=context.agent_name)
+        result = await oauth.status(provider_id, request, agent_name=agent_name)
     except HTTPException as exc:
         raise HTTPException(exc.status_code, "Connection status is unavailable", headers=_PRIVATE_HEADERS) from exc
     # Shared service accounts are runtime configuration, never a personal account.
@@ -150,35 +193,37 @@ async def status(provider_id: str, request: Request, context: _PersonalContext) 
     )
 
 
-@router.post("/{provider_id}/connect")
+@router.post("/agents/{agent_name}/{provider_id}/connect")
 async def connect(
+    agent_name: str,
     provider_id: str,
     request: Request,
-    context: _PersonalContext,
+    context: _ConnectionsContext,
     _body: _EmptyMutation,
 ) -> oauth.OAuthConnectResponse:
-    """Start existing OAuth state handling with a server-derived private target."""
+    """Start existing OAuth state handling with an authorized agent target."""
     _require_same_origin(request, context)
-    provider = _require_provider(context, provider_id)
+    provider = _require_provider(context, agent_name, provider_id)
     if oauth_provider_service_account_configured(provider, context.runtime_paths):
         raise HTTPException(409, "Personal account linking is unavailable for this service", headers=_PRIVATE_HEADERS)
     try:
-        return await oauth.connect(provider_id, request, agent_name=context.agent_name)
+        return await oauth.connect(provider_id, request, agent_name=agent_name)
     except HTTPException as exc:
         raise HTTPException(exc.status_code, "Could not start account connection", headers=_PRIVATE_HEADERS) from exc
 
 
-@router.post("/{provider_id}/disconnect")
+@router.post("/agents/{agent_name}/{provider_id}/disconnect")
 async def disconnect(
+    agent_name: str,
     provider_id: str,
     request: Request,
-    context: _PersonalContext,
+    context: _ConnectionsContext,
     _body: _EmptyMutation,
 ) -> dict[str, str]:
-    """Reset only the authenticated user's scoped provider credentials."""
+    """Reset the authorized agent's scoped provider credentials."""
     _require_same_origin(request, context)
-    _require_provider(context, provider_id)
+    _require_provider(context, agent_name, provider_id)
     try:
-        return await oauth.disconnect(provider_id, request, agent_name=context.agent_name)
+        return await oauth.disconnect(provider_id, request, agent_name=agent_name)
     except HTTPException as exc:
         raise HTTPException(exc.status_code, "Could not disconnect account", headers=_PRIVATE_HEADERS) from exc

--- a/src/mindroom/api/personal_agent.py
+++ b/src/mindroom/api/personal_agent.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 PERSONAL_RESPONSE_HEADERS = {"Cache-Control": "private, no-store", "Referrer-Policy": "no-referrer"}
 
 
+class PersonalAgentAccessDeniedError(HTTPException):
+    """The configured personal agent is valid but unavailable to this requester."""
+
+
 @dataclass(frozen=True)
 class PersonalAgentContext:
     """One authorized personal agent with an explicit private credential owner."""
@@ -70,7 +74,11 @@ def resolve_personal_agent(
     if requester_id not in config.administrators and not any(
         fnmatchcase(requester_id, pattern) for pattern in access.users
     ):
-        raise HTTPException(403, "Personal agent access is required", headers=PERSONAL_RESPONSE_HEADERS)
+        raise PersonalAgentAccessDeniedError(
+            403,
+            "Personal agent access is required",
+            headers=PERSONAL_RESPONSE_HEADERS,
+        )
     identity = build_tool_execution_identity(
         channel=channel,
         agent_name=agent_name,

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def portal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
-    """Serve the real API with two signed users and one private agent."""
+    """Serve the real API with signed users and one private agent."""
     key = _trusted_upstream_jwt_key()
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _client: _trusted_upstream_jwks(key))
     monkeypatch.setattr(
@@ -83,7 +83,7 @@ def portal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
             ),
             "Origin": "https://portal.example.org",
         }
-        for name in ("alice", "bob", "mallory")
+        for name in ("alice", "bob", "mallory", "admin")
     }
     return {
         "client": TestClient(main.app, base_url="https://portal.example.org"),
@@ -103,9 +103,9 @@ def test_catalog_includes_deferred_oauth_tools_without_status_calls(
     monkeypatch.setattr(oauth, "status", status)
     response = portal["client"].get("/api/connections", headers=portal["headers"]["alice"])
     assert response.status_code == 200, response.text
-    assert response.json()["agent_display_name"] == "Personal Mind"
-    assert [item["provider"] for item in response.json()["services"]] == ["google_drive"]
-    assert response.json()["services"][0]["tools"] == ["google_drive"]
+    assert response.json()["agents"][0]["agent_display_name"] == "Personal Mind"
+    assert [item["provider"] for item in response.json()["agents"][0]["services"]] == ["google_drive"]
+    assert response.json()["agents"][0]["services"][0]["tools"] == ["google_drive"]
     assert "credential_service" not in response.text
     assert "no-store" in response.headers["cache-control"]
     status.assert_not_called()
@@ -122,13 +122,16 @@ def test_agent_and_provider_access_rechecked(portal: dict[str, Any]) -> None:
     """A signed identity alone grants no access to another agent's tools."""
     client = portal["client"]
     assert client.get("/api/connections", headers=portal["headers"]["mallory"]).status_code == 403
-    assert client.get("/api/connections/github/status", headers=portal["headers"]["alice"]).status_code == 404
+    assert (
+        client.get("/api/connections/agents/personal/github/status", headers=portal["headers"]["alice"]).status_code
+        == 404
+    )
 
 
 @pytest.mark.parametrize("action", ["connect", "disconnect"])
 def test_mutations_require_same_origin_and_empty_body(portal: dict[str, Any], action: str) -> None:
     """Cross-site requests and hidden body selectors cannot mutate accounts."""
-    url = f"/api/connections/google_drive/{action}"
+    url = f"/api/connections/agents/personal/google_drive/{action}"
     headers = portal["headers"]["alice"]
     client = portal["client"]
     assert client.post(url, headers={**headers, "Origin": "https://evil.example.org"}, json={}).status_code == 403
@@ -158,7 +161,7 @@ def test_personal_mutations_reject_cleartext_public_origin(
     _use_runtime_auth_settings(main.app)
     client = TestClient(main.app, base_url="http://portal.example.org")
     response = client.post(
-        f"/api/connections/google_drive/{action}",
+        f"/api/connections/agents/personal/google_drive/{action}",
         headers={**portal["headers"]["alice"], "Origin": "http://portal.example.org"},
         json={},
     )
@@ -168,10 +171,10 @@ def test_personal_mutations_reject_cleartext_public_origin(
 def test_two_users_complete_and_disconnect_only_their_own_credentials(portal: dict[str, Any]) -> None:
     """Portal callbacks use the same private scope as tool execution."""
     client, headers = portal["client"], portal["headers"]
-    status_url = "/api/connections/google_drive/status"
+    status_url = "/api/connections/agents/personal/google_drive/status"
     for name in ("alice", "bob"):
         assert client.get(status_url, headers=headers[name]).json()["connected"] is False
-    connect = client.post("/api/connections/google_drive/connect", headers=headers["alice"], json={})
+    connect = client.post("/api/connections/agents/personal/google_drive/connect", headers=headers["alice"], json={})
     assert connect.status_code == 200
     state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
     wrong_user = client.get(
@@ -181,7 +184,7 @@ def test_two_users_complete_and_disconnect_only_their_own_credentials(portal: di
         follow_redirects=False,
     )
     assert wrong_user.status_code in {400, 403}
-    connect = client.post("/api/connections/google_drive/connect", headers=headers["alice"], json={})
+    connect = client.post("/api/connections/agents/personal/google_drive/connect", headers=headers["alice"], json={})
     state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
     callback = client.get(
         "/api/oauth/google_drive/callback",
@@ -219,9 +222,23 @@ def test_two_users_complete_and_disconnect_only_their_own_credentials(portal: di
     )
     assert client.get(status_url, headers=headers["alice"]).json()["connected"] is True
     assert client.get(status_url, headers=headers["bob"]).json()["connected"] is False
-    assert client.post("/api/connections/google_drive/disconnect", headers=headers["bob"], json={}).status_code == 200
+    assert (
+        client.post(
+            "/api/connections/agents/personal/google_drive/disconnect",
+            headers=headers["bob"],
+            json={},
+        ).status_code
+        == 200
+    )
     assert client.get(status_url, headers=headers["alice"]).json()["connected"] is True
-    assert client.post("/api/connections/google_drive/disconnect", headers=headers["alice"], json={}).status_code == 200
+    assert (
+        client.post(
+            "/api/connections/agents/personal/google_drive/disconnect",
+            headers=headers["alice"],
+            json={},
+        ).status_code
+        == 200
+    )
     assert client.get(status_url, headers=headers["alice"]).json()["connected"] is False
 
 
@@ -231,7 +248,10 @@ def test_provider_failure_does_not_block_catalog_or_leak_details(
 ) -> None:
     """An unavailable backend affects only its status request."""
     monkeypatch.setattr(oauth, "status", AsyncMock(side_effect=HTTPException(503, "internal-client-secret")))
-    response = portal["client"].get("/api/connections/google_drive/status", headers=portal["headers"]["alice"])
+    response = portal["client"].get(
+        "/api/connections/agents/personal/google_drive/status",
+        headers=portal["headers"]["alice"],
+    )
     assert response.status_code == 503
     assert "internal-client-secret" not in response.text
     assert "no-store" in response.headers["cache-control"]
@@ -244,7 +264,7 @@ def test_unavailable_optional_plugin_does_not_block_healthy_provider(portal: dic
     portal["paths"].config_path.write_text(yaml.safe_dump(portal["payload"]))
     assert config_lifecycle.load_config_into_app(portal["paths"], main.app)
     client = TestClient(main.app, base_url="https://portal.example.org", raise_server_exceptions=False)
-    for url in ("/api/connections", "/api/connections/google_drive/status"):
+    for url in ("/api/connections", "/api/connections/agents/personal/google_drive/status"):
         assert client.get(url, headers=portal["headers"]["alice"]).status_code == 200
 
 
@@ -257,7 +277,10 @@ def test_shared_service_account_is_not_a_personal_connection(portal: dict[str, A
     main.initialize_api_app(main.app, paths)
     _publish_config(main.app, paths, portal["payload"])
     _use_runtime_auth_settings(main.app)
-    response = portal["client"].get("/api/connections/google_drive/status", headers=portal["headers"]["alice"])
+    response = portal["client"].get(
+        "/api/connections/agents/personal/google_drive/status",
+        headers=portal["headers"]["alice"],
+    )
     assert response.status_code == 200
     assert response.json() == {
         "provider": "google_drive",
@@ -268,7 +291,7 @@ def test_shared_service_account_is_not_a_personal_connection(portal: dict[str, A
     }
     assert (
         portal["client"]
-        .post("/api/connections/google_drive/connect", headers=portal["headers"]["alice"], json={})
+        .post("/api/connections/agents/personal/google_drive/connect", headers=portal["headers"]["alice"], json={})
         .status_code
         == 409
     )
@@ -287,7 +310,7 @@ def test_canonical_alias_uses_the_same_private_scope(portal: dict[str, Any]) -> 
     _publish_config(main.app, portal["paths"], portal["payload"])
     _use_runtime_auth_settings(main.app)
     client, headers = portal["client"], portal["headers"]
-    connect = client.post("/api/connections/google_drive/connect", headers=headers["bob"], json={})
+    connect = client.post("/api/connections/agents/personal/google_drive/connect", headers=headers["bob"], json={})
     assert connect.status_code == 200
     state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
     assert (
@@ -299,7 +322,10 @@ def test_canonical_alias_uses_the_same_private_scope(portal: dict[str, Any]) -> 
         ).status_code
         == 307
     )
-    assert client.get("/api/connections/google_drive/status", headers=headers["alice"]).json()["connected"] is True
+    assert (
+        client.get("/api/connections/agents/personal/google_drive/status", headers=headers["alice"]).json()["connected"]
+        is True
+    )
 
 
 def test_shared_agent_configuration_fails_closed(portal: dict[str, Any]) -> None:
@@ -308,3 +334,172 @@ def test_shared_agent_configuration_fails_closed(portal: dict[str, Any]) -> None
     _publish_config(main.app, portal["paths"], portal["payload"])
     _use_runtime_auth_settings(main.app)
     assert portal["client"].get("/api/connections", headers=portal["headers"]["alice"]).status_code == 403
+
+
+@pytest.fixture
+def shared_portal(portal: dict[str, Any]) -> dict[str, Any]:
+    """Add shared agents with distinct managers and an unrelated private agent."""
+    portal["payload"]["agents"].update(
+        {
+            "research": {
+                "display_name": "Research Team",
+                "role": "Research assistant",
+                "tools": ["google_drive"],
+                "credential_managers": ["@alice:example.org", "@mallory:example.org"],
+            },
+            "support": {
+                "display_name": "Support Team",
+                "role": "Support assistant",
+                "tools": ["google_drive"],
+                "credential_managers": ["@bob:example.org"],
+            },
+            "other_private": {
+                "display_name": "Other private agent",
+                "role": "Private assistant",
+                "tools": ["google_drive"],
+                "private": {"per": "user_agent"},
+                "credential_managers": ["@alice:example.org"],
+            },
+        },
+    )
+    _publish_config(main.app, portal["paths"], portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    return portal
+
+
+@pytest.mark.parametrize(
+    ("user", "expected"),
+    [
+        ("alice", ["personal", "research"]),
+        ("bob", ["personal", "support"]),
+        ("mallory", ["research"]),
+        ("admin", ["personal", "research", "support"]),
+    ],
+)
+def test_catalog_lists_only_authorized_agents(shared_portal: dict[str, Any], user: str, expected: list[str]) -> None:
+    """Managers can discover shared connections even without private-agent access."""
+    response = shared_portal["client"].get("/api/connections", headers=shared_portal["headers"][user])
+    assert response.status_code == 200, response.text
+    agents = response.json()["agents"]
+    assert [agent["agent_name"] for agent in agents] == expected
+    assert all(agent["is_shared"] == (agent["agent_name"] != "personal") for agent in agents)
+
+
+@pytest.mark.parametrize("agent", ["research", "other_private", "missing"])
+@pytest.mark.parametrize("action", ["status", "connect", "disconnect"])
+def test_unlisted_agent_actions_are_denied(shared_portal: dict[str, Any], agent: str, action: str) -> None:
+    """Direct URLs cannot bypass catalog authorization or choose another private agent."""
+    response = shared_portal["client"].request(
+        "GET" if action == "status" else "POST",
+        f"/api/connections/agents/{agent}/google_drive/{action}",
+        headers=shared_portal["headers"]["bob"],
+        **({} if action == "status" else {"json": {}}),
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize("worker_scope", [None, "shared"])
+def test_shared_connection_lifecycle_and_revoked_manager(
+    shared_portal: dict[str, Any],
+    worker_scope: str | None,
+) -> None:
+    """Shared credentials reach other managers, stay out of private stores, and enforce revocation."""
+    if worker_scope is not None:
+        shared_portal["payload"]["agents"]["research"]["worker_scope"] = worker_scope
+        _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+        _use_runtime_auth_settings(main.app)
+    client, headers = shared_portal["client"], shared_portal["headers"]
+    base = "/api/connections/agents/research/google_drive"
+    connect = client.post(f"{base}/connect", headers=headers["alice"], json={})
+    assert connect.status_code == 200, connect.text
+    state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
+    callback = client.get(
+        "/api/oauth/google_drive/callback",
+        params={"code": "test-code", "state": state},
+        headers=headers["alice"],
+        follow_redirects=False,
+    )
+    assert callback.status_code == 307, callback.text
+    assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is True
+    assert (
+        client.get(
+            "/api/connections/agents/personal/google_drive/status",
+            headers=headers["alice"],
+        ).json()["connected"]
+        is False
+    )
+    shared_portal["payload"]["agents"]["research"]["credential_managers"] = ["@mallory:example.org"]
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    for action in ("status", "connect", "disconnect"):
+        response = client.request(
+            "GET" if action == "status" else "POST",
+            f"{base}/{action}",
+            headers=headers["alice"],
+            **({} if action == "status" else {"json": {}}),
+        )
+        assert response.status_code == 404
+    assert client.post(f"{base}/disconnect", headers=headers["mallory"], json={}).status_code == 200
+    assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is False
+
+
+def test_shared_manager_alias_is_canonicalized(shared_portal: dict[str, Any]) -> None:
+    """Catalog and actions use the same canonical identity as credential authorization."""
+    shared_portal["payload"]["authorization"] = {"aliases": {"@alice:example.org": ["@bob:example.org"]}}
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    response = shared_portal["client"].get("/api/connections", headers=shared_portal["headers"]["bob"])
+    assert [agent["agent_name"] for agent in response.json()["agents"]] == ["personal", "research"]
+    assert (
+        shared_portal["client"]
+        .get(
+            "/api/connections/agents/research/google_drive/status",
+            headers=shared_portal["headers"]["bob"],
+        )
+        .status_code
+        == 200
+    )
+
+
+@pytest.mark.parametrize("action", ["status", "connect", "disconnect"])
+def test_provider_must_belong_to_selected_agent(shared_portal: dict[str, Any], action: str) -> None:
+    """A provider available to the personal agent cannot be used for an unrelated shared agent."""
+    shared_portal["payload"]["agents"]["research"]["tools"] = ["calculator"]
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    response = shared_portal["client"].request(
+        "GET" if action == "status" else "POST",
+        f"/api/connections/agents/research/google_drive/{action}",
+        headers=shared_portal["headers"]["alice"],
+        **({} if action == "status" else {"json": {}}),
+    )
+    assert response.status_code == 404
+
+
+def test_shared_agent_requester_scoped_provider_stays_personal(
+    shared_portal: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Requester-only providers never expose a manager's credentials to other managers."""
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        requester_scoped_credentials=True,
+    )
+    monkeypatch.setattr(oauth_registry, "_builtin_oauth_providers", lambda: (provider,))
+    client, headers = shared_portal["client"], shared_portal["headers"]
+    base = "/api/connections/agents/research/google_drive"
+    connect = client.post(f"{base}/connect", headers=headers["alice"], json={})
+    assert connect.status_code == 200, connect.text
+    state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
+    callback = client.get(
+        "/api/oauth/google_drive/callback",
+        params={"code": "test-code", "state": state},
+        headers=headers["alice"],
+        follow_redirects=False,
+    )
+    assert callback.status_code == 307, callback.text
+    assert client.get(f"{base}/status", headers=headers["alice"]).json()["connected"] is True
+    assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is False
+    assert client.post(f"{base}/disconnect", headers=headers["mallory"], json={}).status_code == 200
+    assert client.get(f"{base}/status", headers=headers["alice"]).json()["connected"] is True

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -503,3 +503,68 @@ def test_shared_agent_requester_scoped_provider_stays_personal(
     assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is False
     assert client.post(f"{base}/disconnect", headers=headers["mallory"], json={}).status_code == 200
     assert client.get(f"{base}/status", headers=headers["alice"]).json()["connected"] is True
+
+
+@pytest.mark.parametrize("invalid_target", ["missing", "shared"])
+@pytest.mark.parametrize("user", ["alice", "admin"])
+def test_invalid_personal_target_disables_shared_connections(
+    shared_portal: dict[str, Any],
+    invalid_target: str,
+    user: str,
+) -> None:
+    """A malformed portal configuration cannot become a shared credential portal."""
+    if invalid_target == "missing":
+        del shared_portal["payload"]["agents"]["personal"]
+    else:
+        shared_portal["payload"]["agents"]["personal"].pop("private")
+        shared_portal["payload"]["agents"]["personal"]["credential_managers"] = ["@alice:example.org"]
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    client, headers = shared_portal["client"], shared_portal["headers"][user]
+    assert client.get("/api/connections", headers=headers).status_code == 403
+    for action in ("status", "connect", "disconnect"):
+        response = client.request(
+            "GET" if action == "status" else "POST",
+            f"/api/connections/agents/research/google_drive/{action}",
+            headers=headers,
+            **({} if action == "status" else {"json": {}}),
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    ("requester_scoped", "worker_scope", "expected_shared"),
+    [
+        (False, None, True),
+        (False, "shared", True),
+        (False, "user", False),
+        (False, "user_agent", False),
+        (True, None, False),
+        (True, "shared", False),
+        (True, "user", False),
+        (True, "user_agent", False),
+    ],
+)
+def test_catalog_reports_connection_sharing_by_provider_and_scope(
+    shared_portal: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    requester_scoped: bool,
+    worker_scope: str | None,
+    expected_shared: bool,
+) -> None:
+    """Disconnect impact follows credential ownership rather than agent privacy."""
+    shared_portal["payload"]["agents"]["research"]["worker_scope"] = worker_scope
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        requester_scoped_credentials=requester_scoped,
+    )
+    monkeypatch.setattr(oauth_registry, "_builtin_oauth_providers", lambda: (provider,))
+    response = shared_portal["client"].get("/api/connections", headers=shared_portal["headers"]["alice"])
+    assert response.status_code == 200, response.text
+    personal, research = response.json()["agents"]
+    assert personal["services"][0]["is_shared"] is False
+    assert research["is_shared"] is True
+    assert research["services"][0]["is_shared"] is expected_shared

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -385,27 +385,43 @@ def test_catalog_lists_only_authorized_agents(shared_portal: dict[str, Any], use
     assert all(agent["is_shared"] == (agent["agent_name"] != "personal") for agent in agents)
 
 
-@pytest.mark.parametrize("agent", ["research", "other_private", "missing"])
+@pytest.mark.parametrize(
+    ("user", "agent"),
+    [
+        ("bob", "research"),
+        ("bob", "other_private"),
+        ("bob", "missing"),
+        ("alice", "other_private"),
+        ("admin", "other_private"),
+    ],
+)
 @pytest.mark.parametrize("action", ["status", "connect", "disconnect"])
-def test_unlisted_agent_actions_are_denied(shared_portal: dict[str, Any], agent: str, action: str) -> None:
+def test_unlisted_agent_actions_are_denied(
+    shared_portal: dict[str, Any],
+    user: str,
+    agent: str,
+    action: str,
+) -> None:
     """Direct URLs cannot bypass catalog authorization or choose another private agent."""
     response = shared_portal["client"].request(
         "GET" if action == "status" else "POST",
         f"/api/connections/agents/{agent}/google_drive/{action}",
-        headers=shared_portal["headers"]["bob"],
+        headers=shared_portal["headers"][user],
         **({} if action == "status" else {"json": {}}),
     )
     assert response.status_code == 404
 
 
-@pytest.mark.parametrize("worker_scope", [None, "shared"])
+@pytest.mark.parametrize(("worker_scope", "shared_across_agents"), [(None, True), ("shared", False)])
 def test_shared_connection_lifecycle_and_revoked_manager(
     shared_portal: dict[str, Any],
     worker_scope: str | None,
+    shared_across_agents: bool,
 ) -> None:
-    """Shared credentials reach other managers, stay out of private stores, and enforce revocation."""
+    """Connections follow configured ownership, isolate private stores, and enforce revocation."""
     if worker_scope is not None:
-        shared_portal["payload"]["agents"]["research"]["worker_scope"] = worker_scope
+        for agent_name in ("research", "support"):
+            shared_portal["payload"]["agents"][agent_name]["worker_scope"] = worker_scope
         _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
         _use_runtime_auth_settings(main.app)
     client, headers = shared_portal["client"], shared_portal["headers"]
@@ -421,6 +437,10 @@ def test_shared_connection_lifecycle_and_revoked_manager(
     )
     assert callback.status_code == 307, callback.text
     assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is True
+    assert (
+        client.get("/api/connections/agents/support/google_drive/status", headers=headers["bob"]).json()["connected"]
+        is shared_across_agents
+    )
     assert (
         client.get(
             "/api/connections/agents/personal/google_drive/status",
@@ -441,6 +461,10 @@ def test_shared_connection_lifecycle_and_revoked_manager(
         assert response.status_code == 404
     assert client.post(f"{base}/disconnect", headers=headers["mallory"], json={}).status_code == 200
     assert client.get(f"{base}/status", headers=headers["mallory"]).json()["connected"] is False
+    assert (
+        client.get("/api/connections/agents/support/google_drive/status", headers=headers["bob"]).json()["connected"]
+        is False
+    )
 
 
 def test_shared_manager_alias_is_canonicalized(shared_portal: dict[str, Any]) -> None:

--- a/tests/api/test_personal_connections_auth.py
+++ b/tests/api/test_personal_connections_auth.py
@@ -221,7 +221,7 @@ def test_administrator_and_disabled_portal_preserve_dashboard_access(
     [
         "/api/connections",
         "/api/connections/",
-        "/api/connections/google_drive/status",
+        "/api/connections/agents/personal/google_drive/status",
         "/api/oauth/google_drive/callback",
         "/api/oauth/google_drive/success",
         "/api/oauth/google_drive/reset",

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -3,6 +3,7 @@
 # Regenerate with:
 #   uv run vulture --make-whitelist src/mindroom --min-confidence 60 --sort-by-size | perl -pe 's/\.py:\d+/.py/g' > vulture_whitelist.py
 dashboard_credentials_supported  # unused variable (src/mindroom/agent_policy.py)
+is_shared  # JSON response field consumed by connections portal (src/mindroom/api/connections.py)
 can_connect  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 account_label  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 connection_url  # TypedDict field consumed by gateway clients (src/mindroom/mcp_gateway/types.py)


### PR DESCRIPTION
The Connections page now groups OAuth services by agent and includes shared agents when the signed-in user is a configured credential manager or administrator. Managers can use these connections even without access to the selected private agent.

Invalid portal target configuration still fails closed.
Every status, connect, and disconnect request rechecks agent and provider access and reuses the existing OAuth credential scope and lifecycle. The page labels personal and shared agents, explains disconnect impact using each connection's credential scope, and keeps personal MCP clients hidden for shared-only managers. Successful account changes refresh all cards so agents using the same account stay in sync.

Validation:

- Full backend suite on the final head: 18,125 passed, 22 skipped, using a memory-backed temporary test directory.
- Coverage includes shared and private OAuth lifecycle, permission revocation, aliases, administrator access, and requester-only providers, and invalid portal target configuration.
- Final authorization and credential-scope coverage: 108 focused backend tests passed.
- All 51 Connections frontend tests and the production build passed.
- Repository pre-commit hooks passed.
- Desktop and mobile browser checks with fixture API responses.

The initial disk-backed full run timed out in the unchanged 180-day MCP refresh stress test during SQLite commit. That test passed in isolation, and the full suite passed with memory-backed temporary data; no test or production workaround was added.
