### PR TITLE
Hide tools that require Matrix from the MCP gateway

### DIFF
--- a/docs/deployment/personal-mcp-gateway.md
+++ b/docs/deployment/personal-mcp-gateway.md
@@ -36,7 +36,7 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 
 The selected agent must use `private.per: user` or `private.per: user_agent`.
 Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
-Both eager and deferred assigned tools are discoverable.
+Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
 The client cannot choose another agent, user, or credential owner.
 
 `MINDROOM_PUBLIC_URL` must be an HTTPS origin without a path, query, or fragment.
@@ -327,7 +327,8 @@ Provisioned directory records are administrator-managed and outside the OAuth lo
 ## Execution limits
 
 - Tools requiring native confirmation or configured approval cannot run through the gateway; they return `approval_required`.
-- Tools requiring a live Matrix conversation are unavailable through this transport.
+- Toolkits marked `requires_room_context` in their metadata are omitted from discovery and rejected on direct schema and invocation requests before construction.
+  This includes Matrix messaging, subagent sessions, scheduling, conversation attachments, and other tools that require the live Matrix room runtime.
 - MCP generic bridge dispatchers are excluded; only selected, filtered typed functions are exposed.
 - Search returns at most 10 items and 16 KiB. A selected schema is limited to 32 KiB; tool arguments and result payloads to 64 KiB each.
 - HTTP request bodies and MCP tool responses are limited to 128 KiB. JSON-encoded request IDs are limited to 128 bytes; the `MCP-Protocol-Version` header to 64 UTF-8 bytes. Calls have a 60-second gateway deadline, with configurable active-call limits (defaults: 16 per grant, 32 per authoritative requester across grants, and 128 per process). A cancelled or timed-out call retains its capacity until its local background work and toolkit cleanup finish, including its grant and requester allowances.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -158,6 +158,11 @@ A tools module is a Python file that registers one or more tool factories using 
 Each factory function returns a **Toolkit class** (not an instance).
 MindRoom instantiates the class when building agents.
 
+Set `requires_room_context=True` in tool metadata when the toolkit requires the live Matrix room runtime, including its client, requester, or conversation context.
+The MCP gateway omits these toolkits from discovery and rejects direct schema and invocation requests before constructing them.
+Agent runs without a room also hide these tools using the same metadata.
+This requirement describes runtime compatibility; it does not grant or replace tool authorization.
+
 ## OAuth providers
 
 An OAuth module registers provider definitions without registering FastAPI routes.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12358,6 +12358,11 @@ A tools module is a Python file that registers one or more tool factories using 
 Each factory function returns a **Toolkit class** (not an instance).
 MindRoom instantiates the class when building agents.
 
+Set `requires_room_context=True` in tool metadata when the toolkit requires the live Matrix room runtime, including its client, requester, or conversation context.
+The MCP gateway omits these toolkits from discovery and rejects direct schema and invocation requests before constructing them.
+Agent runs without a room also hide these tools using the same metadata.
+This requirement describes runtime compatibility; it does not grant or replace tool authorization.
+
 ## OAuth providers
 
 An OAuth module registers provider definitions without registering FastAPI routes.
@@ -19017,7 +19022,7 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 
 The selected agent must use `private.per: user` or `private.per: user_agent`.
 Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
-Both eager and deferred assigned tools are discoverable.
+Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
 The client cannot choose another agent, user, or credential owner.
 
 `MINDROOM_PUBLIC_URL` must be an HTTPS origin without a path, query, or fragment.
@@ -19308,7 +19313,8 @@ Provisioned directory records are administrator-managed and outside the OAuth lo
 ## Execution limits
 
 - Tools requiring native confirmation or configured approval cannot run through the gateway; they return `approval_required`.
-- Tools requiring a live Matrix conversation are unavailable through this transport.
+- Toolkits marked `requires_room_context` in their metadata are omitted from discovery and rejected on direct schema and invocation requests before construction.
+  This includes Matrix messaging, subagent sessions, scheduling, conversation attachments, and other tools that require the live Matrix room runtime.
 - MCP generic bridge dispatchers are excluded; only selected, filtered typed functions are exposed.
 - Search returns at most 10 items and 16 KiB. A selected schema is limited to 32 KiB; tool arguments and result payloads to 64 KiB each.
 - HTTP request bodies and MCP tool responses are limited to 128 KiB. JSON-encoded request IDs are limited to 128 bytes; the `MCP-Protocol-Version` header to 64 UTF-8 bytes. Calls have a 60-second gateway deadline, with configurable active-call limits (defaults: 16 per grant, 32 per authoritative requester across grants, and 128 per process). A cancelled or timed-out call retains its capacity until its local background work and toolkit cleanup finish, including its grant and requester allowances.

