### PR TITLE
Expose Vault server environment and runtime rollout deadline in Helm

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -17,6 +17,16 @@ helm upgrade --install mindroom-runtime ./cluster/k8s/runtime \
 The default values render a self-contained Deployment, Service, ConfigMap, runtime PVC, and PostgreSQL event-journal StatefulSet.
 A real deployment should provide a useful config and Matrix settings.
 
+## Rollout Progress Deadline
+
+Set `progressDeadlineSeconds` to a positive integer to customize the MindRoom Deployment's rollout progress budget, including scheduling, image initialization, and startup probes.
+Leaving it unset or `null` preserves the Kubernetes default.
+This controls when Kubernetes reports a stalled rollout; it does not change probe settings or Helm's wait timeout.
+
+```yaml
+progressDeadlineSeconds: 1800
+```
+
 ## Event Journal
 
 The runtime chart defaults to PostgreSQL for MindRoom's Matrix event journal, because Kubernetes deployments need a durable database for it.
@@ -338,6 +348,35 @@ With this setup, workers mint Agent Vault tokens through the API port (`14321`),
 Tokenless traffic egresses directly from Squid after the normal policy check.
 When `agentVault.accessTool.enabled` is set, self-service vault grants also keep `agentVault.ownerEmail` as an admin on each worker vault; the Kubernetes worker init container uses that owner account to mint and attach the proxy-role agent token.
 The chart rejects the unsafe default combination of chart-managed approved egress plus Agent Vault without `approvedEgress.parentProxy`, because that would be vault-first and break dynamic grants.
+
+### Agent Vault Server Environment
+
+Use `workers.kubernetes.agentVault.server.extraEnv` for raw Kubernetes `EnvVar` entries, including `valueFrom` Secret references.
+Use `server.envFrom` to import variables from existing Secrets or ConfigMaps.
+Both lists default to empty and apply only to the chart-managed Agent Vault server.
+Keep sensitive values in Secrets and avoid duplicate environment variable names; use the dedicated master-password and SMTP settings for chart-managed variables.
+
+```yaml
+workers:
+  kubernetes:
+    agentVault:
+      server:
+        enabled: true
+        image: registry.example.com/agent-vault@sha256:1111111111111111111111111111111111111111111111111111111111111111
+        extraEnv:
+          - name: AGENT_VAULT_ADDR
+            value: https://vault.example.com
+          - name: AGENT_VAULT_OAUTH_GITHUB_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: vault-oauth
+                key: client-secret
+        envFrom:
+          - secretRef:
+              name: vault-extra-env
+          - configMapRef:
+              name: vault-settings
+```
 
 ### Agent Vault Access Grants
 

--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -20,6 +20,7 @@ A real deployment should provide a useful config and Matrix settings.
 ## Rollout Progress Deadline
 
 Set `progressDeadlineSeconds` to a positive integer to customize the MindRoom Deployment's rollout progress budget, including scheduling, image initialization, and startup probes.
+The chart rejects invalid values and values above Kubernetes' int32 limit of `2147483647` seconds.
 Leaving it unset or `null` preserves the Kubernetes default.
 This controls when Kubernetes reports a stalled rollout; it does not change probe settings or Helm's wait timeout.
 
@@ -355,6 +356,7 @@ Use `workers.kubernetes.agentVault.server.extraEnv` for raw Kubernetes `EnvVar` 
 Use `server.envFrom` to import variables from existing Secrets or ConfigMaps.
 Both lists default to empty and apply only to the chart-managed Agent Vault server.
 Keep sensitive values in Secrets and avoid duplicate environment variable names; use the dedicated master-password and SMTP settings for chart-managed variables.
