### PR TITLE
Add token usage API with per-user model breakdowns

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -276,6 +276,27 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 | GET | `/api/workers` | List active sandbox workers |
 | POST | `/api/workers/cleanup` | Clean up idle sandbox workers |
 
+### Token Usage
+
+`GET /api/usage` returns retained token usage using the same collector as the
+`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
+cannot access it. Standalone deployments should protect the dashboard with
+`MINDROOM_API_KEY` as described above.
+
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
+and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
+`run_count`, and their own `model_breakdown`. Counters include input, output,
+total, cache read/write, reasoning, and audio tokens. Models include their
+provider. Requester aliases are combined; `user_id: null` holds unattributed
+usage.
+
+User and model breakdowns cover retained top-level runs. They can differ from
+session totals, which may include compacted history and nested team-member
+usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
+`user_coverage` fields describe missing sources and these limits. This is a
+retained-usage report, not a billing ledger. Responses contain no conversation
+content and use `Cache-Control: no-store`.
+
 ### Health & Readiness
 
 | Method | Endpoint | Description |

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -278,24 +278,22 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 
 ### Token Usage
 
-`GET /api/usage` returns retained token usage using the same collector as the
-`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
-cannot access it. Standalone deployments should protect the dashboard with
-`MINDROOM_API_KEY` as described above.
+`GET /api/usage` returns retained token usage using the same collector as the `usage_stats` tool.
+It uses dashboard authentication; ordinary Connections users cannot access it.
+Standalone deployments should protect the dashboard with `MINDROOM_API_KEY` as described above.
 
-The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
-and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
-`run_count`, and their own `model_breakdown`. Counters include input, output,
-total, cache read/write, reasoning, and audio tokens. Models include their
-provider. Requester aliases are combined; `user_id: null` holds unattributed
-usage.
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`, and `user_breakdown`.
+Each user has a canonical `user_id`, token `totals`, `run_count`, and their own `model_breakdown`.
+Counters include input, output, total, cache read/write, reasoning, and audio tokens.
+Models include their provider.
+Requester aliases are combined; `user_id: null` holds unattributed usage.
 
-User and model breakdowns cover retained top-level runs. They can differ from
-session totals, which may include compacted history and nested team-member
-usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
-`user_coverage` fields describe missing sources and these limits. This is a
-retained-usage report, not a billing ledger. Responses contain no conversation
-content and use `Cache-Control: no-store`.
+User and model breakdowns cover retained top-level runs.
+They can differ from session totals, which may include compacted history and nested team-member usage.
+Deleted sessions are unavailable.
+The `coverage`, `model_coverage`, and `user_coverage` fields describe missing sources and these limits.
+This is a retained-usage report, not a billing ledger.
+Responses contain no conversation content and use `Cache-Control: no-store`.
 
 ### Health & Readiness
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -849,24 +849,22 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 
 ### Token Usage
 
-`GET /api/usage` returns retained token usage using the same collector as the
-`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
-cannot access it. Standalone deployments should protect the dashboard with
-`MINDROOM_API_KEY` as described above.
+`GET /api/usage` returns retained token usage using the same collector as the `usage_stats` tool.
+It uses dashboard authentication; ordinary Connections users cannot access it.
+Standalone deployments should protect the dashboard with `MINDROOM_API_KEY` as described above.
 