--- a/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__personal-mcp-gateway__index.md
@@ -32,7 +32,7 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 
 The selected agent must use `private.per: user` or `private.per: user_agent`.
 Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
-Both eager and deferred assigned tools are discoverable.
+Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
 The client cannot choose another agent, user, or credential owner.
 
 `MINDROOM_PUBLIC_URL` must be an HTTPS origin without a path, query, or fragment.
@@ -323,7 +323,8 @@ Provisioned directory records are administrator-managed and outside the OAuth lo
 ## Execution limits
 
 - Tools requiring native confirmation or configured approval cannot run through the gateway; they return `approval_required`.
-- Tools requiring a live Matrix conversation are unavailable through this transport.
+- Toolkits marked `requires_room_context` in their metadata are omitted from discovery and rejected on direct schema and invocation requests before construction.
+  This includes Matrix messaging, subagent sessions, scheduling, conversation attachments, and other tools that require the live Matrix room runtime.
 - MCP generic bridge dispatchers are excluded; only selected, filtered typed functions are exposed.
 - Search returns at most 10 items and 16 KiB. A selected schema is limited to 32 KiB; tool arguments and result payloads to 64 KiB each.
 - HTTP request bodies and MCP tool responses are limited to 128 KiB. JSON-encoded request IDs are limited to 128 bytes; the `MCP-Protocol-Version` header to 64 UTF-8 bytes. Calls have a 60-second gateway deadline, with configurable active-call limits (defaults: 16 per grant, 32 per authoritative requester across grants, and 128 per process). A cancelled or timed-out call retains its capacity until its local background work and toolkit cleanup finish, including its grant and requester allowances.

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -154,6 +154,11 @@ A tools module is a Python file that registers one or more tool factories using 
 Each factory function returns a **Toolkit class** (not an instance).
 MindRoom instantiates the class when building agents.
 
+Set `requires_room_context=True` in tool metadata when the toolkit requires the live Matrix room runtime, including its client, requester, or conversation context.
+The MCP gateway omits these toolkits from discovery and rejects direct schema and invocation requests before constructing them.
+Agent runs without a room also hide these tools using the same metadata.
+This requirement describes runtime compatibility; it does not grant or replace tool authorization.
+
 ## OAuth providers
 
 An OAuth module registers provider definitions without registering FastAPI routes.

--- a/src/mindroom/mcp_gateway/toolkits.py
+++ b/src/mindroom/mcp_gateway/toolkits.py
@@ -12,7 +12,6 @@ from mindroom.logging_config import get_logger
 from mindroom.mcp.toolkit import MindRoomMCPToolkit
 from mindroom.mcp_gateway.execution import retain_execution_task, run_gateway_sync
 from mindroom.mcp_gateway.types import GatewayError, GatewayErrorCode
-from mindroom.tool_system.catalog import TOOL_METADATA
 from mindroom.tool_system.tool_hooks import SyncToolCompletionTracker, track_sync_tool_completion
 
 if TYPE_CHECKING:
@@ -75,9 +74,6 @@ def _build_native(context: PersonalAgentContext, entry: EffectiveToolConfig) -> 
     from mindroom.agents import build_agent_toolkit, resolve_runtime_worker_tools  # noqa: PLC0415
     from mindroom.runtime_resolution import resolve_agent_runtime  # noqa: PLC0415
 
