### PR TITLE
Reduce call startup and credential normalization stalls

### DIFF
--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -152,6 +152,14 @@ def _build_call_instructions(chat_system_prompt: str) -> str:
     return f"{chat_system_prompt}\n\n{_VOICE_STYLE_ADDENDUM}"
 
 
+def preload_matrix_call_dependencies(config: Config) -> None:
+    """Load optional call SDKs before bots start syncing."""
+    if not config.calls.enabled or not matrix_calls_dependencies_available():
+        return
+    # LiveKit registers plugins on the main thread, so this import must not be offloaded.
+    from livekit.plugins import openai  # noqa: F401, PLC0415
+
+
 def maybe_build_call_manager(
     *,
     agent_name: str,

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -157,7 +157,10 @@ def preload_matrix_call_dependencies(config: Config) -> None:
     if not config.calls.enabled or not matrix_calls_dependencies_available():
         return
     # LiveKit registers plugins on the main thread, so this import must not be offloaded.
-    from livekit.plugins import openai  # noqa: F401, PLC0415
+    try:
+        from livekit.plugins import openai  # noqa: F401, PLC0415
+    except Exception:
+        logger.warning("calls_dependency_preload_failed", exc_info=True)
 
 
 def maybe_build_call_manager(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -65,6 +65,7 @@ from mindroom.matrix.users import (
     preflight_managed_account_provisioning,
 )
 from mindroom.matrix_identifiers import extract_server_name_from_homeserver
+from mindroom.matrix_rtc.call_manager import preload_matrix_call_dependencies
 from mindroom.mcp.manager import MCPServerManager
 from mindroom.mcp.registry import mcp_tool_name
 from mindroom.mcp.toolkit import bind_mcp_server_manager
@@ -1319,6 +1320,7 @@ class _MultiAgentOrchestrator:
         logger.info("Initializing multi-agent system...")
 
         config = await asyncio.to_thread(load_config, self.runtime_paths, tolerate_plugin_load_errors=True)
+        preload_matrix_call_dependencies(config)
         hook_registry = await asyncio.to_thread(self._build_hook_registry, config)
         entity_names = configured_entity_names(config)
         self._preflight_account_provisioning(config, entity_names=entity_names, include_internal_user=True)

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -186,7 +186,7 @@ def _safe_repr(value: object) -> str:
         return f"<unrepresentable: {type(value).__name__}>"
 
 
-_ACRONYM_BOUNDARY_PATTERN = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_ACRONYM_BOUNDARY_PATTERN = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
 _CAMEL_BOUNDARY_PATTERN = re.compile(r"([a-z0-9])([A-Z])")
 _NON_ALPHANUMERIC_RUN_PATTERN = re.compile(r"[^a-z0-9]+")
 
@@ -215,7 +215,7 @@ class _KeyClassification:
 
 def _normalize_key_text(key: str) -> str:
     """Return the canonical snake_case spelling of one key."""
-    collapsed = _ACRONYM_BOUNDARY_PATTERN.sub(r"\1_\2", key.strip())
+    collapsed = _ACRONYM_BOUNDARY_PATTERN.sub("_", key.strip())
     collapsed = _CAMEL_BOUNDARY_PATTERN.sub(r"\1_\2", collapsed)
     return _NON_ALPHANUMERIC_RUN_PATTERN.sub("_", collapsed.lower()).strip("_")
 

--- a/tach.toml
+++ b/tach.toml
@@ -1878,6 +1878,7 @@ visibility = ["mindroom.orchestrator"]
 [[modules]]
 path = "mindroom.orchestrator"
 depends_on = [
+    "mindroom.matrix_rtc.call_manager",
     "mindroom.knowledge.status",
     "mindroom.knowledge.refresh_scheduler",
     "mindroom.legacy_private_storage",

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -2245,12 +2245,22 @@ class TestMultiAgentOrchestrator:
             assert "router" in orchestrator.agent_bots
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(("calls_enabled", "dependencies_available"), [(False, True), (True, False), (True, True)])
+    @pytest.mark.parametrize(
+        ("calls_enabled", "dependencies_available", "import_error"),
+        [
+            (False, True, None),
+            (True, False, None),
+            (True, True, None),
+            (True, True, ImportError),
+            (True, True, RuntimeError),
+        ],
+    )
     async def test_orchestrator_initialize_uses_custom_config_path(
         self,
         tmp_path: Path,
         calls_enabled: bool,
         dependencies_available: bool,
+        import_error: type[Exception] | None,
     ) -> None:
         """Load the owned config and prepare optional call SDKs before creating bots."""
         config_path = tmp_path / "custom-config.yaml"
@@ -2262,6 +2272,9 @@ class TestMultiAgentOrchestrator:
         def record_import(name: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
             if name == "livekit.plugins":
                 call_import_threads.append(threading.current_thread())
+                if import_error is not None:
+                    msg = "Broken optional call plugin"
+                    raise import_error(msg)
             return original_import(name, *args, **kwargs)
 
         def create_bot(*_args: object) -> None:
@@ -2287,12 +2300,13 @@ class TestMultiAgentOrchestrator:
                     },
                 ),
             ),
-            patch.object(_MultiAgentOrchestrator, "_create_managed_bot", side_effect=create_bot),
+            patch.object(_MultiAgentOrchestrator, "_create_managed_bot", side_effect=create_bot) as create_managed_bot,
             patch(
                 "mindroom.matrix_rtc.call_manager.matrix_calls_dependencies_available",
                 return_value=dependencies_available,
             ),
             patch("builtins.__import__", new=record_import),
+            capture_logs() as logs,
         ):
             orchestrator = _MultiAgentOrchestrator(
                 runtime_paths=resolve_runtime_paths(
@@ -2304,6 +2318,8 @@ class TestMultiAgentOrchestrator:
             await orchestrator.initialize()
 
         mock_load_config.assert_called_once()
+        create_managed_bot.assert_called_once()
+        assert any(log["event"] == "calls_dependency_preload_failed" for log in logs) is (import_error is not None)
         assert mock_load_config.call_args.args[0].config_path == config_path.resolve()
 
     @pytest.mark.asyncio

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import os
 import signal
 import sys
@@ -2244,10 +2245,29 @@ class TestMultiAgentOrchestrator:
             assert "router" in orchestrator.agent_bots
 
     @pytest.mark.asyncio
-    async def test_orchestrator_initialize_uses_custom_config_path(self, tmp_path: Path) -> None:
-        """Initialize should load the exact config file owned by the orchestrator."""
+    @pytest.mark.parametrize(("calls_enabled", "dependencies_available"), [(False, True), (True, False), (True, True)])
+    async def test_orchestrator_initialize_uses_custom_config_path(
+        self,
+        tmp_path: Path,
+        calls_enabled: bool,
+        dependencies_available: bool,
+    ) -> None:
+        """Load the owned config and prepare optional call SDKs before creating bots."""
         config_path = tmp_path / "custom-config.yaml"
         mock_config = _runtime_bound_config(Config(router=RouterConfig(model="default")), tmp_path)
+        mock_config.calls.enabled = calls_enabled
+        call_import_threads: list[threading.Thread] = []
+        original_import = builtins.__import__
+
+        def record_import(name: str, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            if name == "livekit.plugins":
+                call_import_threads.append(threading.current_thread())
+            return original_import(name, *args, **kwargs)
+
+        def create_bot(*_args: object) -> None:
+            assert call_import_threads == (
+                [threading.main_thread()] if calls_enabled and dependencies_available else []
+            )
 
         with (
             patch("mindroom.orchestrator.load_config", return_value=mock_config) as mock_load_config,
@@ -2267,7 +2287,12 @@ class TestMultiAgentOrchestrator:
                     },
                 ),
             ),
-            patch.object(_MultiAgentOrchestrator, "_create_managed_bot"),
+            patch.object(_MultiAgentOrchestrator, "_create_managed_bot", side_effect=create_bot),
+            patch(
+                "mindroom.matrix_rtc.call_manager.matrix_calls_dependencies_available",
+                return_value=dependencies_available,
+            ),
+            patch("builtins.__import__", new=record_import),
         ):
             orchestrator = _MultiAgentOrchestrator(
                 runtime_paths=resolve_runtime_paths(

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -555,6 +555,7 @@ _REDACTED_KEYS = (
     "Bearer_Token",
     "Cookie",
     "HTTPAPIKey",
+    "HTTPServerAPIKey",
     "Password",
     "TOKEN",
     "Token",
@@ -596,6 +597,7 @@ _REDACTED_KEYS = (
     "x_token",
 )
 _KEPT_KEYS = (
+    "ABC",
     "XMLHttpToken",
     "input_tokens",
     "max_tokens",

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2634,6 +2634,7 @@ async def test_orchestrator_tracks_sync_tasks(tmp_path: Path) -> None:
         config.mcp_servers = {}
         config.plugins = []
         config.event_journal = MagicMock()
+        config.calls = Config().calls
         config.mindroom_user = None
         config.get_all_configured_rooms.return_value = []
         mock_load_config.return_value = config


### PR DESCRIPTION
Calls enabled at startup now preload the optional LiveKit SDKs during initialization, before bots begin syncing. Plugin registration stays on the main thread as required by LiveKit. Failed imports log a warning and allow startup to continue, preserving the existing call-level failure behavior. Enabling calls later through config reload retains the existing lazy behavior.

Credential-key normalization now uses a fixed-width acronym boundary instead of a greedy uppercase match, preserving redaction decisions while avoiding suffix rescanning.

Three offline trials reduced the first-call import-prefix heartbeat gap from about 700 ms to about 1 ms, with roughly 750 ms of import work moved to startup. This measures the import portion of call setup, not provider response latency.

Validation: the final Python CI suite passed with 18,151 tests and 12 skips; all pre-commit hooks passed. Regression coverage checks startup ordering, missing and broken optional dependencies, and acronym redaction. Independent review found no remaining required changes.