-The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
-and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
-`run_count`, and their own `model_breakdown`. Counters include input, output,
-total, cache read/write, reasoning, and audio tokens. Models include their
-provider. Requester aliases are combined; `user_id: null` holds unattributed
-usage.
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`, and `user_breakdown`.
+Each user has a canonical `user_id`, token `totals`, `run_count`, and their own `model_breakdown`.
+Counters include input, output, total, cache read/write, reasoning, and audio tokens.
+Models include their provider.
+Requester aliases are combined; `user_id: null` holds unattributed usage.
 
-User and model breakdowns cover retained top-level runs. They can differ from
-session totals, which may include compacted history and nested team-member
-usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
-`user_coverage` fields describe missing sources and these limits. This is a
-retained-usage report, not a billing ledger. Responses contain no conversation
-content and use `Cache-Control: no-store`.
+User and model breakdowns cover retained top-level runs.
+They can differ from session totals, which may include compacted history and nested team-member usage.
+Deleted sessions are unavailable.
+The `coverage`, `model_coverage`, and `user_coverage` fields describe missing sources and these limits.
+This is a retained-usage report, not a billing ledger.
+Responses contain no conversation content and use `Cache-Control: no-store`.
 
 ### Health & Readiness
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -847,6 +847,27 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 | GET | `/api/workers` | List active sandbox workers |
 | POST | `/api/workers/cleanup` | Clean up idle sandbox workers |
 
+### Token Usage
+
+`GET /api/usage` returns retained token usage using the same collector as the
+`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
+cannot access it. Standalone deployments should protect the dashboard with
+`MINDROOM_API_KEY` as described above.
+
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
+and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
+`run_count`, and their own `model_breakdown`. Counters include input, output,
+total, cache read/write, reasoning, and audio tokens. Models include their
+provider. Requester aliases are combined; `user_id: null` holds unattributed
+usage.
+
+User and model breakdowns cover retained top-level runs. They can differ from
+session totals, which may include compacted history and nested team-member
+usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
+`user_coverage` fields describe missing sources and these limits. This is a
+retained-usage report, not a billing ledger. Responses contain no conversation
+content and use `Cache-Control: no-store`.
+
 ### Health & Readiness
 
 | Method | Endpoint | Description |

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -274,24 +274,22 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 
 ### Token Usage
 
-`GET /api/usage` returns retained token usage using the same collector as the
-`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
-cannot access it. Standalone deployments should protect the dashboard with
-`MINDROOM_API_KEY` as described above.
+`GET /api/usage` returns retained token usage using the same collector as the `usage_stats` tool.
+It uses dashboard authentication; ordinary Connections users cannot access it.
+Standalone deployments should protect the dashboard with `MINDROOM_API_KEY` as described above.
 
-The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
-and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
-`run_count`, and their own `model_breakdown`. Counters include input, output,
-total, cache read/write, reasoning, and audio tokens. Models include their
-provider. Requester aliases are combined; `user_id: null` holds unattributed
-usage.
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`, and `user_breakdown`.
+Each user has a canonical `user_id`, token `totals`, `run_count`, and their own `model_breakdown`.
+Counters include input, output, total, cache read/write, reasoning, and audio tokens.
+Models include their provider.
+Requester aliases are combined; `user_id: null` holds unattributed usage.
 
-User and model breakdowns cover retained top-level runs. They can differ from
-session totals, which may include compacted history and nested team-member
-usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
-`user_coverage` fields describe missing sources and these limits. This is a
-retained-usage report, not a billing ledger. Responses contain no conversation
-content and use `Cache-Control: no-store`.
+User and model breakdowns cover retained top-level runs.
+They can differ from session totals, which may include compacted history and nested team-member usage.
+Deleted sessions are unavailable.
+The `coverage`, `model_coverage`, and `user_coverage` fields describe missing sources and these limits.
+This is a retained-usage report, not a billing ledger.
+Responses contain no conversation content and use `Cache-Control: no-store`.
 
 ### Health & Readiness
 

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -272,6 +272,27 @@ Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard 
 | GET | `/api/workers` | List active sandbox workers |
 | POST | `/api/workers/cleanup` | Clean up idle sandbox workers |
 
+### Token Usage
+
+`GET /api/usage` returns retained token usage using the same collector as the
+`usage_stats` tool. It uses dashboard authentication; ordinary Connections users
+cannot access it. Standalone deployments should protect the dashboard with
+`MINDROOM_API_KEY` as described above.
+
+The JSON includes overall `totals`, an entity `breakdown`, a `model_breakdown`,
+and `user_breakdown`. Each user has a canonical `user_id`, token `totals`,
+`run_count`, and their own `model_breakdown`. Counters include input, output,
+total, cache read/write, reasoning, and audio tokens. Models include their
+provider. Requester aliases are combined; `user_id: null` holds unattributed
+usage.
+
+User and model breakdowns cover retained top-level runs. They can differ from
+session totals, which may include compacted history and nested team-member
+usage. Deleted sessions are unavailable. The `coverage`, `model_coverage`, and
+`user_coverage` fields describe missing sources and these limits. This is a
+retained-usage report, not a billing ledger. Responses contain no conversation
+content and use `Cache-Control: no-store`.
+
 ### Health & Readiness
 
 | Method | Endpoint | Description |

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -40,6 +40,7 @@ from mindroom.api.script_gateway import router as script_gateway_router
 from mindroom.api.skills import router as skills_router
 from mindroom.api.thread_exports import router as thread_exports_router
 from mindroom.api.tools import router as tools_router