-    metadata = TOOL_METADATA.get(entry.name)
-    if metadata is not None and metadata.requires_room_context:
-        raise GatewayError(code=GatewayErrorCode.TOOL_UNAVAILABLE)
     runtime = resolve_agent_runtime(
         context.agent_name,
         context.config,

--- a/src/mindroom/mcp_gateway/toolkits.py
+++ b/src/mindroom/mcp_gateway/toolkits.py
@@ -12,6 +12,7 @@ from mindroom.logging_config import get_logger
 from mindroom.mcp.toolkit import MindRoomMCPToolkit
 from mindroom.mcp_gateway.execution import retain_execution_task, run_gateway_sync
 from mindroom.mcp_gateway.types import GatewayError, GatewayErrorCode
+from mindroom.tool_system.catalog import TOOL_METADATA
 from mindroom.tool_system.tool_hooks import SyncToolCompletionTracker, track_sync_tool_completion
 
 if TYPE_CHECKING:
@@ -74,6 +75,10 @@ def _build_native(context: PersonalAgentContext, entry: EffectiveToolConfig) -> 
     from mindroom.agents import build_agent_toolkit, resolve_runtime_worker_tools  # noqa: PLC0415
     from mindroom.runtime_resolution import resolve_agent_runtime  # noqa: PLC0415
 
+    # Plugin metadata can change after selection while this build is scheduled.
+    metadata = TOOL_METADATA.get(entry.name)
+    if metadata is not None and metadata.requires_room_context:
+        raise GatewayError(code=GatewayErrorCode.TOOL_NOT_FOUND)
     runtime = resolve_agent_runtime(
         context.agent_name,
         context.config,

--- a/src/mindroom/mcp_gateway/tools.py
+++ b/src/mindroom/mcp_gateway/tools.py
@@ -96,6 +96,7 @@ def _entries(context: PersonalAgentContext) -> dict[str, EffectiveToolConfig]:
             enable_dynamic_tools_manager=False,
         ).runtime_tool_configs
         if entry.authored_name in authored
+        and ((metadata := TOOL_METADATA.get(entry.name)) is None or not metadata.requires_room_context)
     }
 
 

--- a/src/mindroom/tool_system/declarations.py
+++ b/src/mindroom/tool_system/declarations.py
@@ -104,7 +104,11 @@ class ToolValidationInfo:
 
 @dataclass
 class ToolMetadata:
-    """Complete metadata for a tool."""
+    """Complete metadata for a tool.
+
+    ``requires_room_context`` marks toolkits that need the live Matrix room
+    runtime, including its client, requester, and conversation context.
+    """
 
     name: str
     display_name: str

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -358,6 +358,7 @@ class _ApprovedEgressTools(Toolkit):
     category=ToolCategory.INTEGRATIONS,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.SPECIAL,
+    requires_room_context=True,
     icon="FiShield",
     icon_color="text-emerald-600",
     function_names=("request_network_access",),

--- a/src/mindroom/tools/attachments.py
+++ b/src/mindroom/tools/attachments.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="Paperclip",
     icon_color="text-teal-500",
     config_fields=[],

--- a/src/mindroom/tools/dynamic_workflow.py
+++ b/src/mindroom/tools/dynamic_workflow.py
@@ -17,6 +17,7 @@ register_builtin_tool_metadata(
         category=ToolCategory.PRODUCTIVITY,
         status=ToolStatus.AVAILABLE,
         setup_type=SetupType.NONE,
+        requires_room_context=True,
         icon="Workflow",
         icon_color="text-violet-500",
         config_fields=[

--- a/src/mindroom/tools/external_trigger_manager.py
+++ b/src/mindroom/tools/external_trigger_manager.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="Webhook",
     icon_color="text-emerald-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/matrix_api.py
+++ b/src/mindroom/tools/matrix_api.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="MessageSquare",
     icon_color="text-emerald-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/matrix_message.py
+++ b/src/mindroom/tools/matrix_message.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="MessageSquare",
     icon_color="text-green-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/matrix_room.py
+++ b/src/mindroom/tools/matrix_room.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="LayoutList",
     icon_color="text-blue-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/report_publishing.py
+++ b/src/mindroom/tools/report_publishing.py
@@ -16,6 +16,7 @@ register_builtin_tool_metadata(
         category=ToolCategory.PRODUCTIVITY,
         status=ToolStatus.AVAILABLE,
         setup_type=SetupType.NONE,
+        requires_room_context=True,
         consumes_workspace_paths=True,
         icon="Share2",
         icon_color="text-emerald-500",

--- a/src/mindroom/tools/scheduler.py
+++ b/src/mindroom/tools/scheduler.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="Calendar",
     icon_color="text-emerald-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/subagents.py
+++ b/src/mindroom/tools/subagents.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="Workflow",
     icon_color="text-teal-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/thread_model.py
+++ b/src/mindroom/tools/thread_model.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="Cpu",
     icon_color="text-purple-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/thread_summary.py
+++ b/src/mindroom/tools/thread_summary.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     icon="MessageCircleMore",
     icon_color="text-cyan-500",
     dependencies=["agno"],

--- a/src/mindroom/tools/usage_stats.py
+++ b/src/mindroom/tools/usage_stats.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     category=ToolCategory.INFORMATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
+    requires_room_context=True,
     default_execution_target=ToolExecutionTarget.PRIMARY,
     icon="FaChartBar",
     icon_color="text-cyan-500",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -160,7 +160,7 @@
       "icon": "MessageSquare",
       "icon_color": "text-emerald-500",
       "name": "matrix_api",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -184,7 +184,7 @@
       "icon": "MessageSquare",
       "icon_color": "text-green-500",
       "name": "matrix_message",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -208,7 +208,7 @@
       "icon": "LayoutList",
       "icon_color": "text-blue-500",
       "name": "matrix_room",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -871,7 +871,7 @@
       "icon": "MessageCircleMore",
       "icon_color": "text-cyan-500",
       "name": "thread_summary",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -6155,7 +6155,7 @@
       "icon": "Workflow",
       "icon_color": "text-teal-500",
       "name": "subagents",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -7128,7 +7128,7 @@
       "icon": "FaChartBar",
       "icon_color": "text-cyan-500",
       "name": "usage_stats",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -7259,7 +7259,7 @@
       "icon": "FiShield",
       "icon_color": "text-emerald-600",
       "name": "approved_egress",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "special",
       "status": "available"
     },
@@ -7639,7 +7639,7 @@
       "icon": "Paperclip",
       "icon_color": "text-teal-500",
       "name": "attachments",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -8084,7 +8084,7 @@
       "icon": "Workflow",
       "icon_color": "text-violet-500",
       "name": "dynamic_workflow",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -8112,7 +8112,7 @@
       "icon": "Webhook",
       "icon_color": "text-emerald-500",
       "name": "external_trigger_manager",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -8848,7 +8848,7 @@
       "icon": "Share2",
       "icon_color": "text-emerald-500",
       "name": "report_publishing",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -8875,7 +8875,7 @@
       "icon": "Calendar",
       "icon_color": "text-emerald-500",
       "name": "scheduler",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },
@@ -9086,7 +9086,7 @@
       "icon": "Cpu",
       "icon_color": "text-purple-500",
       "name": "thread_model",
-      "requires_room_context": false,
+      "requires_room_context": true,
       "setup_type": "none",
       "status": "available"
     },