+The chart rejects `extraEnv` entries that repeat the master-password variable or any SMTP variable emitted when `server.smtp.enabled` is true.
 
 ```yaml
 workers:

--- a/cluster/k8s/runtime/templates/agent-vault-server.yaml
+++ b/cluster/k8s/runtime/templates/agent-vault-server.yaml
@@ -98,6 +98,13 @@ spec:
                   name: {{ $server.smtp.existingSecret }}
                   key: AGENT_VAULT_SMTP_FROM
             {{- end }}
+            {{- with $server.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $server.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: api
               containerPort: {{ $server.apiPort }}

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -26,7 +26,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- if ne .Values.progressDeadlineSeconds nil }}
-  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds | int64 }}
   {{- end }}
   strategy:
     type: Recreate

--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -25,6 +25,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if ne .Values.progressDeadlineSeconds nil }}
+  progressDeadlineSeconds: {{ .Values.progressDeadlineSeconds }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -1,3 +1,9 @@
+{{- if ne .Values.progressDeadlineSeconds nil -}}
+{{- $deadline := toJson .Values.progressDeadlineSeconds -}}
+{{- if or (not (regexMatch "^[1-9][0-9]*$" $deadline)) (lt (int64 $deadline) 1) (gt (int64 $deadline) 2147483647) -}}
+{{- fail "progressDeadlineSeconds must be a positive integer no greater than 2147483647" -}}
+{{- end -}}
+{{- end -}}
 {{- if not (or (eq .Values.eventCache.backend "postgres") (eq .Values.eventCache.backend "sqlite")) -}}
 {{- fail "eventCache.backend must be either postgres or sqlite" -}}
 {{- end -}}
@@ -213,6 +219,17 @@
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}
+{{- if $agentVault.server.enabled -}}
+{{- $managedVaultEnv := list "AGENT_VAULT_MASTER_PASSWORD" -}}
+{{- if $agentVault.server.smtp.enabled -}}
+{{- $managedVaultEnv = concat $managedVaultEnv (list "AGENT_VAULT_SMTP_HOST" "AGENT_VAULT_SMTP_PORT" "AGENT_VAULT_SMTP_TLS_MODE" "AGENT_VAULT_SMTP_FROM_NAME" "AGENT_VAULT_SMTP_USERNAME" "AGENT_VAULT_SMTP_PASSWORD" "AGENT_VAULT_SMTP_FROM") -}}
+{{- end -}}
+{{- range $index, $entry := $agentVault.server.extraEnv -}}
+{{- if has (default "" $entry.name) $managedVaultEnv -}}
+{{- fail (printf "workers.kubernetes.agentVault.server.extraEnv[%d] cannot override chart-managed %s" $index $entry.name) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- $agentVaultProxyUrl := lower (regexReplaceAll "/+$" (trim (default "" $agentVault.proxyUrl)) "") -}}
 {{- $agentVaultServiceName := include "mindroom-runtime.agentVaultServerName" . -}}
 {{- $agentVaultMitmPort := printf "%v" $agentVault.server.mitmPort -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -438,6 +438,7 @@ workers:
         # the vault's encryption key.
         masterPasswordSecretKey: AGENT_VAULT_MASTER_PASSWORD
         # Raw Kubernetes EnvVar entries appended to the Agent Vault server.
+        # Cannot override the chart-managed master password or enabled SMTP settings.
         extraEnv: []
         # Raw Kubernetes EnvFromSource entries for the Agent Vault server.
         envFrom: []

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -6,6 +6,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 replicaCount: 1
+# Optional rollout progress deadline for the MindRoom Deployment, in seconds.
+# Leave null to use the Kubernetes default.
+progressDeadlineSeconds: null
 
 image:
   repository: ghcr.io/mindroom-ai/mindroom
@@ -434,6 +437,10 @@ workers:
         # Key in bootstrapSecretName holding the master password that protects
         # the vault's encryption key.
         masterPasswordSecretKey: AGENT_VAULT_MASTER_PASSWORD
+        # Raw Kubernetes EnvVar entries appended to the Agent Vault server.
+        extraEnv: []
+        # Raw Kubernetes EnvFromSource entries for the Agent Vault server.
+        envFrom: []
         persistence:
           enabled: true
           size: 1Gi

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1503,6 +1503,94 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
     assert "name=agentvault" not in conf
 
 
+@pytest.mark.parametrize("deadline", [None, 1800])
+def test_runtime_chart_progress_deadline_is_optional(deadline: int | None) -> None:
+    """A custom rollout budget reaches the Deployment; omission keeps the Kubernetes default."""
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        *((f"progressDeadlineSeconds={deadline}",) if deadline is not None else ()),
+        release_name="mindroom-runtime",
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-runtime")
+
+    if deadline is None:
+        assert "progressDeadlineSeconds" not in deployment["spec"]
+    else:
+        assert deployment["spec"]["progressDeadlineSeconds"] == 1800
+
+
+@pytest.mark.parametrize("smtp_enabled", [False, True])
+@pytest.mark.parametrize("custom_env", [False, True])
+def test_runtime_chart_agent_vault_server_environment(
+    tmp_path: Path,
+    smtp_enabled: bool,
+    custom_env: bool,
+) -> None:
+    """Vault-only environment extensions preserve built-in password and SMTP wiring."""
+    extra_env = [
+        {"name": "AGENT_VAULT_ADDR", "value": "https://vault.example.test"},
+        {
+            "name": "AGENT_VAULT_OAUTH_GITHUB_CLIENT_SECRET",
+            "valueFrom": {"secretKeyRef": {"name": "vault-oauth", "key": "client-secret"}},
+        },
+    ]
+    env_from = [
+        {"secretRef": {"name": "vault-extra-env"}},
+        {"configMapRef": {"name": "vault-settings"}, "prefix": "VAULT_"},
+    ]
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump(
+            {
+                "workers": {
+                    "kubernetes": {
+                        "agentVault": {
+                            "server": {
+                                "enabled": True,
+                                "image": "example.test/agent-vault:test",
+                                "extraEnv": extra_env if custom_env else [],
+                                "envFrom": env_from if custom_env else [],
+                                "smtp": {
+                                    "enabled": smtp_enabled,
+                                    "host": "smtp.example.test",
+                                    "existingSecret": "vault-smtp",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ),
+    )
+    docs = _render_chart(Path("cluster/k8s/runtime"), values_files=(values_path,), release_name="mindroom-runtime")
+    vault = _container(_resource(docs, "Deployment", "agent-vault"), "agent-vault")
+    env = _env_by_name(vault)
+
+    assert env["AGENT_VAULT_MASTER_PASSWORD"] == {
+        "name": "AGENT_VAULT_MASTER_PASSWORD",
+        "valueFrom": {"secretKeyRef": {"name": "agent-vault-bootstrap", "key": "AGENT_VAULT_MASTER_PASSWORD"}},
+    }
+    if smtp_enabled:
+        assert env["AGENT_VAULT_SMTP_HOST"]["value"] == "smtp.example.test"
+        assert env["AGENT_VAULT_SMTP_PASSWORD"] == {
+            "name": "AGENT_VAULT_SMTP_PASSWORD",
+            "valueFrom": {"secretKeyRef": {"name": "vault-smtp", "key": "AGENT_VAULT_SMTP_PASSWORD"}},
+        }
+    else:
+        assert "AGENT_VAULT_SMTP_HOST" not in env
+    if custom_env:
+        assert vault["env"][-2:] == extra_env
+        assert vault["envFrom"] == env_from
+    else:
+        assert "AGENT_VAULT_ADDR" not in env
+        assert "envFrom" not in vault
+
+    runtime = _container(_resource(docs, "Deployment", "mindroom-runtime"), "mindroom")
+    assert "AGENT_VAULT_ADDR" not in _env_by_name(runtime)
+    assert "AGENT_VAULT_OAUTH_GITHUB_CLIENT_SECRET" not in _env_by_name(runtime)
+    assert "envFrom" not in runtime
+
+
 def test_runtime_chart_agent_vault_access_tool_sets_owner_email() -> None:
     """The self-service access tool must know the owner used by worker token minting."""
     docs = _render_chart(

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1503,12 +1503,20 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
     assert "name=agentvault" not in conf
 
 
-@pytest.mark.parametrize("deadline", [None, 1800])
-def test_runtime_chart_progress_deadline_is_optional(deadline: int | None) -> None:
+@pytest.mark.parametrize("deadline", [None, 1, 1800, 2147483647])
+@pytest.mark.parametrize("from_values_file", [False, True])
+def test_runtime_chart_progress_deadline_is_optional(
+    tmp_path: Path,
+    deadline: int | None,
+    from_values_file: bool,
+) -> None:
     """A custom rollout budget reaches the Deployment; omission keeps the Kubernetes default."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(yaml.safe_dump({"progressDeadlineSeconds": deadline}))
     docs = _render_chart(
         Path("cluster/k8s/runtime"),
-        *((f"progressDeadlineSeconds={deadline}",) if deadline is not None else ()),
+        *((f"progressDeadlineSeconds={deadline}",) if deadline is not None and not from_values_file else ()),
+        values_files=(values_path,) if from_values_file else (),
         release_name="mindroom-runtime",
     )
     deployment = _resource(docs, "Deployment", "mindroom-runtime")
@@ -1516,7 +1524,65 @@ def test_runtime_chart_progress_deadline_is_optional(deadline: int | None) -> No
     if deadline is None:
         assert "progressDeadlineSeconds" not in deployment["spec"]
     else:
-        assert deployment["spec"]["progressDeadlineSeconds"] == 1800
+        assert isinstance(deployment["spec"]["progressDeadlineSeconds"], int)
+        assert deployment["spec"]["progressDeadlineSeconds"] == deadline
+
+
+@pytest.mark.parametrize("deadline", [0, -1, 1.5, "abc", True, "", 2147483648, 999999999999999999999999])
+@pytest.mark.parametrize("from_values_file", [False, True])
+def test_runtime_chart_rejects_invalid_progress_deadline(
+    tmp_path: Path,
+    deadline: str | float,
+    from_values_file: bool,
+) -> None:
+    """Reject invalid Kubernetes int32 deadlines during rendering rather than installation."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(yaml.safe_dump({"progressDeadlineSeconds": deadline}))
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        set_string_args=() if from_values_file else (f"progressDeadlineSeconds={deadline}",),
+        values_files=(values_path,) if from_values_file else (),
+    )
+
+    assert completed.returncode != 0
+    assert "progressDeadlineSeconds must be a positive integer no greater than 2147483647" in completed.stderr
+
+
+@pytest.mark.parametrize("smtp_enabled", [False, True])
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "AGENT_VAULT_MASTER_PASSWORD",
+        "AGENT_VAULT_SMTP_HOST",
+        "AGENT_VAULT_SMTP_PORT",
+        "AGENT_VAULT_SMTP_TLS_MODE",
+        "AGENT_VAULT_SMTP_FROM_NAME",
+        "AGENT_VAULT_SMTP_USERNAME",
+        "AGENT_VAULT_SMTP_PASSWORD",
+        "AGENT_VAULT_SMTP_FROM",
+    ],
+)
+def test_runtime_chart_agent_vault_server_rejects_managed_environment(env_name: str, smtp_enabled: bool) -> None:
+    """Extensions cannot replace chart-managed credentials; disabled SMTP stays configurable."""
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.kubernetes.agentVault.server.enabled=true",
+        "workers.kubernetes.agentVault.server.image=example.test/agent-vault:test",
+        f"workers.kubernetes.agentVault.server.smtp.enabled={str(smtp_enabled).lower()}",
+        "workers.kubernetes.agentVault.server.smtp.host=smtp.example.test",
+        "workers.kubernetes.agentVault.server.smtp.existingSecret=vault-smtp",
+        f"workers.kubernetes.agentVault.server.extraEnv[0].name={env_name}",
+        "workers.kubernetes.agentVault.server.extraEnv[0].value=custom-value",
+    )
+
+    if env_name == "AGENT_VAULT_MASTER_PASSWORD" or smtp_enabled:
+        assert completed.returncode != 0
+        assert f"server.extraEnv[0] cannot override chart-managed {env_name}" in completed.stderr
+    else:
+        completed.check_returncode()
+        docs = [doc for doc in yaml.safe_load_all(completed.stdout) if isinstance(doc, dict)]
+        vault = _container(_resource(docs, "Deployment", "agent-vault"), "agent-vault")
+        assert _env_by_name(vault)[env_name]["value"] == "custom-value"
 
 
 @pytest.mark.parametrize("smtp_enabled", [False, True])


### PR DESCRIPTION
The runtime chart currently requires manifest patches to configure additional Agent Vault server settings or change the runtime Deployment's rollout deadline.

Add optional `progressDeadlineSeconds` and `workers.kubernetes.agentVault.server.extraEnv` / `envFrom` values. Vault environment entries support literal values and Kubernetes Secret/ConfigMap references and remain scoped to the Vault server. Unset options preserve the existing rendered resources.

Validate rollout deadlines as positive int32 values, including values loaded from YAML files, and render them as integers. Reject `extraEnv` entries that override the chart-managed master password or enabled SMTP settings. Document the options with synthetic examples and add rendered-manifest coverage for defaults, boundaries, invalid inputs, SMTP combinations, and container scope.

Validation:
- Latest chart suite: 147 tests passed; new behavior and validation failures were verified before implementation.
- Helm lint, both README examples, repository pre-commit hooks, and independent review passed.
- Default renders matched the baseline for plain runtime, Vault, and Vault with SMTP.
- Full non-Matrix suite before the validation follow-up: 18,234 passed, 10 skipped with four workers. An initial eight-worker run hit a timeout in an unchanged shutdown test; its full 145-test file also passed separately.

## Summary by Sourcery

Expose optional runtime rollout and Agent Vault server environment configuration through Helm values while preserving existing defaults and managed wiring.

New Features:
- Allow configuring the runtime Deployment rollout progress deadline.
- Allow adding custom environment variables and env sources to the chart-managed Agent Vault server.

Enhancements:
- Validate rollout deadlines against Kubernetes' positive int32 range and prevent custom Vault environment entries from overriding chart-managed password or SMTP settings.
- Preserve existing default rendering and scope custom Vault environment configuration exclusively to the Vault server.

Documentation:
- Document rollout deadline and Agent Vault server environment configuration with usage examples.

Tests:
- Add rendered-manifest coverage for default and custom rollout deadlines, Vault environment sources, SMTP combinations, managed-variable conflicts, and container scoping.