+from mindroom.api.usage import router as usage_router
 from mindroom.api.workers import router as workers_router
 from mindroom.background_tasks import run_blocking_until_complete
 from mindroom.credentials_sync import sync_env_to_credentials
@@ -731,6 +732,7 @@ app.include_router(schedules_router, dependencies=[Depends(verify_user)])
 app.include_router(knowledge_router, dependencies=[Depends(verify_user)])
 app.include_router(skills_router, dependencies=[Depends(verify_user)])
 app.include_router(tools_router, dependencies=[Depends(verify_user)])
+app.include_router(usage_router, dependencies=[Depends(verify_user)])
 app.include_router(workers_router, dependencies=[Depends(verify_user)])
 app.include_router(openai_compat_router)  # Uses its own bearer auth, not verify_user
 app.include_router(report_publishing_public_router)

--- a/src/mindroom/api/usage.py
+++ b/src/mindroom/api/usage.py
@@ -1,0 +1,21 @@
+"""Dashboard API for aggregate-only retained token usage."""
+
+from fastapi import APIRouter, Request, Response
+
+from mindroom.api import config_lifecycle
+from mindroom.usage_stats import collect_admin_usage
+
+__all__ = ["get_usage", "router"]
+
+router = APIRouter(prefix="/api/usage", tags=["usage"])
+
+
+@router.get("")
+def get_usage(request: Request, response: Response) -> dict[str, object]:
+    """Return retained usage by user and model under dashboard administrator auth."""
+    config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
+    # FastAPI runs synchronous handlers in its thread pool, keeping SQLite scans
+    # and report serialization off the runtime event loop.
+    report = collect_admin_usage(config=config, runtime_paths=runtime_paths)
+    response.headers["Cache-Control"] = "no-store"
+    return report.to_dict()

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, replace
 from dataclasses import field as dataclass_field
+from functools import cache
 from typing import TYPE_CHECKING, Literal
 
 from mindroom.requester_identity import resolve_human_requester_alias
@@ -338,6 +339,10 @@ def _collect_usage(
     expected_agent: str | None,
     expected_requester: str | None,
 ) -> UsageReport:
+    @cache
+    def canonical_requester(requester_id: str) -> str:
+        return resolve_human_requester_alias(requester_id, config, runtime_paths)
+
     usage = _UsageAccumulator()
     model_usage = _ModelUsageAccumulator()
     scanned_sources: set[str] = set()