--- a/tests/test_mcp_gateway_tools.py
+++ b/tests/test_mcp_gateway_tools.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.api.personal_agent import PersonalAgentContext
+    from mindroom.config.models import EffectiveToolConfig
 
 
 @pytest.fixture
@@ -170,6 +171,36 @@ async def test_gateway_rechecks_tool_metadata_after_discovery(
         assert response == {
             "error": {"code": "tool_not_found", "message": "This tool is not assigned to your personal agent."},
         }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["search", "schema", "invoke"])
+async def test_gateway_rechecks_room_requirement_after_selection(
+    context: PersonalAgentContext,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    """A registry change while construction is scheduled invalidates the selected toolkit."""
+    original = gateway_toolkits._build_native
+
+    def reload_before_build(selected_context: PersonalAgentContext, entry: EffectiveToolConfig) -> Toolkit:
+        monkeypatch.setattr(TOOL_METADATA[entry.name], "requires_room_context", True)
+        return original(selected_context, entry)
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("Gateway constructed a toolkit after its room requirement changed")
+
+    monkeypatch.setattr(gateway_toolkits, "_build_native", reload_before_build)
+    monkeypatch.setattr(agents, "build_agent_toolkit", forbidden)
+    if operation == "search":
+        response = await gateway.search_tools(context, toolkit="calculator")
+    elif operation == "schema":
+        response = await gateway.get_tool(context, toolkit="calculator", function="add")
+    else:
+        response = await gateway.invoke_tool(context, toolkit="calculator", function="add", arguments={"a": 2, "b": 3})
+    assert response == {
+        "error": {"code": "tool_not_found", "message": "This tool is not assigned to your personal agent."},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_gateway_tools.py
+++ b/tests/test_mcp_gateway_tools.py
@@ -18,6 +18,7 @@ from mindroom import agents, constants
 from mindroom.api.config_lifecycle import ApiSnapshot
 from mindroom.api.personal_agent import resolve_personal_agent
 from mindroom.config.main import Config
+from mindroom.config.models import ToolConfigEntry
 from mindroom.config.plugin import PluginEntryConfig
 from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
 from mindroom.hooks import ToolAfterCallContext, ToolBeforeCallContext, hook
@@ -96,6 +97,79 @@ async def test_metadata_search_never_constructs_toolkit(
     limited = await gateway.search_tools(context, limit=1)
     assert "error" not in limited
     assert len(limited["results"]) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deferred", [False, True])
+@pytest.mark.parametrize(
+    ("toolkit", "function"),
+    [
+        ("approved_egress", "request_network_access"),
+        ("attachments", "list_attachments"),
+        ("callback_manager", "mint_callback"),
+        ("dynamic_workflow", "list_workflows"),
+        ("external_trigger_manager", "list_triggers"),
+        ("matrix_api", "matrix_api"),
+        ("matrix_message", "matrix_message"),
+        ("matrix_room", "matrix_room"),
+        ("report_publishing", "publish_report"),
+        ("scheduler", "list_schedules"),
+        ("subagents", "agents_list"),
+        ("thread_model", "list_models"),
+        ("thread_summary", "set_thread_summary"),
+        ("usage_stats", "get_my_usage"),
+    ],
+)
+async def test_room_runtime_tools_are_hidden_and_cannot_be_selected(
+    context: PersonalAgentContext,
+    monkeypatch: pytest.MonkeyPatch,
+    toolkit: str,
+    function: str,
+    deferred: bool,
+) -> None:
+    """Room-dependent tools cannot be discovered or reached through direct gateway calls."""
+    config = context.config.model_copy(deep=True)
+    config.agents["personal"].tools = ["calculator", ToolConfigEntry(name=toolkit, defer=deferred)]
+    context = replace(context, config=config)
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("Gateway constructed a room-dependent toolkit")
+
+    monkeypatch.setattr(agents, "build_agent_toolkit", forbidden)
+    result = await gateway.search_tools(context)
+    assert "error" not in result
+    assert [item["toolkit"] for item in result["results"]] == ["calculator"]
+    for response in (
+        await gateway.search_tools(context, toolkit=toolkit),
+        await gateway.get_tool(context, toolkit=toolkit, function=function),
+        await gateway.invoke_tool(context, toolkit=toolkit, function=function, arguments={}),
+    ):
+        assert response == {
+            "error": {"code": "tool_not_found", "message": "This tool is not assigned to your personal agent."},
+        }
+
+
+@pytest.mark.asyncio
+async def test_gateway_rechecks_tool_metadata_after_discovery(
+    context: PersonalAgentContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A previously discovered function becomes inaccessible when its context requirement changes."""
+    result = await gateway.search_tools(context, toolkit="calculator")
+    assert "error" not in result
+    assert result["results"]
+    monkeypatch.setattr(TOOL_METADATA["calculator"], "requires_room_context", True)
+
+    result = await gateway.search_tools(context)
+    assert "error" not in result
+    assert [item["toolkit"] for item in result["results"]] == ["duckduckgo"]
+    for response in (
+        await gateway.get_tool(context, toolkit="calculator", function="add"),
+        await gateway.invoke_tool(context, toolkit="calculator", function="add", arguments={"a": 2, "b": 3}),
+    ):
+        assert response == {
+            "error": {"code": "tool_not_found", "message": "This tool is not assigned to your personal agent."},
+        }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The MCP gateway currently advertises toolkits that need a live Matrix conversation, leaving external clients with tools they cannot use.

Use the existing `requires_room_context` metadata to omit these toolkits from discovery and reject selected searches, schema requests, and calls before construction. Mark thirteen built-in toolkits with their actual room requirement, including Matrix messaging, subagents, scheduling, and attachments. Retain the construction-time metadata check to reject toolkits whose room requirement changes after selection.

The metadata also drives existing roomless agent filtering. Shared-agent gateway access is outside this change.

Validation: full backend suite passed (18,179 tests; 22 skipped), repository pre-commit hooks passed, and independent subagent review approved. Regression tests cover eager/deferred discovery, direct access rejection before construction, and metadata changes after discovery or selection.

## Summary by Sourcery

Hide Matrix room-dependent toolkits from MCP gateway discovery and reject their direct access consistently.

Bug Fixes:
- Prevent the MCP gateway from exposing or directly serving toolkits that require live Matrix room context.
- Reject room-dependent toolkit searches, schema requests, and invocations before toolkit construction, including when metadata changes after discovery or selection.

Enhancements:
- Mark built-in room-dependent toolkits with requires_room_context metadata and reuse that metadata for roomless agent filtering.
- Remove the redundant construction-time unavailable check so gateway entry points apply consistent filtering.

Documentation:
- Document the requires_room_context metadata and the MCP gateway behavior for room-dependent toolkits.

Tests:
- Add regression coverage for eager and deferred discovery, direct access rejection before construction, and metadata changes after discovery or selection.