### PR TITLE
Bump mindroom-nio to 1.0.4

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -98,9 +98,10 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
+Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/docs/dev/matrix-event-journal-contracts.md
+++ b/docs/dev/matrix-event-journal-contracts.md
@@ -26,7 +26,7 @@ One shared boundary helper encodes `None` to the empty string and decodes it bac
 ### Durable sync batch boundary
 
 The Matrix client uses `nio.durable.open_durable_sync` with Classic or Simplified Sliding Sync.
-Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.3` package, with no Git source override.
+Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.4` package, with no Git source override.
 Account, device, consumer and stream ownership bind once when opening the session.
 Soft-logout renewal requests the existing device; it preserves the bound stream, membership positions, and attempted-delivery sending identity.
 Hard logout, missing device storage, or changed identity stops startup instead of attempting a stream replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==1.0.3",
+  "mindroom-nio[e2e]==1.0.4",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17294,9 +17294,10 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
+Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -94,9 +94,10 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.3`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
+Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -272,6 +272,7 @@ def test_runtime_dependency_requires_released_durable_nio() -> None:
     assert Version("1.0.0") not in requirement.specifier
     assert Version("1.0.1") not in requirement.specifier
     assert Version("1.0.2") not in requirement.specifier
-    assert Version("1.0.3") in requirement.specifier
-    assert Version("1.0.4") not in requirement.specifier
+    assert Version("1.0.3") not in requirement.specifier
+    assert Version("1.0.4") in requirement.specifier
+    assert Version("1.0.5") not in requirement.specifier
     assert Version("2.0.0") not in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -4594,7 +4594,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.3" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.4" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4706,7 +4706,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "1.0.3"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4719,9 +4719,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/b2/94e495d1d4e9bc0be574b3182de666238c1606c4278a51036820e2363928/mindroom_nio-1.0.3.tar.gz", hash = "sha256:72fe6cd80e30a9edf89c065bb8730ece7885ec469194b899e87ceb0c69f9037a", size = 211136, upload-time = "2026-09-10T19:19:43.65Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/e7/2554b5c138174bc47630932f18f8ac5d40ad6412528ac4f3e2326647acbb/mindroom_nio-1.0.4.tar.gz", hash = "sha256:6f62350e1a2d82e82322a8332bacd20732c66100cfb924c34befce74b8c6a6eb", size = 211230, upload-time = "2026-09-11T09:36:53.51Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/f9/5b2e244cad717706f7fee62598b5e4e580dc302c253bc63c1317eb64798c/mindroom_nio-1.0.3-py3-none-any.whl", hash = "sha256:a71857229dcf46a365e198b58c5c96755f6c2e5c2ff6b62d07ef6f111aeba08b", size = 246308, upload-time = "2026-09-10T19:19:41.877Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/75e54b03ee70f976351de65aea35e17794aaf1739f73bfb597a214627835/mindroom_nio-1.0.4-py3-none-any.whl", hash = "sha256:bb0a1c90e91caadc9493824f1134fb736722952d9dc6f6e359578265966a85dd", size = 246431, upload-time = "2026-09-11T09:36:51.996Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Update `mindroom-nio[e2e]` from 1.0.3 to 1.0.4 to include the durable queue scan reduction.

Refresh the published package artifacts in `uv.lock`, update the existing exact-pin test, and align the runtime documentation and generated references. No other dependency versions change.

Validation: all pre-commit hooks passed, along with 12 packaging/real Olm round-trip tests and five documentation tests. The full local Python run passed 18,184 tests with 22 skipped; its one MCP token-refresh timeout passed on isolated retry in 182 seconds, within the unchanged 300-second limit. Independent review approved the final commit.