@@ -361,7 +366,7 @@ def _collect_usage(
                     runs=tuple(
                         replace(
                             run,
-                            requester_id=resolve_human_requester_alias(run.requester_id, config, runtime_paths),
+                            requester_id=canonical_requester(run.requester_id),
                         )
                         if run.requester_id is not None
                         else run

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -31,6 +31,7 @@ __all__ = [
     "UsageCoverage",
     "UsageModelBreakdownRow",
     "UsageReport",
+    "UsageUserBreakdownRow",
     "collect_admin_usage",
     "collect_self_usage",
 ]
@@ -46,6 +47,12 @@ _MODEL_COVERAGE_NOTE = (
     "Model breakdown uses retained top-level runs with usable token metrics. "
     "It does not necessarily sum to report totals, which may include compacted history "
     "and nested team-member usage."
+)
+_USER_COVERAGE_NOTE = (
+    "User breakdown uses requester-attributed retained top-level runs, grouped by canonical user identity. "
+    "A null user_id means requester identity is unavailable. "
+    "It does not necessarily sum to report totals, which may include compacted history "
+    "and nested team-member usage. Deleted sessions are unavailable."
 )
 
 
@@ -147,6 +154,25 @@ class UsageModelBreakdownRow:
 
 
 @dataclass(frozen=True, slots=True)
+class UsageUserBreakdownRow:
+    """Retained top-level usage for one canonical requester and their models."""
+
+    user_id: str | None
+    totals: TokenTotals
+    run_count: int
+    model_breakdown: tuple[UsageModelBreakdownRow, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the administrator-only user breakdown."""
+        return {
+            "user_id": self.user_id,
+            "totals": self.totals.to_dict(),
+            "run_count": self.run_count,
+            "model_breakdown": [row.to_dict() for row in self.model_breakdown],
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class UsageReport:
     """Aggregate-only retained token usage."""
 
@@ -157,10 +183,11 @@ class UsageReport:
     coverage: UsageCoverage
     model_breakdown: tuple[UsageModelBreakdownRow, ...]
     model_coverage: UsageCoverage
+    user_breakdown: tuple[UsageUserBreakdownRow, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         """Return the stable custom-tool payload fields."""
-        return {
+        payload: dict[str, object] = {
             "scope": self.scope,
             "totals": self.totals.to_dict(),
             "session_count": self.session_count,
@@ -169,6 +196,10 @@ class UsageReport:
             "model_breakdown": [row.to_dict() for row in self.model_breakdown],
             "model_coverage": self.model_coverage.to_dict(),
         }
+        if self.scope == "admin":
+            payload["user_breakdown"] = [row.to_dict() for row in self.user_breakdown]
+            payload["user_coverage"] = replace(self.model_coverage, note=_USER_COVERAGE_NOTE).to_dict()
+        return payload
 
 
 @dataclass(slots=True)
@@ -227,6 +258,7 @@ class _UsageAccumulator:
 @dataclass(slots=True)
 class _ModelUsageAccumulator:
     buckets: dict[tuple[str, str], _Aggregate] = dataclass_field(default_factory=dict)
+    user_buckets: dict[str | None, dict[tuple[str, str], _Aggregate]] = dataclass_field(default_factory=dict)
     seen_runs: set[tuple[str, str, str]] = dataclass_field(default_factory=set)
     unavailable_sources: set[str] = dataclass_field(default_factory=set)
 
@@ -257,6 +289,7 @@ class _ModelUsageAccumulator:
             row_key=row.row_key,
             buckets=self.buckets,
             seen_runs=self.seen_runs,
+            user_buckets=self.user_buckets if scope == "admin" else None,
         )
 
 
@@ -322,7 +355,7 @@ def _collect_usage(
                 model_usage.unavailable_sources.add(item.path_label)
                 continue
             row = item
-            if scope == "self" and not item.source.requester_isolated:
+            if scope == "admin" or not item.source.requester_isolated:
                 row = replace(
                     item,
                     runs=tuple(
@@ -372,7 +405,22 @@ def _collect_usage(
         ),
         model_breakdown=model_breakdown,
         model_coverage=model_coverage,
+        user_breakdown=_user_breakdown(model_usage.user_buckets),
     )
+
+
+def _user_breakdown(
+    buckets: Mapping[str | None, dict[tuple[str, str], _Aggregate]],
+) -> tuple[UsageUserBreakdownRow, ...]:
+    rows: list[UsageUserBreakdownRow] = []
+    for user_id, models in buckets.items():
+        totals = TokenTotals()
+        run_count = 0
+        for aggregate in models.values():
+            totals = totals.plus(aggregate.totals)
+            run_count += aggregate.count
+        rows.append(UsageUserBreakdownRow(user_id, totals, run_count, _model_breakdown(models)))
+    return tuple(sorted(rows, key=lambda row: (-row.totals.total_tokens, row.user_id or "")))
 
 
 def _model_breakdown(
@@ -399,9 +447,10 @@ def _add_model_entries(
     row_key: str,
     buckets: dict[tuple[str, str], _Aggregate],
     seen_runs: set[tuple[str, str, str]],
+    user_buckets: dict[str | None, dict[tuple[str, str], _Aggregate]] | None = None,
 ) -> None:
     row_seen_runs: set[tuple[str, str, str]] = set()
-    accepted_entries: list[tuple[tuple[str, str], TokenTotals]] = []
+    accepted_entries: list[tuple[str | None, tuple[str, str], TokenTotals]] = []
     for run, totals in entries:
         if run.run_id is not None:
             identity = (source_path, row_key, run.run_id)
@@ -409,10 +458,12 @@ def _add_model_entries(
                 continue
             row_seen_runs.add(identity)
         key = (run.model_provider or "unknown", run.model or "unknown")
-        accepted_entries.append((key, totals))
+        accepted_entries.append((run.requester_id, key, totals))
     seen_runs.update(row_seen_runs)
-    for key, totals in accepted_entries:
+    for requester_id, key, totals in accepted_entries:
         buckets.setdefault(key, _Aggregate()).add(totals)
+        if user_buckets is not None:
+            user_buckets.setdefault(requester_id, {}).setdefault(key, _Aggregate()).add(totals)
 
 
 def _model_entries_for_row(

--- a/tach.toml
+++ b/tach.toml
@@ -1186,6 +1186,7 @@ depends_on = [
     "mindroom.api.script_gateway",
     "mindroom.api.skills",
     "mindroom.api.tools",
+    "mindroom.api.usage",
     "mindroom.api.workers",
     "mindroom.constants",
     "mindroom.credentials_sync",
@@ -1385,6 +1386,13 @@ path = "mindroom.api.skills"
 depends_on = [
     "mindroom.constants",
     "mindroom.tool_system.skills",
+]
+
+[[modules]]
+path = "mindroom.api.usage"
+depends_on = [
+    "mindroom.api.config_lifecycle",
+    "mindroom.usage_stats",
 ]
 
 [[modules]]

--- a/tests/api/test_connections_auth.py
+++ b/tests/api/test_connections_auth.py
@@ -92,6 +92,7 @@ def connections_auth_client(
         "/api/config",
         "/api/credentials",
         "/api/workers",
+        "/api/usage",
         "/api/connections-admin",
         "/api/connections_extra/status",
         "/api/oauth/google_drive/connect",

--- a/tests/api/test_usage_api.py
+++ b/tests/api/test_usage_api.py
@@ -11,7 +11,8 @@ from mindroom.api import config_lifecycle, main
 
 
 def test_usage_endpoint_reads_retained_tokens_and_requires_dashboard_auth(
-    temp_config_file: Path, tmp_path: Path
+    temp_config_file: Path,
+    tmp_path: Path,
 ) -> None:
     """Missing auth must not expose usage; valid auth reads real retained sessions."""
     runtime_paths = constants.resolve_primary_runtime_paths(
@@ -27,7 +28,7 @@ def test_usage_endpoint_reads_retained_tokens_and_requires_dashboard_auth(
     with sqlite3.connect(database) as connection:
         connection.execute(
             "CREATE TABLE test_agent_sessions (session_id TEXT, session_type TEXT, agent_id TEXT, "
-            "team_id TEXT, user_id TEXT, session_data TEXT, runs TEXT)"
+            "team_id TEXT, user_id TEXT, session_data TEXT, runs TEXT)",
         )
         connection.execute(
             "INSERT INTO test_agent_sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -47,8 +48,8 @@ def test_usage_endpoint_reads_retained_tokens_and_requires_dashboard_auth(
                             "metrics": metrics,
                             "content": "private message",
                             "messages": [{"content": "private prompt"}],
-                        }
-                    ]
+                        },
+                    ],
                 ),
             ),
         )

--- a/tests/api/test_usage_api.py
+++ b/tests/api/test_usage_api.py
@@ -1,0 +1,67 @@
+"""Usage API authentication and retained-storage integration."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from mindroom import constants
+from mindroom.api import config_lifecycle, main
+
+
+def test_usage_endpoint_reads_retained_tokens_and_requires_dashboard_auth(
+    temp_config_file: Path, tmp_path: Path
+) -> None:
+    """Missing auth must not expose usage; valid auth reads real retained sessions."""
+    runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=temp_config_file,
+        storage_path=tmp_path / "storage",
+        process_env={"MINDROOM_API_KEY": "test-usage-key"},
+    )
+    main.initialize_api_app(main.app, runtime_paths)
+    config_lifecycle.load_config_into_app(runtime_paths, main.app)
+    database = runtime_paths.storage_root / "agents/test_agent/sessions/test_agent.db"
+    database.parent.mkdir(parents=True)
+    metrics = {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20, "cache_read_tokens": 9}
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE test_agent_sessions (session_id TEXT, session_type TEXT, agent_id TEXT, "
+            "team_id TEXT, user_id TEXT, session_data TEXT, runs TEXT)"
+        )
+        connection.execute(
+            "INSERT INTO test_agent_sessions VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                "session",
+                "agent",
+                "test_agent",
+                None,
+                "@alice:example.org",
+                json.dumps({"session_metrics": metrics}),
+                json.dumps(
+                    [
+                        {
+                            "run_id": "run",
+                            "model": "test-model",
+                            "model_provider": "ollama",
+                            "metrics": metrics,
+                            "content": "private message",
+                            "messages": [{"content": "private prompt"}],
+                        }
+                    ]
+                ),
+            ),
+        )
+    client = TestClient(main.app)
+    assert client.get("/api/usage").status_code == 401
+    assert client.get("/api/usage", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    response = client.get("/api/usage", headers={"Authorization": "Bearer test-usage-key"})
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    payload = response.json()
+    assert payload["totals"]["total_tokens"] == 20
+    assert payload["user_breakdown"][0]["user_id"] == "@alice:example.org"
+    assert payload["user_breakdown"][0]["model_breakdown"][0]["totals"]["cache_read_tokens"] == 9
+    assert "private message" not in response.text
+    assert "private prompt" not in response.text
+    assert str(database) not in response.text

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -12,6 +12,7 @@ from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.requester_identity import resolve_human_requester_alias
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from mindroom.usage_stats import collect_admin_usage, collect_self_usage
 from mindroom.usage_stats_storage import (
@@ -191,6 +192,36 @@ def test_admin_groups_canonical_users_and_models_without_counting_duplicate_runs
     assert payload["totals"]["total_tokens"] == 100
     assert "retained top-level runs" in payload["user_coverage"]["note"]
     assert "null" in payload["user_coverage"]["note"]
+
+
+def test_admin_resolves_repeated_requesters_once_per_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = _source()
+    run = _run(requester_id="@telegram-alice:example.test")
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(source, run, row_key="first"),
+                _row(source, run, row_key="second"),
+            ),
+        },
+    )
+    resolutions: list[str] = []
+
+    def resolve(user_id: str, config: Config, runtime_paths: RuntimePaths) -> str:
+        resolutions.append(user_id)
+        return resolve_human_requester_alias(user_id, config, runtime_paths)
+
+    monkeypatch.setattr("mindroom.usage_stats.resolve_human_requester_alias", resolve)
+    first = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+    changed_config = _config()
+    changed_config.authorization.aliases = {"@bob:example.test": ["@telegram-alice:example.test"]}
+    second = collect_admin_usage(config=changed_config, runtime_paths=_paths(tmp_path))
+
+    assert first.user_breakdown[0].user_id == "@alice:example.test"
+    assert second.user_breakdown[0].user_id == "@bob:example.test"
+    assert resolutions == ["@telegram-alice:example.test", "@telegram-alice:example.test"]
 
 
 def test_self_report_does_not_expose_user_breakdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -141,6 +142,69 @@ def _wire(
         yield from rows.get(source.path_label, ())
 
     monkeypatch.setattr("mindroom.usage_stats.iter_usage_storage_rows", iter_rows)
+
+
+def test_admin_groups_canonical_users_and_models_without_counting_duplicate_runs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    cached = replace(
+        _run(run_id="cached"),
+        metrics=MappingProxyType({**_metrics(10), "cache_read_tokens": 6, "cache_write_tokens": 1}),
+    )
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    cached,
+                    cached,
+                    _run(
+                        requester_id="@telegram-alice:example.test",
+                        run_id="alias",
+                        total_tokens=20,
+                        model="other-model",
+                    ),
+                    _run(requester_id="@bob:example.test", run_id="bob", total_tokens=15),
+                    _run(requester_id=None, run_id="unattributed", total_tokens=5),
+                    session_metrics=_metrics(100),
+                ),
+            ),
+        },
+    )
+
+    payload = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path)).to_dict()
+
+    users = payload["user_breakdown"]
+    assert [row["user_id"] for row in users] == ["@alice:example.test", "@bob:example.test", None]
+    assert [row["totals"]["total_tokens"] for row in users] == [30, 15, 5]
+    assert users[0]["run_count"] == 2
+    assert users[0]["totals"]["cache_read_tokens"] == 6
+    assert users[0]["totals"]["cache_write_tokens"] == 1
+    assert [(row["model"], row["totals"]["total_tokens"]) for row in users[0]["model_breakdown"]] == [
+        ("other-model", 20),
+        ("gpt-6-astra", 10),
+    ]
+    assert payload["totals"]["total_tokens"] == 100
+    assert "retained top-level runs" in payload["user_coverage"]["note"]
+    assert "null" in payload["user_coverage"]["note"]
+
+
+def test_self_report_does_not_expose_user_breakdown(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = _source()
+    _wire(monkeypatch, (source,), {source.path_label: (_row(source, _run()),)})
+    payload = collect_self_usage(
+        agent_name="code",
+        requester_id="@alice:example.test",
+        config=_config(),
+        runtime_paths=_paths(tmp_path),
+        execution_identity=_identity(),
+    ).to_dict()
+    assert "user_breakdown" not in payload
+    assert "user_coverage" not in payload
 
 
 def test_self_usage_is_requester_scoped_and_small(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Expose `GET /api/usage` through existing dashboard authentication, reusing the retained-session collector behind `usage_stats`.
The response groups token usage by canonical user and provider/model, including input/output, cache read/write, reasoning, and audio counters.

User aliases share one bucket; unattributed usage has a null user ID.
User and model breakdowns cover retained top-level runs, while session totals can include compacted history and nested team-member usage.
Coverage fields explain these limits.
Self-scope tool responses remain requester-only; the API returns aggregate fields with `Cache-Control: no-store` and scans SQLite in the thread pool.
Requester canonicalization is cached within each report and refreshed for subsequent reports.

Authentication preserves existing dashboard policy: standalone API-key configuration, Supabase instance ownership through `ACCOUNT_ID`, and administrator checks for trusted Connections deployments.
A separate Matrix-administrator requirement across every deployment mode would reject valid standalone and Supabase owners.
User rows sort deterministically by descending token totals and then identity; no null-last tie ordering is promised.

Validation: final-head CI passed with 18,231 tests passed and 12 skipped; all image builds, smoke checks, documentation, security, and dependency checks passed.
All repository pre-commit hooks passed.
Two fresh independent reviewers approved the final head with no findings after reviewing the bot comments; focused checks covered accounting, aliases, cache freshness, API-key authentication, signed administrator/non-administrator JWTs, and Supabase owner/non-owner access.

## Summary by Sourcery

Add an authenticated dashboard API for aggregate retained token usage with canonical user and model breakdowns.

New Features:
- Expose an authenticated `GET /api/usage` dashboard endpoint with aggregate retained token usage grouped by provider/model and canonical user.
- Include token counters covering input, output, cache, reasoning, and audio usage, along with coverage metadata describing report limitations.

Bug Fixes:
- Prevent requester aliases from being split across usage buckets while preserving fresh alias resolution for separate reports.
- Keep self-scoped usage responses requester-only without exposing administrator user breakdowns.

Enhancements:
- Reuse the retained-session usage collector for administrator reports and ensure usage responses are aggregate-only and non-cacheable.

Documentation:
- Document the token usage endpoint, authentication requirements, response breakdowns, coverage limitations, and non-billing semantics.

Tests:
- Add API and collector coverage for authentication, aggregation, canonical user grouping, duplicate-run handling, cache freshness, privacy, and self-scope behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated dashboard API for retained token-usage reports.
  - Reports include totals, run counts, model and user breakdowns, token categories, provider details, requester attribution, and coverage information.
  - Responses identify unattributed usage and indicate data limitations, including deleted sessions and retained-run coverage.

- **Privacy**
  - Responses exclude conversation content, prompts, and database details.
  - Usage responses are not cached and are not intended as billing records.

- **Documentation**
  - Added API reference documentation covering authentication, response fields, privacy, and coverage semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->