### PR TITLE
Compact Connections table with per-agent tool exposure

### DIFF
--- a/docs/deployment/mcp-gateway.md
+++ b/docs/deployment/mcp-gateway.md
@@ -54,6 +54,7 @@ Under **MCP access**, select all compatible tools for an agent or choose tools i
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
+Custom selections hide tools that are no longer available and discard those stale choices when saved.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.

--- a/docs/deployment/mcp-gateway.md
+++ b/docs/deployment/mcp-gateway.md
@@ -46,24 +46,30 @@ Loopback HTTP origins are accepted for local development.
 Gateway environment changes require an API restart.
 The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED=true` and `MINDROOM_TRUSTED_UPSTREAM_REQUIRE_JWT=true`.
 
-## Choose exposed agents
+## Choose exposed agents and tools
 
-On Connections, enable **Expose through MCP** for each agent you want your clients to use.
+Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
+Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Each tool selection applies only to that agent, even when another agent has the same tool.
+An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
+Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.
-Turning agents off remains available when stored data exceeds a lowered gateway or per-user quota.
+Withdrawing agent or tool access remains available when stored data exceeds a lowered gateway or per-user quota.
 New agents are not automatically added to an existing selection.
 
 The page lists all assigned tools, including those without browser authentication.
-OAuth controls remain grouped by service, and room-dependent tools are labeled **MindRoom only**.
+Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
 Upstream service credentials are validated after admission and before using the remote session.
-Calls already admitted may finish after an agent is turned off.
+Calls already admitted may finish after an agent or tool is turned off.
+Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.
 Removing eligibility hides a saved choice; restoring that permission can restore the previously saved choice.
 Selections are bound to the signed Matrix identity, canonical requester, and provisioned account when enabled.
 Deleting and recreating a provisioned account does not restore its previous selection.

--- a/frontend/src/connections/AgentTable.tsx
+++ b/frontend/src/connections/AgentTable.tsx
@@ -1,0 +1,290 @@
+import { Fragment, useMemo, useState } from "react";
+import {
+  type ColumnDef,
+  type ExpandedState,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  ChevronDown,
+  ChevronRight,
+  Search,
+  Users,
+  UserRound,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { AgentTools } from "./AgentTools";
+import type { AgentConnections } from "./types";
+import type { McpSelectionState } from "./useMcpSelection";
+
+type AgentTableRow = AgentConnections & { mcp: McpSelectionState };
+
+const columns: ColumnDef<AgentTableRow>[] = [
+  {
+    id: "agent",
+    header: "Agent",
+    accessorFn: (agent) => agent.agent_display_name,
+    cell: ({ row }) => {
+      const agent = row.original;
+      const Icon = agent.is_shared ? Users : UserRound;
+      return (
+        <button
+          type="button"
+          className="flex w-full items-center gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`${row.getIsExpanded() ? "Collapse" : "Expand"} ${agent.agent_display_name}`}
+          aria-expanded={row.getIsExpanded()}
+          aria-controls={`agent-tools-${agent.agent_name}`}
+          onClick={row.getToggleExpandedHandler()}
+        >
+          {row.getIsExpanded() ? (
+            <ChevronDown
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+          ) : (
+            <ChevronRight
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+              aria-hidden="true"
+            />
+          )}
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/5 text-primary">
+            <Icon className="h-4 w-4" aria-hidden="true" />
+          </span>
+          <span id={`agent-${agent.agent_name}`} className="font-medium">
+            {agent.agent_display_name}
+          </span>
+        </button>
+      );
+    },
+  },
+  {
+    id: "type",
+    header: "Type",
+    cell: ({ row }) => (
+      <Badge variant="secondary" className="font-normal">
+        {row.original.is_shared ? "Shared" : "Personal"}
+      </Badge>
+    ),
+  },
+  {
+    id: "tools",
+    header: "Tools & connections",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {row.original.tools.length} tools
+        <span className="mx-2 text-border">/</span>
+        {row.original.services.length} connections
+      </span>
+    ),
+  },
+  {
+    id: "mcp",
+    header: "MCP access",
+    cell: ({ row }) => {
+      const mcp = row.original.mcp;
+      if (!mcp.selection?.enabled)
+        return <span className="text-muted-foreground">—</span>;
+      const choice = mcp.selectedTools(row.original.agent_name);
+      return (
+        <label className="inline-flex items-center gap-2.5 whitespace-nowrap">
+          <Checkbox
+            aria-label={`Expose ${row.original.agent_display_name} through MCP`}
+            checked={
+              choice === null ? true : choice?.length ? "indeterminate" : false
+            }
+            disabled={mcp.loading || mcp.saving || mcp.error !== null}
+            onCheckedChange={(checked) =>
+              void mcp.toggle(row.original.agent_name, checked === true)
+            }
+          />
+          <span className="text-xs text-muted-foreground">
+            {choice === null
+              ? "All tools"
+              : choice?.length
+                ? `${choice.length} selected`
+                : "Off"}
+          </span>
+        </label>
+      );
+    },
+  },
+];
+
+export function AgentTable({
+  agents,
+  mcp,
+  refreshVersion,
+  onConnectionChange,
+}: {
+  agents: AgentConnections[];
+  mcp: McpSelectionState;
+  refreshVersion: number;
+  onConnectionChange: () => void;
+}) {
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+  const [search, setSearch] = useState("");
+  const [scope, setScope] = useState("all");
+  const data = useMemo(
+    () =>
+      agents
+        .filter((agent) =>
+          scope === "personal"
+            ? !agent.is_shared
+            : scope === "shared"
+              ? agent.is_shared
+              : scope === "exposed"
+                ? Object.prototype.hasOwnProperty.call(
+                    mcp.selection?.agents ?? {},
+                    agent.agent_name,
+                  )
+                : true,
+        )
+        .map((agent) => ({ ...agent, mcp })),
+    [agents, scope, mcp],
+  );
+  const table = useReactTable({
+    data,
+    columns,
+    state: { expanded, globalFilter: search },
+    onExpandedChange: setExpanded,
+    onGlobalFilterChange: setSearch,
+    getRowId: (agent) => `connection:${agent.agent_name}`,
+    getRowCanExpand: () => true,
+    autoResetPageIndex: false,
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _column, value: string) => {
+      const agent = row.original;
+      return [
+        agent.agent_name,
+        agent.agent_display_name,
+        ...agent.tools.flatMap((tool) => [tool.name, tool.display_name]),
+      ].some((name) => name.toLowerCase().includes(value.toLowerCase().trim()));
+    },
+  });
+  return (
+    <section
+      className="overflow-hidden rounded-2xl border bg-card shadow-sm"
+      aria-label="Agent connections"
+    >
+      <div className="flex flex-col gap-4 border-b px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <h2 className="font-semibold">Agents</h2>
+          <span className="rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+            {agents.length}
+          </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative flex-1 sm:w-64">
+            <Search
+              className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
+            <Input
+              type="search"
+              aria-label="Search agents or tools"
+              placeholder="Search agents or tools…"
+              className="h-9 pl-9"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
+          <select
+            aria-label="Filter agents"
+            value={scope}
+            onChange={(event) => setScope(event.target.value)}
+            className="h-9 rounded-lg border bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="all">All agents</option>
+            <option value="personal">Personal</option>
+            <option value="shared">Shared</option>
+            {mcp.selection?.enabled && (
+              <option value="exposed">MCP enabled</option>
+            )}
+          </select>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <table aria-label="Agents" className="w-full min-w-[680px] text-sm">
+          <thead className="bg-muted/30 text-left text-xs text-muted-foreground">
+            {table.getHeaderGroups().map((group) => (
+              <tr key={group.id}>
+                {group.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    scope="col"
+                    className="px-5 py-3 font-medium"
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext(),
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <Fragment key={row.id}>
+                <tr
+                  className={`border-t transition-colors hover:bg-muted/30 ${row.getIsExpanded() ? "bg-muted/30" : ""}`}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id} className="px-5 py-4">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </td>
+                  ))}
+                </tr>
+                {row.getIsExpanded() && (
+                  <tr>
+                    <td
+                      colSpan={columns.length}
+                      className="border-t border-border/60 p-0"
+                    >
+                      <section
+                        id={`agent-tools-${row.original.agent_name}`}
+                        aria-labelledby={`agent-${row.original.agent_name}`}
+                        className="border-l-2 border-primary/30 bg-background"
+                      >
+                        <AgentTools
+                          agent={row.original}
+                          mcp={mcp}
+                          refreshVersion={refreshVersion}
+                          onConnectionChange={onConnectionChange}
+                        />
+                      </section>
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            ))}
+            {!table.getRowModel().rows.length && (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="px-5 py-12 text-center text-muted-foreground"
+                >
+                  No agents match your search.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p className="border-t px-5 py-3 text-xs text-muted-foreground">
+        {table.getRowModel().rows.length} of {agents.length} agents · Expand an
+        agent to manage its connections and tools.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/connections/AgentTools.tsx
+++ b/frontend/src/connections/AgentTools.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { ConnectionServiceRows } from "./ConnectionServiceRows";
+import { ToolExposure, ToolName } from "./ToolRow";
+import type { AgentConnections } from "./types";
+import type { McpSelectionState } from "./useMcpSelection";
+
+export function AgentTools({
+  agent,
+  mcp,
+  refreshVersion,
+  onConnectionChange,
+}: {
+  agent: AgentConnections;
+  mcp: McpSelectionState;
+  refreshVersion: number;
+  onConnectionChange: () => void;
+}) {
+  const [otherOpen, setOtherOpen] = useState(false);
+  const otherTools = agent.tools.filter((tool) => tool.provider === null);
+  if (!agent.tools.length)
+    return (
+      <p className="px-6 py-5 text-sm text-muted-foreground">
+        No tools are available for this agent yet.
+      </p>
+    );
+  return (
+    <div className="overflow-x-auto">
+      <table
+        aria-label={`${agent.agent_display_name} tools`}
+        className="w-full min-w-[640px] text-sm"
+      >
+        <thead className="text-left text-xs text-muted-foreground">
+          <tr>
+            <th scope="col" className="w-[44%] px-5 py-3 font-medium">
+              Tool
+            </th>
+            <th scope="col" className="w-[25%] px-4 py-3 font-medium">
+              Connection
+            </th>
+            <th scope="col" className="w-[15%] px-4 py-3 font-medium">
+              MCP access
+            </th>
+            <th scope="col" className="px-5 py-3 text-right font-medium">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {agent.services.map((service) => (
+            <ConnectionServiceRows
+              key={service.provider}
+              agent={agent}
+              service={service}
+              mcp={mcp}
+              refreshVersion={refreshVersion}
+              onConnectionChange={onConnectionChange}
+            />
+          ))}
+          {otherTools.length > 0 && (
+            <>
+              <tr className="border-t border-border/60">
+                <td colSpan={4}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center gap-2 px-5 py-3 text-left text-sm hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                    aria-expanded={otherOpen}
+                    aria-label={`Other tools for ${agent.agent_display_name}`}
+                    onClick={() => setOtherOpen((open) => !open)}
+                  >
+                    {otherOpen ? (
+                      <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    )}
+                    <span className="font-medium">Other tools</span>
+                    <span className="rounded-md bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {otherTools.length}
+                    </span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      No additional setup
+                    </span>
+                  </button>
+                </td>
+              </tr>
+              {otherOpen &&
+                otherTools.map((tool) => (
+                  <tr key={tool.name} className="border-t border-border/60">
+                    <th scope="row" className="px-5 py-3 text-left font-normal">
+                      <ToolName tool={tool} />
+                    </th>
+                    <td className="px-4 py-3 text-xs text-muted-foreground">
+                      No setup needed
+                    </td>
+                    <td className="px-4 py-3">
+                      <ToolExposure agent={agent} tool={tool} mcp={mcp} />
+                    </td>
+                    <td />
+                  </tr>
+                ))}
+            </>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/connections/ConnectionIcon.tsx
+++ b/frontend/src/connections/ConnectionIcon.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { Plug } from "lucide-react";
 import { getIconForTool, iconMap } from "@/components/Integrations/iconMapping";
 
@@ -31,9 +32,11 @@ function nameVariants(name: string): string[] {
 export function ConnectionIcon({
   names,
   iconName,
+  className,
 }: {
   names: string[];
   iconName?: string | null;
+  className?: string;
 }) {
   const variants = new Set(names.flatMap(nameVariants));
   // Prefer specific names (Google Calendar) over generic ones (Calendar).
@@ -43,7 +46,10 @@ export function ConnectionIcon({
   return (
     <span
       aria-hidden="true"
-      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60 text-primary ring-1 ring-inset ring-border/60"
+      className={cn(
+        "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/60 text-primary ring-1 ring-inset ring-border/60",
+        className,
+      )}
     >
       {getIconForTool(iconName ?? null, null, fallbackIcon)}
     </span>

--- a/frontend/src/connections/ConnectionServiceRows.tsx
+++ b/frontend/src/connections/ConnectionServiceRows.tsx
@@ -1,0 +1,288 @@
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
+import { CheckCircle2, Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { connectWithPopup, type OAuthAuthorization } from "./oauthPopup";
+import { requestConnection } from "./request";
+import { ToolName, ToolExposure } from "./ToolRow";
+import type {
+  AgentConnections,
+  ConnectionService,
+  ConnectionStatus,
+} from "./types";
+import type { McpSelectionState } from "./useMcpSelection";
+
+/** One account status and operation lifecycle, even when several tools share it. */
+export function ConnectionServiceRows({
+  agent,
+  service,
+  mcp,
+  refreshVersion,
+  onConnectionChange,
+}: {
+  agent: AgentConnections;
+  service: ConnectionService;
+  mcp: McpSelectionState;
+  refreshVersion: number;
+  onConnectionChange: () => void;
+}) {
+  const [status, setStatus] = useState<ConnectionStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"connect" | "disconnect" | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const statusRequest = useRef<AbortController | null>(null);
+  const operation = useRef<AbortController | null>(null);
+  const basePath = `/api/connections/agents/${encodeURIComponent(agent.agent_name)}/${encodeURIComponent(service.provider)}`;
+
+  const loadStatus = useCallback(async () => {
+    statusRequest.current?.abort();
+    const controller = new AbortController();
+    statusRequest.current = controller;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await requestConnection<ConnectionStatus>(
+        `${basePath}/status`,
+        controller.signal,
+      );
+      if (!controller.signal.aborted) setStatus(next);
+    } catch {
+      if (!controller.signal.aborted) {
+        setStatus(null);
+        setError("Could not load connection status. Try again.");
+      }
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  }, [basePath]);
+
+  useEffect(() => {
+    void loadStatus();
+    return () => statusRequest.current?.abort();
+  }, [loadStatus, refreshVersion]);
+
+  useEffect(() => () => operation.current?.abort(), []);
+
+  const connect = async () => {
+    const controller = new AbortController();
+    operation.current = controller;
+    setBusy("connect");
+    setError(null);
+    try {
+      await connectWithPopup(
+        service.provider,
+        () =>
+          requestConnection<OAuthAuthorization>(
+            `${basePath}/connect`,
+            controller.signal,
+            "POST",
+          ),
+        controller.signal,
+      );
+      if (!controller.signal.aborted) onConnectionChange();
+    } catch (cause) {
+      if (!controller.signal.aborted)
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Could not connect. Try again.",
+        );
+    } finally {
+      if (!controller.signal.aborted) setBusy(null);
+    }
+  };
+
+  const disconnect = async () => {
+    setConfirmOpen(false);
+    setBusy("disconnect");
+    setError(null);
+    const controller = new AbortController();
+    operation.current = controller;
+    try {
+      await requestConnection(
+        `${basePath}/disconnect`,
+        controller.signal,
+        "POST",
+      );
+      if (!controller.signal.aborted) onConnectionChange();
+    } catch (cause) {
+      if (!controller.signal.aborted)
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : "Could not disconnect. Try again.",
+        );
+    } finally {
+      if (!controller.signal.aborted) setBusy(null);
+    }
+  };
+
+  const tools = agent.tools.filter(
+    (tool) => tool.provider === service.provider,
+  );
+  return (
+    <>
+      {tools.map((tool, index) => (
+        <Fragment key={tool.name}>
+          <tr className="border-t border-border/60">
+            <th scope="row" className="px-5 py-3 text-left font-normal">
+              <ToolName tool={tool} />
+            </th>
+            {index === 0 && (
+              <td rowSpan={tools.length} className="px-4 py-3 align-top">
+                {loading ? (
+                  <span
+                    role="status"
+                    className="flex items-center gap-2 text-sm text-muted-foreground"
+                  >
+                    <Loader2
+                      className="h-3.5 w-3.5 animate-spin"
+                      aria-hidden="true"
+                    />
+                    Checking connection…
+                  </span>
+                ) : (
+                  status && (
+                    <>
+                      <span className="flex items-center gap-1.5 text-sm">
+                        {status.connected && (
+                          <CheckCircle2
+                            className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400"
+                            aria-hidden="true"
+                          />
+                        )}
+                        {status.reset_required
+                          ? "Reset required"
+                          : status.connected
+                            ? "Connected"
+                            : "Not connected"}
+                      </span>
+                      {status.account_label && (
+                        <p className="mt-1 max-w-56 break-all text-xs text-muted-foreground">
+                          {status.account_label}
+                        </p>
+                      )}
+                    </>
+                  )
+                )}
+                {error && (
+                  <Alert variant="destructive" className="mt-2 p-2">
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+              </td>
+            )}
+            <td className="px-4 py-3">
+              <ToolExposure agent={agent} tool={tool} mcp={mcp} />
+            </td>
+            {index === 0 && (
+              <td
+                rowSpan={tools.length}
+                className="px-5 py-3 text-right align-top"
+              >
+                {!loading && !status && (
+                  <Button variant="outline" onClick={() => void loadStatus()}>
+                    Retry status
+                  </Button>
+                )}
+                {!loading && status && (
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    {status.reset_required ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy !== null}
+                        aria-label={`Reset ${service.display_name} connection`}
+                        onClick={() => setConfirmOpen(true)}
+                      >
+                        Reset connection
+                      </Button>
+                    ) : status.connected ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={busy !== null}
+                        aria-label={`Disconnect ${service.display_name}`}
+                        onClick={() => setConfirmOpen(true)}
+                      >
+                        Disconnect
+                      </Button>
+                    ) : (
+                      <Button
+                        size="sm"
+                        disabled={busy !== null || !status.can_connect}
+                        aria-label={`Connect ${service.display_name}`}
+                        onClick={() => void connect()}
+                      >
+                        {busy === "connect" ? "Connecting…" : "Connect"}
+                      </Button>
+                    )}
+                    {busy === "connect" && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => {
+                          operation.current?.abort();
+                          setBusy(null);
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    )}
+                    {!status.connected &&
+                      !status.can_connect &&
+                      !status.reset_required && (
+                        <p className="w-full text-sm text-muted-foreground">
+                          This service is not ready to connect yet.
+                        </p>
+                      )}
+                  </div>
+                )}
+                <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>
+                        {status?.reset_required ? "Reset" : "Disconnect"}{" "}
+                        {service.display_name}?
+                      </DialogTitle>
+                      <DialogDescription>
+                        {service.is_shared
+                          ? `This removes the saved connection used by ${agent.agent_display_name}. Anyone using this connection will lose access until you connect again.`
+                          : "This removes your saved connection. Your assistant will lose access until you connect again."}
+                      </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                      <Button
+                        variant="outline"
+                        onClick={() => setConfirmOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        variant="destructive"
+                        onClick={() => void disconnect()}
+                      >
+                        {status?.reset_required
+                          ? "Reset connection"
+                          : "Disconnect"}
+                      </Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </td>
+            )}
+          </tr>
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/connections/Connections.test.tsx
+++ b/frontend/src/connections/Connections.test.tsx
@@ -9,8 +9,10 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Connections } from "./Connections";
+import type { ConnectionService } from "./types";
 
-const service = {
+const service: ConnectionService = {
+  icon: null,
   provider: "mail",
   is_shared: false,
   display_name: "Mail",
@@ -34,7 +36,16 @@ const catalog = (services: (typeof service)[]) => ({
       agent_display_name: "Personal assistant",
       is_shared: false,
       services,
-      tools: [],
+      tools: services.flatMap((item) =>
+        item.tools.map((name) => ({
+          name,
+          display_name: item.display_name,
+          description: item.description,
+          provider: item.provider,
+          requires_room_context: false,
+          icon: item.icon,
+        })),
+      ),
     },
   ],
 });
@@ -45,7 +56,7 @@ function installApi(overrides: Record<string, () => Promise<Response>> = {}) {
     if (overrides[path]) return overrides[path]();
     if (path === "/api/connections") return json(catalog([service]));
     if (path === "/api/connections/mcp/selection")
-      return json({ enabled: false, selected_agents: [] });
+      return json({ enabled: false, agents: {} });
     if (path === "/api/connections/mcp/clients")
       return json({ enabled: false, clients: [] });
     if (path === "/api/connections/agents/personal/mail/status")
@@ -58,6 +69,12 @@ function installApi(overrides: Record<string, () => Promise<Response>> = {}) {
   });
 }
 
+async function expandAgent(name = "Personal assistant") {
+  fireEvent.click(
+    await screen.findByRole("button", { name: `Expand ${name}` }),
+  );
+}
+
 beforeEach(() => installApi());
 afterEach(() => {
   cleanup();
@@ -65,16 +82,39 @@ afterEach(() => {
 });
 
 describe("connections", () => {
-  it("shows only the server's services without loading dashboard configuration", async () => {
+  it("keeps agents collapsed and loads connections only after expansion", async () => {
     render(<Connections />);
     expect(
-      await screen.findByRole("heading", { name: "Mail" }),
+      await screen.findByRole("table", { name: "Agents" }),
     ).toBeInTheDocument();
+    const expand = screen.getByRole("button", {
+      name: "Expand Personal assistant",
+    });
+    expect(expand).toHaveAttribute("aria-expanded", "false");
+    expect(fetch).not.toHaveBeenCalledWith(
+      "/api/connections/agents/personal/mail/status",
+      expect.anything(),
+    );
+    fireEvent.click(expand);
+    expect(
+      await screen.findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("table", { name: "Personal assistant tools" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows only the server's services without loading dashboard configuration", async () => {
+    render(<Connections />);
+    await expandAgent();
+    expect(await screen.findByText("Mail")).toBeInTheDocument();
     expect(screen.getByText("Personal assistant")).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "Connect Mail" }),
     ).toBeEnabled();
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Filter agents" }),
+    ).toBeInTheDocument();
     expect(
       vi
         .mocked(fetch)
@@ -97,7 +137,12 @@ describe("connections", () => {
         json(
           catalog([
             service,
-            { ...service, provider: "calendar", display_name: "Calendar" },
+            {
+              ...service,
+              provider: "calendar",
+              display_name: "Calendar",
+              tools: ["calendar"],
+            },
           ]),
         ),
       "/api/connections/agents/personal/mail/status": () =>
@@ -113,6 +158,7 @@ describe("connections", () => {
         }),
     });
     render(<Connections />);
+    await expandAgent();
     expect(
       await screen.findByRole("button", { name: "Disconnect Calendar" }),
     ).toBeEnabled();
@@ -130,13 +176,14 @@ describe("connections", () => {
     ).toBeEnabled();
   });
 
-  it("keeps service cards usable while the client list fails", async () => {
+  it("keeps connection rows usable while the client list fails", async () => {
     installApi({
       "/api/connections/mcp/clients": async () =>
         json({ detail: "Sensitive server detail" }, 500),
     });
 
     render(<Connections />);
+    await expandAgent();
 
     expect(
       await screen.findByRole("button", { name: "Connect Mail" }),
@@ -164,6 +211,7 @@ describe("connections", () => {
       },
     });
     render(<Connections />);
+    await expandAgent();
     fireEvent.click(
       await screen.findByRole("button", { name: "Disconnect Mail" }),
     );
@@ -187,6 +235,7 @@ describe("connections", () => {
       },
     });
     render(<Connections />);
+    await expandAgent();
     fireEvent.click(
       await screen.findByRole("button", { name: "Reset Mail connection" }),
     );
@@ -223,6 +272,7 @@ describe("connections", () => {
       },
     });
     render(<Connections />);
+    await expandAgent();
     fireEvent.click(
       await screen.findByRole("button", { name: "Connect Mail" }),
     );
@@ -254,6 +304,7 @@ describe("connections", () => {
       "/api/connections": async () => json(catalog([])),
     });
     render(<Connections />);
+    await expandAgent();
     expect(await screen.findByText(/no tools.*available/i)).toBeInTheDocument();
   });
 
@@ -289,6 +340,7 @@ describe("connections", () => {
         json({ ...status, can_connect: false }),
     });
     render(<Connections />);
+    await expandAgent();
     expect(
       await screen.findByRole("button", { name: "Connect Mail" }),
     ).toBeDisabled();
@@ -307,6 +359,7 @@ describe("connections", () => {
         new Promise(() => {}),
     });
     const { unmount } = render(<Connections />);
+    await expandAgent();
     fireEvent.click(
       await screen.findByRole("button", { name: "Connect Mail" }),
     );
@@ -328,7 +381,7 @@ describe("shared agent connections", () => {
               agent_name: "research",
               agent_display_name: "Research Team",
               is_shared: true,
-              tools: [],
+              tools: catalog([service]).agents[0].tools,
               services: [service],
             },
           ],
@@ -341,6 +394,8 @@ describe("shared agent connections", () => {
       },
     });
     render(<Connections />);
+    await expandAgent();
+    await expandAgent("Research Team");
     const personal = await screen.findByRole("region", {
       name: "Personal assistant",
     });
@@ -373,7 +428,7 @@ describe("shared agent connections", () => {
               agent_name: "research",
               agent_display_name: "Research Team",
               is_shared: true,
-              tools: [],
+              tools: catalog([service]).agents[0].tools,
               services: [service],
             },
           ],
@@ -381,6 +436,7 @@ describe("shared agent connections", () => {
       "/api/connections/agents/research/mail/status": async () => json(status),
     });
     render(<Connections />);
+    await expandAgent("Research Team");
     expect(
       await screen.findByRole("button", { name: "Connect Mail" }),
     ).toBeEnabled();
@@ -400,7 +456,7 @@ describe("shared agent connections", () => {
               agent_name: "research",
               agent_display_name: "Research Team",
               is_shared: true,
-              tools: [],
+              tools: catalog([service]).agents[0].tools,
               services: [{ ...service, is_shared: true }],
             },
           ],
@@ -417,6 +473,8 @@ describe("shared agent connections", () => {
       },
     });
     render(<Connections />);
+    await expandAgent();
+    await expandAgent("Research Team");
     const personal = await screen.findByRole("region", {
       name: "Personal assistant",
     });
@@ -424,7 +482,11 @@ describe("shared agent connections", () => {
     expect(
       await within(personal).findByRole("button", { name: "Connect Mail" }),
     ).toBeEnabled();
-    expect(within(shared).getByText("Shared agent")).toBeInTheDocument();
+    expect(
+      screen
+        .getByRole("button", { name: "Collapse Research Team" })
+        .closest("tr"),
+    ).toHaveTextContent("Shared");
     fireEvent.click(
       await within(shared).findByRole("button", { name: "Disconnect Mail" }),
     );
@@ -451,7 +513,7 @@ it("describes a requester-only connection on a shared agent as personal", async 
             agent_name: "research",
             agent_display_name: "Research Team",
             is_shared: true,
-            tools: [],
+            tools: catalog([service]).agents[0].tools,
             services: [service],
           },
         ],
@@ -460,6 +522,7 @@ it("describes a requester-only connection on a shared agent as personal", async 
       json({ ...status, connected: true }),
   });
   render(<Connections />);
+  await expandAgent("Research Team");
   fireEvent.click(
     await screen.findByRole("button", { name: "Disconnect Mail" }),
   );
@@ -475,11 +538,13 @@ describe("MCP agent selection", () => {
       {
         ...catalog([service]).agents[0],
         tools: [
+          ...catalog([service]).agents[0].tools,
           {
             name: "calculator",
             display_name: "Calculator",
             description: "Calculate numbers.",
             provider: null,
+            icon: null,
             requires_room_context: false,
           },
           {
@@ -487,6 +552,7 @@ describe("MCP agent selection", () => {
             display_name: "Matrix Message",
             description: "Send room messages.",
             provider: null,
+            icon: null,
             requires_room_context: true,
           },
         ],
@@ -502,6 +568,7 @@ describe("MCP agent selection", () => {
             display_name: "Web Search",
             description: "Search the web.",
             provider: null,
+            icon: null,
             requires_room_context: false,
           },
         ],
@@ -512,12 +579,15 @@ describe("MCP agent selection", () => {
   it("lists tools without authentication and marks room-dependent tools", async () => {
     installApi({ "/api/connections": async () => json(withTools()) });
     render(<Connections />);
-    expect(
-      await screen.findByRole("heading", { name: "Calculator" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Matrix Message" }),
-    ).toBeInTheDocument();
+    await expandAgent();
+    expect(screen.queryByText("Calculator")).not.toBeInTheDocument();
+    const other = screen.getByRole("button", {
+      name: "Other tools for Personal assistant",
+    });
+    expect(other).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(other);
+    expect(await screen.findByText("Calculator")).toBeInTheDocument();
+    expect(screen.getByText("Matrix Message")).toBeInTheDocument();
     expect(screen.getByText("MindRoom only")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Connect Calculator" }),
@@ -525,17 +595,173 @@ describe("MCP agent selection", () => {
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
   });
 
+  it("keeps individual tool choices separate per agent and supports all or off", async () => {
+    let selected: Record<string, string[] | null> = { personal: null };
+    const data = withTools();
+    data.agents[1].tools = data.agents[0].tools.filter(
+      (tool) => tool.provider === null,
+    );
+    installApi({ "/api/connections": async () => json(data) });
+    const fallback = vi.mocked(fetch).getMockImplementation()!;
+    vi.mocked(fetch).mockImplementation(async (input, options) => {
+      if (String(input) !== selectionPath) return fallback(input, options);
+      if (options?.method === "POST")
+        selected = JSON.parse(String(options.body)).agents;
+      return json({ enabled: true, agents: selected });
+    });
+    render(<Connections />);
+    await expandAgent();
+    await expandAgent("Research Team");
+    for (const name of ["Personal assistant", "Research Team"]) {
+      fireEvent.click(
+        screen.getByRole("button", { name: `Other tools for ${name}` }),
+      );
+    }
+    const personalTool = screen.getByRole("checkbox", {
+      name: "Expose Calculator for Personal assistant through MCP",
+    });
+    const sharedTool = screen.getByRole("checkbox", {
+      name: "Expose Calculator for Research Team through MCP",
+    });
+    const personal = screen.getByRole("checkbox", {
+      name: "Expose Personal assistant through MCP",
+    });
+    expect(personalTool).toBeChecked();
+    expect(sharedTool).not.toBeChecked();
+    fireEvent.click(personalTool);
+    await waitFor(() => expect(selected).toEqual({ personal: ["mail"] }));
+    expect(personal).toHaveAttribute("aria-checked", "mixed");
+    fireEvent.click(sharedTool);
+    await waitFor(() =>
+      expect(selected).toEqual({ personal: ["mail"], shared: ["calculator"] }),
+    );
+    expect(personalTool).not.toBeChecked();
+    expect(sharedTool).toBeChecked();
+    fireEvent.click(sharedTool);
+    await waitFor(() => expect(selected).toEqual({ personal: ["mail"] }));
+    fireEvent.click(personal);
+    await waitFor(() => expect(selected).toEqual({ personal: null }));
+    expect(personalTool).toBeChecked();
+    fireEvent.click(personal);
+    await waitFor(() => expect(selected).toEqual({}));
+    expect(personalTool).not.toBeChecked();
+    expect(
+      screen.queryByRole("checkbox", { name: /Expose Matrix Message/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters by tool name, agent type, and MCP access without fetching hidden statuses", async () => {
+    installApi({
+      "/api/connections": async () => json(withTools()),
+      [selectionPath]: async () =>
+        json({ enabled: true, agents: { personal: null } }),
+    });
+    render(<Connections />);
+    await screen.findByRole("button", { name: "Expand Research Team" });
+    const search = screen.getByRole("searchbox", {
+      name: "Search agents or tools",
+    });
+    const filter = screen.getByRole("combobox", { name: "Filter agents" });
+    fireEvent.change(search, { target: { value: "WEB SEARCH" } });
+    expect(
+      screen.queryByRole("button", { name: "Expand Personal assistant" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Expand Research Team" }),
+    ).toBeInTheDocument();
+    fireEvent.change(search, { target: { value: "" } });
+    fireEvent.change(filter, { target: { value: "personal" } });
+    expect(
+      screen.queryByRole("button", { name: "Expand Research Team" }),
+    ).not.toBeInTheDocument();
+    fireEvent.change(filter, { target: { value: "shared" } });
+    expect(
+      screen.queryByRole("button", { name: "Expand Personal assistant" }),
+    ).not.toBeInTheDocument();
+    fireEvent.change(filter, { target: { value: "exposed" } });
+    expect(
+      screen.getByRole("button", { name: "Expand Personal assistant" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Expand Research Team" }),
+    ).not.toBeInTheDocument();
+    expect(fetch).not.toHaveBeenCalledWith(
+      "/api/connections/agents/personal/mail/status",
+      expect.anything(),
+    );
+  });
+
+  it.each(["constructor", "__proto__"])(
+    "handles an agent named %s independently of object keys",
+    async (name) => {
+      const data = catalog([]);
+      data.agents[0].agent_name = name;
+      installApi({
+        "/api/connections": async () => json(data),
+        [selectionPath]: async () => json({ enabled: true, agents: {} }),
+      });
+      const fallback = vi.mocked(fetch).getMockImplementation()!;
+      vi.mocked(fetch).mockImplementation(async (input, options) => {
+        if (String(input) === selectionPath && options?.method === "POST") {
+          const { agents } = JSON.parse(String(options.body));
+          expect(Object.keys(agents)).toEqual([name]);
+          expect(agents[name]).toBeNull();
+          return json({ enabled: true, agents });
+        }
+        return fallback(input, options);
+      });
+      render(<Connections />);
+      expect(
+        await screen.findByRole("button", {
+          name: "Expand Personal assistant",
+        }),
+      ).toHaveAttribute("aria-expanded", "false");
+      const checkbox = screen.getByRole("checkbox", {
+        name: "Expose Personal assistant through MCP",
+      });
+      expect(checkbox).not.toBeChecked();
+      fireEvent.click(checkbox);
+      await waitFor(() => expect(checkbox).toBeChecked());
+    },
+  );
+
+  it("renders each toolkit separately while sharing one provider connection", async () => {
+    const data = catalog([{ ...service, tools: ["mail", "contacts"] }]);
+    data.agents[0].tools[1].display_name = "Contacts";
+    installApi({ "/api/connections": async () => json(data) });
+    render(<Connections />);
+    await expandAgent();
+    expect(
+      await screen.findByRole("button", { name: "Connect Mail" }),
+    ).toBeEnabled();
+    const rows = within(
+      screen.getByRole("table", { name: "Personal assistant tools" }),
+    ).getAllByRole("row");
+    expect(rows).toHaveLength(3);
+    expect(rows[1]).toHaveTextContent("Mail");
+    expect(rows[2]).toHaveTextContent("Contacts");
+    expect(
+      screen.getAllByRole("button", { name: "Connect Mail" }),
+    ).toHaveLength(1);
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.filter(([url]) => String(url).endsWith("/mail/status")),
+    ).toHaveLength(1);
+  });
+
   it("saves one complete selection for all clients, including empty", async () => {
-    let selected = ["personal"];
+    let selected: Record<string, string[] | null> = { personal: null };
     installApi({ "/api/connections": async () => json(withTools()) });
     const fallback = vi.mocked(fetch).getMockImplementation()!;
     vi.mocked(fetch).mockImplementation(async (input, options) => {
       if (String(input) !== selectionPath) return fallback(input, options);
       if (options?.method === "POST")
         selected = JSON.parse(String(options.body)).agents;
-      return json({ enabled: true, selected_agents: selected });
+      return json({ enabled: true, agents: selected });
     });
     render(<Connections />);
+    await expandAgent();
     const personal = await screen.findByRole("checkbox", {
       name: "Expose Personal assistant through MCP",
     });
@@ -547,12 +773,12 @@ describe("MCP agent selection", () => {
     expect(screen.getByText(/every connected MCP client/i)).toBeInTheDocument();
     fireEvent.click(shared);
     await waitFor(() => expect(shared).toBeChecked());
-    expect(selected).toEqual(["personal", "shared"]);
+    expect(selected).toEqual({ personal: null, shared: null });
     fireEvent.click(personal);
     await waitFor(() => expect(personal).not.toBeChecked());
     fireEvent.click(shared);
     await waitFor(() => expect(shared).not.toBeChecked());
-    expect(selected).toEqual([]);
+    expect(selected).toEqual({});
     expect(screen.getByRole("button", { name: "Connect Mail" })).toBeEnabled();
   });
 
@@ -566,9 +792,10 @@ describe("MCP agent selection", () => {
         return new Promise((resolve) => {
           finish = resolve;
         });
-      return json({ enabled: true, selected_agents: ["personal"] });
+      return json({ enabled: true, agents: { personal: null } });
     });
     render(<Connections />);
+    await expandAgent();
     const personal = await screen.findByRole("checkbox", {
       name: "Expose Personal assistant through MCP",
     });

--- a/frontend/src/connections/Connections.tsx
+++ b/frontend/src/connections/Connections.tsx
@@ -1,312 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { CheckCircle2, Loader2, Plug } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Plug } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { ConnectedClients } from "./ConnectedClients";
-import { ConnectionIcon } from "./ConnectionIcon";
-import { connectWithPopup, type OAuthAuthorization } from "./oauthPopup";
+import { AgentTable } from "./AgentTable";
 import { requestConnection } from "./request";
 import { useMcpSelection } from "./useMcpSelection";
-
-interface ConnectionService {
-  provider: string;
-  is_shared: boolean;
-  display_name: string;
-  description: string;
-  icon: string | null;
-  tools: string[];
-}
-
-interface AgentConnections {
-  agent_name: string;
-  agent_display_name: string;
-  is_shared: boolean;
-  services: ConnectionService[];
-  tools: ConnectionTool[];
-}
-
-interface ConnectionTool {
-  name: string;
-  display_name: string;
-  description: string;
-  icon: string | null;
-  provider: string | null;
-  requires_room_context: boolean;
-}
-
-interface ConnectionList {
-  agents: AgentConnections[];
-}
-
-interface ConnectionStatus {
-  provider: string;
-  connected: boolean;
-  can_connect: boolean;
-  reset_required: boolean;
-  account_label: string | null;
-}
-
-function ConnectionCard({
-  agent,
-  service,
-  refreshVersion,
-  onConnectionChange,
-}: {
-  agent: AgentConnections;
-  service: ConnectionService;
-  refreshVersion: number;
-  onConnectionChange: () => void;
-}) {
-  const [status, setStatus] = useState<ConnectionStatus | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [busy, setBusy] = useState<"connect" | "disconnect" | null>(null);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const statusRequest = useRef<AbortController | null>(null);
-  const operation = useRef<AbortController | null>(null);
-  const basePath = `/api/connections/agents/${encodeURIComponent(agent.agent_name)}/${encodeURIComponent(service.provider)}`;
-
-  const loadStatus = useCallback(async () => {
-    statusRequest.current?.abort();
-    const controller = new AbortController();
-    statusRequest.current = controller;
-    setLoading(true);
-    setError(null);
-    try {
-      const next = await requestConnection<ConnectionStatus>(
-        `${basePath}/status`,
-        controller.signal,
-      );
-      if (!controller.signal.aborted) setStatus(next);
-    } catch {
-      if (!controller.signal.aborted) {
-        setStatus(null);
-        setError("Could not load connection status. Try again.");
-      }
-    } finally {
-      if (!controller.signal.aborted) setLoading(false);
-    }
-  }, [basePath]);
-
-  useEffect(() => {
-    void loadStatus();
-    return () => statusRequest.current?.abort();
-  }, [loadStatus, refreshVersion]);
-
-  useEffect(() => () => operation.current?.abort(), []);
-
-  const connect = async () => {
-    const controller = new AbortController();
-    operation.current = controller;
-    setBusy("connect");
-    setError(null);
-    try {
-      await connectWithPopup(
-        service.provider,
-        () =>
-          requestConnection<OAuthAuthorization>(
-            `${basePath}/connect`,
-            controller.signal,
-            "POST",
-          ),
-        controller.signal,
-      );
-      if (!controller.signal.aborted) onConnectionChange();
-    } catch (cause) {
-      if (!controller.signal.aborted)
-        setError(
-          cause instanceof Error
-            ? cause.message
-            : "Could not connect. Try again.",
-        );
-    } finally {
-      if (!controller.signal.aborted) setBusy(null);
-    }
-  };
-
-  const disconnect = async () => {
-    setConfirmOpen(false);
-    setBusy("disconnect");
-    setError(null);
-    const controller = new AbortController();
-    operation.current = controller;
-    try {
-      await requestConnection(
-        `${basePath}/disconnect`,
-        controller.signal,
-        "POST",
-      );
-      if (!controller.signal.aborted) onConnectionChange();
-    } catch (cause) {
-      if (!controller.signal.aborted)
-        setError(
-          cause instanceof Error
-            ? cause.message
-            : "Could not disconnect. Try again.",
-        );
-    } finally {
-      if (!controller.signal.aborted) setBusy(null);
-    }
-  };
-
-  return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-start gap-3">
-          <ConnectionIcon
-            names={[service.provider, service.display_name, ...service.tools]}
-            iconName={service.icon}
-          />
-          <div className="min-w-0 flex-1 space-y-2">
-            <CardTitle className="break-words text-lg">
-              {service.display_name}
-            </CardTitle>
-            {!loading && status && (
-              <Badge variant={status.connected ? "default" : "secondary"}>
-                {status.connected ? "Connected" : "Not connected"}
-              </Badge>
-            )}
-          </div>
-        </div>
-        <CardDescription>{service.description}</CardDescription>
-        <div className="flex flex-wrap gap-2">
-          {service.tools.map((name) => {
-            const tool = agent.tools.find((item) => item.name === name);
-            return (
-              <Badge key={name} variant="outline">
-                {tool?.display_name ?? name}
-                {tool?.requires_room_context ? " · MindRoom only" : ""}
-              </Badge>
-            );
-          })}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {loading && (
-          <p
-            role="status"
-            className="flex items-center gap-2 text-sm text-muted-foreground"
-          >
-            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-            Checking connection…
-          </p>
-        )}
-        {!loading && status?.account_label && (
-          <p className="flex items-center gap-2 break-all text-sm">
-            <CheckCircle2
-              className="h-4 w-4 shrink-0 text-primary"
-              aria-hidden="true"
-            />
-            {status.account_label}
-          </p>
-        )}
-        {status?.reset_required && (
-          <p className="text-sm text-muted-foreground">
-            This connection needs to be reset before you can connect again.
-          </p>
-        )}
-        {error && (
-          <Alert variant="destructive">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-        {!loading && !status && (
-          <Button variant="outline" onClick={() => void loadStatus()}>
-            Retry status
-          </Button>
-        )}
-        {!loading && status && (
-          <div className="flex flex-wrap gap-2">
-            {status.reset_required ? (
-              <Button
-                variant="outline"
-                disabled={busy !== null}
-                aria-label={`Reset ${service.display_name} connection`}
-                onClick={() => setConfirmOpen(true)}
-              >
-                Reset connection
-              </Button>
-            ) : status.connected ? (
-              <Button
-                variant="outline"
-                disabled={busy !== null}
-                aria-label={`Disconnect ${service.display_name}`}
-                onClick={() => setConfirmOpen(true)}
-              >
-                Disconnect
-              </Button>
-            ) : (
-              <Button
-                disabled={busy !== null || !status.can_connect}
-                aria-label={`Connect ${service.display_name}`}
-                onClick={() => void connect()}
-              >
-                {busy === "connect" ? "Connecting…" : "Connect"}
-              </Button>
-            )}
-            {busy === "connect" && (
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  operation.current?.abort();
-                  setBusy(null);
-                }}
-              >
-                Cancel
-              </Button>
-            )}
-            {!status.connected &&
-              !status.can_connect &&
-              !status.reset_required && (
-                <p className="w-full text-sm text-muted-foreground">
-                  This service is not ready to connect yet.
-                </p>
-              )}
-          </div>
-        )}
-      </CardContent>
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>
-              {status?.reset_required ? "Reset" : "Disconnect"}{" "}
-              {service.display_name}?
-            </DialogTitle>
-            <DialogDescription>
-              {service.is_shared
-                ? `This removes the saved connection used by ${agent.agent_display_name}. Anyone using this connection will lose access until you connect again.`
-                : "This removes your saved connection. Your assistant will lose access until you connect again."}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={() => void disconnect()}>
-              {status?.reset_required ? "Reset connection" : "Disconnect"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </Card>
-  );
-}
+import type { ConnectionList } from "./types";
 
 export function Connections() {
   const mcp = useMcpSelection();
@@ -335,24 +35,26 @@ export function Connections() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-background px-5 py-12 sm:py-16">
-      <div className="mx-auto max-w-3xl space-y-8">
-        <header className="space-y-3">
-          <Plug className="h-8 w-8 text-primary" aria-hidden="true" />
-          <h1 className="text-3xl font-semibold tracking-tight">
-            Your connections
-          </h1>
-          <p className="text-muted-foreground">
-            Connect services for your personal assistant and shared agents you
-            manage, and choose which tools your MCP clients can use.
-          </p>
+    <main className="min-h-screen bg-muted/20 px-4 py-8 sm:px-6 sm:py-12">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="flex items-start gap-4">
+          <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border bg-background shadow-sm">
+            <Plug className="h-5 w-5 text-primary" aria-hidden="true" />
+          </span>
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-semibold tracking-tight sm:text-3xl">
+              Your connections
+            </h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
+              Manage accounts and choose which tools your MCP clients can use.
+            </p>
+          </div>
         </header>
-        <ConnectedClients />
         {mcp.selection?.enabled && (
           <p className="text-sm text-muted-foreground">
-            Expose an agent below to make its compatible tools available to
-            every connected MCP client. Your selection only affects your
-            clients.
+            MCP access applies to every connected MCP client for your account.
+            Select all compatible tools for an agent, or expand it to choose
+            individual tools.
           </p>
         )}
         {mcp.loading && (
@@ -365,6 +67,7 @@ export function Connections() {
             <AlertDescription>{mcp.error}</AlertDescription>
             <Button
               variant="outline"
+              size="sm"
               className="mt-3"
               disabled={mcp.loading || mcp.saving}
               onClick={() => void mcp.reload()}
@@ -381,83 +84,15 @@ export function Connections() {
         {!connections && !error && (
           <p role="status">Loading your connections…</p>
         )}
-        {connections?.agents.map((agent) => (
-          <section
-            key={agent.agent_name}
-            aria-labelledby={`agent-${agent.agent_name}`}
-            className="space-y-4"
-          >
-            <div className="flex items-center gap-3">
-              <h2
-                id={`agent-${agent.agent_name}`}
-                className="text-xl font-semibold"
-              >
-                {agent.agent_display_name}
-              </h2>
-              <Badge variant="secondary">
-                {agent.is_shared ? "Shared agent" : "Personal agent"}
-              </Badge>
-            </div>
-            {mcp.selection?.enabled && (
-              <label className="flex items-center gap-3 text-sm">
-                <input
-                  type="checkbox"
-                  className="h-4 w-4 accent-primary"
-                  aria-label={`Expose ${agent.agent_display_name} through MCP`}
-                  checked={mcp.selection.selected_agents.includes(
-                    agent.agent_name,
-                  )}
-                  disabled={mcp.loading || mcp.saving || mcp.error !== null}
-                  onChange={(event) =>
-                    void mcp.toggle(agent.agent_name, event.target.checked)
-                  }
-                />
-                Expose through MCP
-              </label>
-            )}
-            {agent.services.length === 0 && agent.tools.length === 0 && (
-              <Card>
-                <CardContent className="pt-6 text-muted-foreground">
-                  No tools are available for this agent yet.
-                </CardContent>
-              </Card>
-            )}
-            <div className="grid gap-5 sm:grid-cols-2">
-              {agent.services.map((service) => (
-                <ConnectionCard
-                  key={service.provider}
-                  agent={agent}
-                  service={service}
-                  refreshVersion={refreshVersion}
-                  onConnectionChange={refreshConnections}
-                />
-              ))}
-              {agent.tools
-                .filter((tool) => tool.provider === null)
-                .map((tool) => (
-                  <Card key={tool.name}>
-                    <CardHeader>
-                      <div className="flex items-start gap-3">
-                        <ConnectionIcon
-                          names={[tool.name, tool.display_name]}
-                          iconName={tool.icon}
-                        />
-                        <div className="min-w-0 flex-1 space-y-2">
-                          <CardTitle className="break-words text-lg">
-                            {tool.display_name}
-                          </CardTitle>
-                          {tool.requires_room_context && (
-                            <Badge variant="secondary">MindRoom only</Badge>
-                          )}
-                        </div>
-                      </div>
-                      <CardDescription>{tool.description}</CardDescription>
-                    </CardHeader>
-                  </Card>
-                ))}
-            </div>
-          </section>
-        ))}
+        {connections && (
+          <AgentTable
+            agents={connections.agents}
+            mcp={mcp}
+            refreshVersion={refreshVersion}
+            onConnectionChange={refreshConnections}
+          />
+        )}
+        <ConnectedClients />
       </div>
     </main>
   );

--- a/frontend/src/connections/ToolRow.tsx
+++ b/frontend/src/connections/ToolRow.tsx
@@ -1,0 +1,51 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { ConnectionIcon } from "./ConnectionIcon";
+import type { AgentConnections, ConnectionTool } from "./types";
+import type { McpSelectionState } from "./useMcpSelection";
+
+export function ToolName({ tool }: { tool: ConnectionTool }) {
+  return (
+    <div className="flex items-center gap-3">
+      <ConnectionIcon
+        names={[tool.name, tool.display_name]}
+        iconName={tool.icon}
+        className="h-8 w-8 rounded-lg [&_svg]:h-4 [&_svg]:w-4"
+      />
+      <div className="min-w-0">
+        <span className="font-medium">{tool.display_name}</span>
+        <p
+          className="mt-0.5 max-w-md truncate text-xs text-muted-foreground"
+          title={tool.description}
+        >
+          {tool.description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function ToolExposure({
+  agent,
+  tool,
+  mcp,
+}: {
+  agent: AgentConnections;
+  tool: ConnectionTool;
+  mcp: McpSelectionState;
+}) {
+  if (tool.requires_room_context)
+    return <span className="text-xs text-muted-foreground">MindRoom only</span>;
+  if (!mcp.selection?.enabled)
+    return <span className="text-muted-foreground">—</span>;
+  const selected = mcp.selectedTools(agent.agent_name);
+  return (
+    <Checkbox
+      aria-label={`Expose ${tool.display_name} for ${agent.agent_display_name} through MCP`}
+      checked={selected === null || selected?.includes(tool.name) === true}
+      disabled={mcp.loading || mcp.saving || mcp.error !== null}
+      onCheckedChange={(checked) =>
+        void mcp.toggleTool(agent, tool.name, checked === true)
+      }
+    />
+  );
+}

--- a/frontend/src/connections/types.ts
+++ b/frontend/src/connections/types.ts
@@ -1,0 +1,37 @@
+export interface ConnectionService {
+  provider: string;
+  is_shared: boolean;
+  display_name: string;
+  description: string;
+  icon: string | null;
+  tools: string[];
+}
+
+export interface AgentConnections {
+  agent_name: string;
+  agent_display_name: string;
+  is_shared: boolean;
+  services: ConnectionService[];
+  tools: ConnectionTool[];
+}
+
+export interface ConnectionTool {
+  name: string;
+  display_name: string;
+  description: string;
+  icon: string | null;
+  provider: string | null;
+  requires_room_context: boolean;
+}
+
+export interface ConnectionList {
+  agents: AgentConnections[];
+}
+
+export interface ConnectionStatus {
+  provider: string;
+  connected: boolean;
+  can_connect: boolean;
+  reset_required: boolean;
+  account_label: string | null;
+}

--- a/frontend/src/connections/useMcpSelection.ts
+++ b/frontend/src/connections/useMcpSelection.ts
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { AgentConnections } from "./types";
 import { requestConnection } from "./request";
 
 interface McpSelection {
   enabled: boolean;
-  selected_agents: string[];
+  agents: Record<string, string[] | null>;
 }
 
 const selectionPath = "/api/connections/mcp/selection";
@@ -45,14 +46,11 @@ export function useMcpSelection() {
     };
   }, [reload]);
 
-  const toggle = async (agent: string, checked: boolean) => {
+  const save = async (agents: McpSelection["agents"]) => {
     if (!selection?.enabled || mutation.current || loading || error) return;
     const controller = new AbortController();
     mutation.current = controller;
     setSaving(true);
-    const agents = checked
-      ? [...selection.selected_agents, agent]
-      : selection.selected_agents.filter((name) => name !== agent);
     try {
       const result = await requestConnection<McpSelection>(
         selectionPath,
@@ -72,5 +70,51 @@ export function useMcpSelection() {
     }
   };
 
-  return { selection, error, loading, saving, reload, toggle };
+  const selectedTools = (agent: string) =>
+    selection && Object.prototype.hasOwnProperty.call(selection.agents, agent)
+      ? selection.agents[agent]
+      : undefined;
+
+  const toggle = (agent: string, checked: boolean) => {
+    if (!selection) return;
+    const agents = { ...selection.agents };
+    if (checked) return save({ ...agents, [agent]: null });
+    delete agents[agent];
+    return save(agents);
+  };
+
+  const toggleTool = (
+    agent: AgentConnections,
+    tool: string,
+    checked: boolean,
+  ) => {
+    if (!selection) return;
+    const agents = { ...selection.agents };
+    const current = selectedTools(agent.agent_name);
+    const tools = new Set(
+      current === null
+        ? agent.tools
+            .filter((item) => !item.requires_room_context)
+            .map((item) => item.name)
+        : (current ?? []),
+    );
+    if (checked) tools.add(tool);
+    else tools.delete(tool);
+    if (tools.size) return save({ ...agents, [agent.agent_name]: [...tools] });
+    delete agents[agent.agent_name];
+    return save(agents);
+  };
+
+  return {
+    selection,
+    selectedTools,
+    error,
+    loading,
+    saving,
+    reload,
+    toggle,
+    toggleTool,
+  };
 }
+
+export type McpSelectionState = ReturnType<typeof useMcpSelection>;

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19069,24 +19069,30 @@ Loopback HTTP origins are accepted for local development.
 Gateway environment changes require an API restart.
 The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED=true` and `MINDROOM_TRUSTED_UPSTREAM_REQUIRE_JWT=true`.
 
-## Choose exposed agents
+## Choose exposed agents and tools
 
-On Connections, enable **Expose through MCP** for each agent you want your clients to use.
+Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
+Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Each tool selection applies only to that agent, even when another agent has the same tool.
+An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
+Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.
-Turning agents off remains available when stored data exceeds a lowered gateway or per-user quota.
+Withdrawing agent or tool access remains available when stored data exceeds a lowered gateway or per-user quota.
 New agents are not automatically added to an existing selection.
 
 The page lists all assigned tools, including those without browser authentication.
-OAuth controls remain grouped by service, and room-dependent tools are labeled **MindRoom only**.
+Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
 Upstream service credentials are validated after admission and before using the remote session.
-Calls already admitted may finish after an agent is turned off.
+Calls already admitted may finish after an agent or tool is turned off.
+Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.
 Removing eligibility hides a saved choice; restoring that permission can restore the previously saved choice.
 Selections are bound to the signed Matrix identity, canonical requester, and provisioned account when enabled.
 Deleting and recreating a provisioned account does not restore its previous selection.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19077,6 +19077,7 @@ Under **MCP access**, select all compatible tools for an agent or choose tools i
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
+Custom selections hide tools that are no longer available and discard those stale choices when saved.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.

--- a/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
@@ -50,6 +50,7 @@ Under **MCP access**, select all compatible tools for an agent or choose tools i
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
+Custom selections hide tools that are no longer available and discard those stale choices when saved.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.

--- a/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
@@ -42,24 +42,30 @@ Loopback HTTP origins are accepted for local development.
 Gateway environment changes require an API restart.
 The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_AUTH_ENABLED=true` and `MINDROOM_TRUSTED_UPSTREAM_REQUIRE_JWT=true`.
 
-## Choose exposed agents
+## Choose exposed agents and tools
 
-On Connections, enable **Expose through MCP** for each agent you want your clients to use.
+Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
+Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Each tool selection applies only to that agent, even when another agent has the same tool.
+An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
+Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.
 One saved selection applies to every connected MCP client for your account, in either authentication mode.
 The eligible personal agent is selected once by default; shared agents start off.
 You can turn every agent off, and the empty selection survives restarts and new client connections.
-Turning agents off remains available when stored data exceeds a lowered gateway or per-user quota.
+Withdrawing agent or tool access remains available when stored data exceeds a lowered gateway or per-user quota.
 New agents are not automatically added to an existing selection.
 
 The page lists all assigned tools, including those without browser authentication.
-OAuth controls remain grouped by service, and room-dependent tools are labeled **MindRoom only**.
+Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
 Upstream service credentials are validated after admission and before using the remote session.
-Calls already admitted may finish after an agent is turned off.
+Calls already admitted may finish after an agent or tool is turned off.
+Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.
 Removing eligibility hides a saved choice; restoring that permission can restore the previously saved choice.
 Selections are bound to the signed Matrix identity, canonical requester, and provisioned account when enabled.
 Deleting and recreating a provisioned account does not restore its previous selection.

--- a/src/mindroom/api/mcp_gateway.py
+++ b/src/mindroom/api/mcp_gateway.py
@@ -58,10 +58,21 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.mcp_gateway.external_auth import ExternalIdentity
     from mindroom.mcp_gateway.oauth import GatewayAccessToken
-    from mindroom.mcp_gateway.types import GatewayToolResponse
+    from mindroom.mcp_gateway.types import GatewayToolResponse, SearchResult
 
 logger = get_logger(__name__)
 _MACHINE_HEADERS = {**CONNECTIONS_HEADERS, "Access-Control-Allow-Origin": "*"}
+
+
+async def _check_search_access(
+    result: SearchResult,
+    require_current_access: Callable[[str | None, str | None], None],
+) -> None:
+    """Recheck each published toolkit once, even when multiple functions share it."""
+    await run_gateway_sync(require_current_access, None, None)
+    if "error" not in result:
+        for agent, toolkit in {(item["agent"], item["toolkit"]) for item in result["results"]}:
+            await run_gateway_sync(require_current_access, agent, toolkit)
 
 
 def _enabled(paths: RuntimePaths) -> bool:
@@ -268,16 +279,13 @@ class GatewayRuntime:
     async def _search_selection(
         self,
         user: ConnectionUserContext,
-        selected: list[str],
+        selected: dict[str, tuple[str, ...] | None],
         arguments: dict[str, Any],
-        require_current_access: Callable[[str | None], None],
+        require_current_access: Callable[[str | None, str | None], None],
     ) -> GatewayToolResponse:
         contexts = [resolve_connection_agent(user, agent_name) for agent_name in selected]
-        result = await search_agents(contexts, **arguments)
-        await run_gateway_sync(require_current_access, None)
-        if "error" not in result:
-            for agent_name in {item["agent"] for item in result["results"]}:
-                await run_gateway_sync(require_current_access, agent_name)
+        result = await search_agents(contexts, toolkits_by_agent=selected, **arguments)
+        await _check_search_access(result, require_current_access)
         return result
 
     def _access_guard(
@@ -285,17 +293,17 @@ class GatewayRuntime:
         request: Request,
         user: ConnectionUserContext,
         require_authority: Callable[[], None],
-    ) -> Callable[[str | None], None]:
+    ) -> Callable[[str | None, str | None], None]:
         state = require_api_state(request.app)
 
-        def require_current_access(agent_name: str | None = None) -> None:
+        def require_current_access(agent_name: str | None, toolkit: str | None) -> None:
             with state.config_lock:
                 current = state.snapshot
                 if current.runtime_config != user.config or current.runtime_paths != user.runtime_paths:
                     raise GatewayError(GatewayErrorCode.TOOL_UNAVAILABLE)
                 require_authority()
                 if agent_name is not None:
-                    self.selections.require_selected(user.owner, agent_name)
+                    self.selections.require_selected(user.owner, agent_name, toolkit)
 
         return require_current_access
 
@@ -304,32 +312,43 @@ class GatewayRuntime:
         _, user, require_authority = await self.principal(request)
         defaults = (user.personal_agent_name,) if user.personal_agent_name is not None else ()
         saved = await self.selections.get(user.owner, defaults)
-        selected = [agent for agent in saved if agent in user.agent_names]
+        selected = {agent: tools for agent, tools in saved.items() if agent in user.agent_names}
         require_current_access = self._access_guard(request, user, require_authority)
 
         agent = arguments.get("agent")
         if name == "search_tools" and agent is None and "toolkit" not in arguments:
             return await self._search_selection(user, selected, arguments, require_current_access)
-        if agent not in selected:
+        if not isinstance(agent, str) or agent not in selected:
             return {
                 "error": {"code": GatewayErrorCode.TOOL_NOT_FOUND, "message": "Agent is not selected or available."},
             }
         context = resolve_connection_agent(user, agent)
         operation_arguments = {key: value for key, value in arguments.items() if key != "agent"}
+        if name == "search_tools" and "toolkit" not in arguments:
+            return await self._search_selection(
+                user,
+                {agent: selected[agent]},
+                operation_arguments,
+                require_current_access,
+            )
 
         def require_selected_access() -> None:
-            require_current_access(context.agent_name)
+            toolkit = arguments.get("toolkit")
+            require_current_access(context.agent_name, toolkit if isinstance(toolkit, str) else None)
 
         async with self._config_lock:
             if not self.manager.is_configured_for(user.config):
                 await self.manager.sync_servers(user.config, discover=False)
         if name == "search_tools":
-            return await search_tools(
+            result = await search_tools(
                 context,
                 manager=self.manager,
                 require_current_access=require_selected_access,
+                allowed_toolkits=selected[agent],
                 **operation_arguments,
             )
+            await _check_search_access(result, require_current_access)
+            return result
         if name == "get_tool":
             return await get_tool(
                 context,

--- a/src/mindroom/api/mcp_selection.py
+++ b/src/mindroom/api/mcp_selection.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from starlette.requests import Request
 
+    from mindroom.api.connection_agents import ConnectionUserContext
     from mindroom.mcp_gateway.oauth import GatewayOAuthProvider
     from mindroom.mcp_gateway.selection import AgentSelections, GatewaySelections
 
@@ -60,6 +61,38 @@ async def _selection_choices(request: Request, origin: str) -> AgentSelections:
     return {name: None if tools is None else tuple(tools) for name, tools in mutation["agents"].items()}
 
 
+def _available_choices(
+    choices: AgentSelections,
+    context: ConnectionUserContext,
+    *,
+    previous: AgentSelections | None = None,
+) -> AgentSelections:
+    """Hide stale choices and discard them on save without accepting new unavailable tools."""
+    metadata = (
+        resolved_tool_metadata_for_runtime(context.runtime_paths, context.config, tolerate_plugin_load_errors=True)
+        if any(choices.values())
+        else {}
+    )
+    result: AgentSelections = {}
+    for name, tools in choices.items():
+        if name not in context.agent_names:
+            continue
+        if tools is None:
+            result[name] = None
+            continue
+        available = {
+            tool
+            for tool in context.config.resolve_entity(name).available_tools
+            if tool in metadata and not metadata[tool].requires_room_context
+        }
+        if previous is not None and set(tools) - available - set(previous.get(name) or ()):
+            raise HTTPException(400, "Tool is not available for MCP")
+        selected = tuple(tool for tool in tools if tool in available)
+        if selected:
+            result[name] = selected
+    return result
+
+
 async def _handle_selection(
     request: Request,
     runtime_for_request: Callable[[Request], _SelectionRuntime],
@@ -81,35 +114,19 @@ async def _handle_selection(
         account_id=owner.account_id,
     )
     runtime_for_request(request)
+    defaults = (context.personal_agent_name,) if context.personal_agent_name is not None else ()
+    saved = await runtime.selections.get(context.owner, defaults)
     if choices is None:
-        defaults = (context.personal_agent_name,) if context.personal_agent_name is not None else ()
-        saved = await runtime.selections.get(context.owner, defaults)
+        selected = _available_choices(saved, context)
     else:
         if any(name not in context.agent_names for name in choices):
             raise HTTPException(404, "Agent is not available")
-        metadata = (
-            resolved_tool_metadata_for_runtime(
-                context.runtime_paths,
-                context.config,
-                tolerate_plugin_load_errors=True,
-            )
-            if any(choices.values())
-            else {}
-        )
-        for name, tools in choices.items():
-            available = context.config.resolve_entity(name).available_tools
-            if tools is not None and any(
-                tool not in available or tool not in metadata or metadata[tool].requires_room_context for tool in tools
-            ):
-                raise HTTPException(400, "Tool is not available for MCP")
+        selected = _available_choices(choices, context, previous=saved)
         try:
-            saved = await runtime.selections.set(context.owner, choices)
+            selected = await runtime.selections.set(context.owner, selected)
         except ValueError as exc:
             raise HTTPException(400, "Invalid agent selection") from exc
-    return JSONResponse(
-        {"enabled": True, "agents": {name: tools for name, tools in saved.items() if name in context.agent_names}},
-        headers=CONNECTIONS_HEADERS,
-    )
+    return JSONResponse({"enabled": True, "agents": selected}, headers=CONNECTIONS_HEADERS)
 
 
 def selection_routes(runtime_for_request: Callable[[Request], _SelectionRuntime]) -> list[Route]:

--- a/src/mindroom/api/mcp_selection.py
+++ b/src/mindroom/api/mcp_selection.py
@@ -85,7 +85,8 @@ def _available_choices(
             for tool in context.config.resolve_entity(name).available_tools
             if tool in metadata and not metadata[tool].requires_room_context
         }
-        if previous is not None and set(tools) - available - set(previous.get(name) or ()):
+        previous_tools = previous.get(name, ()) if previous is not None else None
+        if previous_tools is not None and set(tools) - available - set(previous_tools):
             raise HTTPException(400, "Tool is not available for MCP")
         selected = tuple(tool for tool in tools if tool in available)
         if selected:

--- a/src/mindroom/api/mcp_selection.py
+++ b/src/mindroom/api/mcp_selection.py
@@ -16,6 +16,7 @@ from mindroom.api.mcp_identity import resolve_gateway_browser_owner
 from mindroom.mcp_gateway.selection import SelectionAccessDeniedError
 from mindroom.mcp_gateway.server import read_gateway_body
 from mindroom.mcp_gateway.store import GatewayOAuthCapacityError
+from mindroom.tool_system.catalog import resolved_tool_metadata_for_runtime
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -23,7 +24,7 @@ if TYPE_CHECKING:
     from starlette.requests import Request
 
     from mindroom.mcp_gateway.oauth import GatewayOAuthProvider
-    from mindroom.mcp_gateway.selection import GatewaySelections
+    from mindroom.mcp_gateway.selection import AgentSelections, GatewaySelections
 
 
 class _SelectionRuntime(Protocol):
@@ -37,7 +38,7 @@ class _SelectionRuntime(Protocol):
     def selections(self) -> GatewaySelections: ...
 
 
-async def _selection_names(request: Request, origin: str) -> tuple[str, ...]:
+async def _selection_choices(request: Request, origin: str) -> AgentSelections:
     if request.headers.get("origin") != origin or request.headers.get("sec-fetch-site") == "cross-site":
         raise HTTPException(403, "Selection changes require a same-origin request")
     if request.headers.get("content-type", "").split(";", 1)[0] != "application/json":
@@ -49,11 +50,14 @@ async def _selection_names(request: Request, origin: str) -> tuple[str, ...]:
     if (
         not isinstance(mutation, dict)
         or set(mutation) != {"agents"}
-        or not isinstance(mutation["agents"], list)
-        or any(not isinstance(name, str) for name in mutation["agents"])
+        or not isinstance(mutation["agents"], dict)
+        or any(
+            tools is not None and (not isinstance(tools, list) or any(not isinstance(tool, str) for tool in tools))
+            for tools in mutation["agents"].values()
+        )
     ):
         raise HTTPException(400, "Invalid agent selection")
-    return tuple(mutation["agents"])
+    return {name: None if tools is None else tuple(tools) for name, tools in mutation["agents"].items()}
 
 
 async def _handle_selection(
@@ -65,11 +69,11 @@ async def _handle_selection(
         runtime = runtime_for_request(request)
     except HTTPException as exc:
         if exc.status_code == 404 and request.method in {"GET", "HEAD"}:
-            return JSONResponse({"enabled": False, "selected_agents": []}, headers=CONNECTIONS_HEADERS)
+            return JSONResponse({"enabled": False, "agents": {}}, headers=CONNECTIONS_HEADERS)
         raise
     if request.query_params:
         raise HTTPException(400, "Selection target overrides are not accepted")
-    names = await _selection_names(request, runtime.origin) if request.method == "POST" else None
+    choices = await _selection_choices(request, runtime.origin) if request.method == "POST" else None
     owner = await resolve_gateway_browser_owner(request, user, runtime.provider)
     context = resolve_connection_user(
         rebind_current_request_snapshot(request),
@@ -77,18 +81,33 @@ async def _handle_selection(
         account_id=owner.account_id,
     )
     runtime_for_request(request)
-    if names is None:
+    if choices is None:
         defaults = (context.personal_agent_name,) if context.personal_agent_name is not None else ()
         saved = await runtime.selections.get(context.owner, defaults)
     else:
-        if any(name not in context.agent_names for name in names):
+        if any(name not in context.agent_names for name in choices):
             raise HTTPException(404, "Agent is not available")
+        metadata = (
+            resolved_tool_metadata_for_runtime(
+                context.runtime_paths,
+                context.config,
+                tolerate_plugin_load_errors=True,
+            )
+            if any(choices.values())
+            else {}
+        )
+        for name, tools in choices.items():
+            available = context.config.resolve_entity(name).available_tools
+            if tools is not None and any(
+                tool not in available or tool not in metadata or metadata[tool].requires_room_context for tool in tools
+            ):
+                raise HTTPException(400, "Tool is not available for MCP")
         try:
-            saved = await runtime.selections.set(context.owner, names)
+            saved = await runtime.selections.set(context.owner, choices)
         except ValueError as exc:
             raise HTTPException(400, "Invalid agent selection") from exc
     return JSONResponse(
-        {"enabled": True, "selected_agents": [name for name in saved if name in context.agent_names]},
+        {"enabled": True, "agents": {name: tools for name, tools in saved.items() if name in context.agent_names}},
         headers=CONNECTIONS_HEADERS,
     )
 

--- a/src/mindroom/mcp_gateway/selection.py
+++ b/src/mindroom/mcp_gateway/selection.py
@@ -1,4 +1,4 @@
-"""One durable agent selection per verified owner, shared by all MCP clients."""
+"""One durable agent/tool selection per verified owner, shared by all MCP clients."""
 
 from __future__ import annotations
 
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
     from mindroom.mcp_gateway.store import GatewayOAuthStore
     from mindroom.mcp_gateway.types import GatewayOwner
 
+type AgentSelections = dict[str, tuple[str, ...] | None]
+# None selects every compatible toolkit, including future additions.
+
 
 class SelectionAccessDeniedError(GatewayError):
     """The saved selection or provisioned account no longer allows this call."""
@@ -28,19 +31,37 @@ def _owner_key(owner: GatewayOwner) -> str:
     return hashlib.sha256(identity.encode()).hexdigest()
 
 
-def _payload(names: tuple[str, ...]) -> str:
+def _payload(choices: AgentSelections) -> str:
     if (
-        len(names) > 1000
-        or len(set(names)) != len(names)
-        or any(not name or len(name) > GATEWAY_AGENT_NAME_LIMIT for name in names)
+        len(choices) > 1000
+        or any(not name or len(name) > GATEWAY_AGENT_NAME_LIMIT for name in choices)
+        or any(
+            tools is not None
+            and (
+                len(tools) > 1000 or len(set(tools)) != len(tools) or any(not tool or len(tool) > 128 for tool in tools)
+            )
+            for tools in choices.values()
+        )
     ):
         msg = "Agent selection requires bounded unique names"
         raise ValueError(msg)
-    payload = json.dumps(names)
+    payload = json.dumps({name: tools for name, tools in choices.items() if tools is None or tools})
     if len(payload.encode()) > 65_536:
         msg = "Agent selection is too large"
         raise ValueError(msg)
     return payload
+
+
+def _decode(payload: str) -> AgentSelections:
+    return {name: None if tools is None else tuple(tools) for name, tools in json.loads(payload).items()}
+
+
+def _narrows(choices: AgentSelections, previous: AgentSelections) -> bool:
+    return all(
+        name in previous
+        and (previous[name] is None or (tools is not None and set(tools).issubset(previous[name] or ())))
+        for name, tools in choices.items()
+    )
 
 
 class GatewaySelections:
@@ -50,48 +71,51 @@ class GatewaySelections:
         self.store = store
 
     @staticmethod
-    def _read(connection: sqlite3.Connection, owner: GatewayOwner) -> tuple[str, ...] | None:
+    def _read(connection: sqlite3.Connection, owner: GatewayOwner) -> AgentSelections | None:
         if owner.account_id is not None and not account_is_active(connection, owner.account_id):
             raise SelectionAccessDeniedError
         row = connection.execute(
             "SELECT agents FROM gateway_selections WHERE owner_key = ?",
             (_owner_key(owner),),
         ).fetchone()
-        return tuple(json.loads(row["agents"])) if row else None
+        return _decode(row["agents"]) if row else None
 
-    def _save(self, connection: sqlite3.Connection, owner: GatewayOwner, payload: str) -> tuple[str, ...]:
+    def _save(self, connection: sqlite3.Connection, owner: GatewayOwner, payload: str) -> AgentSelections:
         previous = self._read(connection, owner)
-        names = tuple(json.loads(payload))
+        choices = _decode(payload)
         connection.execute(
             """INSERT INTO gateway_selections (owner_key, requester_id, account_id, agents) VALUES (?, ?, ?, ?)
                ON CONFLICT(owner_key) DO UPDATE SET agents = excluded.agents""",
             (_owner_key(owner), owner.requester_id, owner.account_id, payload),
         )
         # Withdrawing exposure must remain possible after an operator lowers the quotas.
-        if previous is None or not set(names).issubset(previous):
+        if previous is None or not _narrows(choices, previous):
             self.store.require_capacity(connection, requester_id=owner.requester_id)
-        return names
+        return choices
 
-    async def get(self, owner: GatewayOwner, default_agents: tuple[str, ...]) -> tuple[str, ...]:
+    async def get(self, owner: GatewayOwner, default_agents: tuple[str, ...]) -> AgentSelections:
         """Persist the initial default once, without overwriting a deliberate empty selection."""
         saved = await self.store.read(lambda connection: self._read(connection, owner))
         if saved is not None:
             return saved
-        payload = _payload(default_agents)
+        payload = _payload(dict.fromkeys(default_agents))
 
-        def initialize(connection: sqlite3.Connection) -> tuple[str, ...]:
+        def initialize(connection: sqlite3.Connection) -> AgentSelections:
             current = self._read(connection, owner)
             return current if current is not None else self._save(connection, owner, payload)
 
         return await self.store.transact(initialize)
 
-    async def set(self, owner: GatewayOwner, names: tuple[str, ...]) -> tuple[str, ...]:
+    async def set(self, owner: GatewayOwner, choices: AgentSelections) -> AgentSelections:
         """Replace the complete selection atomically under the existing storage budgets."""
-        payload = _payload(names)
+        payload = _payload(choices)
         return await self.store.transact(lambda connection: self._save(connection, owner, payload))
 
-    def require_selected(self, owner: GatewayOwner, agent_name: str) -> None:
+    def require_selected(self, owner: GatewayOwner, agent_name: str, toolkit: str | None = None) -> None:
         """Read committed authority immediately before dispatch; safe to call in worker threads."""
         selected = self.store.read_sync(lambda connection: self._read(connection, owner))
         if selected is None or agent_name not in selected:
+            raise SelectionAccessDeniedError
+        tools = selected[agent_name]
+        if toolkit is not None and tools is not None and toolkit not in tools:
             raise SelectionAccessDeniedError

--- a/src/mindroom/mcp_gateway/selection_schema.py
+++ b/src/mindroom/mcp_gateway/selection_schema.py
@@ -33,3 +33,7 @@ def initialize_selections(connection: sqlite3.Connection) -> None:
                 ON CONFLICT(requester_id) DO UPDATE SET bytes_used = bytes_used + excluded.bytes_used;
                 DELETE FROM requester_usage WHERE requester_id = {owner}.requester_id AND bytes_used = 0;
             END""")  # noqa: S608
+    # Preserve existing all-tools choices. The update trigger adjusts byte accounting.
+    connection.execute("""UPDATE gateway_selections SET agents = (
+        SELECT json_group_object(value, NULL) FROM json_each(gateway_selections.agents)
+    ) WHERE json_type(agents) = 'array'""")

--- a/src/mindroom/mcp_gateway/tools.py
+++ b/src/mindroom/mcp_gateway/tools.py
@@ -220,6 +220,7 @@ async def search_tools(
     limit: int = 5,
     manager: MCPServerManager | None = None,
     require_current_access: Callable[[], None] | None = None,
+    allowed_toolkits: tuple[str, ...] | None = None,
 ) -> SearchResult:
     """Search assigned toolkit metadata or one selected function catalog without schemas."""
     if not isinstance(query, str) or len(query) > 256 or not isinstance(limit, int) or isinstance(limit, bool):
@@ -247,7 +248,7 @@ async def search_tools(
         entries = await run_gateway_sync(_entries, context)
         items: list[SearchItem] = []
         for name in entries:
-            if not _handle(name):
+            if not _handle(name) or (allowed_toolkits is not None and name not in allowed_toolkits):
                 continue
             metadata = TOOL_METADATA.get(name)
             server = context.config.mcp_servers.get(name.removeprefix("mcp_")) if name.startswith("mcp_") else None
@@ -271,11 +272,22 @@ async def search_tools(
     return await _guard(context, search())
 
 
-async def search_agents(contexts: list[AgentToolContext], *, query: str = "", limit: int = 5) -> SearchResult:
+async def search_agents(
+    contexts: list[AgentToolContext],
+    *,
+    query: str = "",
+    limit: int = 5,
+    toolkits_by_agent: dict[str, tuple[str, ...] | None] | None = None,
+) -> SearchResult:
     """Aggregate metadata with one global result and byte limit, without constructing tools."""
     items: list[SearchItem] = []
     for context in contexts:
-        response = await search_tools(context, query=query, limit=limit)
+        response = await search_tools(
+            context,
+            query=query,
+            limit=limit,
+            allowed_toolkits=toolkits_by_agent.get(context.agent_name, ()) if toolkits_by_agent is not None else None,
+        )
         if "error" in response:
             return response
         items.extend(response["results"])

--- a/tach.toml
+++ b/tach.toml
@@ -5484,7 +5484,7 @@ depends_on = ["mindroom.api.config_lifecycle", "mindroom.mcp_gateway.accounts", 
 
 [[modules]]
 path = "mindroom.api.mcp_selection"
-depends_on = ["mindroom.api.auth", "mindroom.api.config_lifecycle", "mindroom.api.connection_agents", "mindroom.api.mcp_identity", "mindroom.mcp_gateway.selection", "mindroom.mcp_gateway.server", "mindroom.mcp_gateway.store"]
+depends_on = ["mindroom.api.auth", "mindroom.api.config_lifecycle", "mindroom.api.connection_agents", "mindroom.api.mcp_identity", "mindroom.mcp_gateway.selection", "mindroom.mcp_gateway.server", "mindroom.mcp_gateway.store", "mindroom.tool_system.catalog"]
 
 [[modules]]
 path = "mindroom.mcp_gateway.selection"

--- a/tests/api/test_mcp_external_auth.py
+++ b/tests/api/test_mcp_external_auth.py
@@ -77,8 +77,8 @@ def test_external_clients_share_dashboard_agent_selection(
         credential_managers=["@alice:example.org"],
     )
     selection = "/api/connections/mcp/selection"
-    assert external_client.get(selection, headers=headers).json()["selected_agents"] == ["personal"]
-    response = external_client.post(selection, headers={**headers, "Origin": ORIGIN}, json={"agents": ["shared"]})
+    assert external_client.get(selection, headers=headers).json()["agents"] == {"personal": None}
+    response = external_client.post(selection, headers={**headers, "Origin": ORIGIN}, json={"agents": {"shared": None}})
     assert response.status_code == 200, response.text
     assert external_client.get("/api/connections/mcp/clients", headers=headers).json()["enabled"] is False
     # Install the external issuer's distinct test key after the signed browser requests.

--- a/tests/api/test_mcp_selection.py
+++ b/tests/api/test_mcp_selection.py
@@ -32,13 +32,15 @@ if TYPE_CHECKING:
 SELECTION = "/api/connections/mcp/selection"
 
 
-def test_removed_tools_cannot_block_other_agent_withdrawal(
+@pytest.mark.parametrize("all_tools", [False, True], ids=["custom", "all-tools"])
+def test_removed_tools_cannot_block_access_withdrawal(
     gateway_client: TestClient,
     signed_headers: Callable[[str], dict[str, str]],
+    all_tools: bool,
 ) -> None:
     """Old browser state and fresh reads can both withdraw access after a tool is removed."""
     config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
-    config.agents["personal"].tools = ["calculator", "duckduckgo"]
+    config.agents["personal"].tools = ["calculator", "duckduckgo", "shell"]
     config.agents["shared"] = AgentConfig(
         display_name="Shared",
         role="Shared tools",
@@ -46,17 +48,18 @@ def test_removed_tools_cannot_block_other_agent_withdrawal(
         credential_managers=["@alice:example.org"],
     )
     headers = {**signed_headers("alice"), "Origin": ORIGIN}
-    original = {"personal": ["calculator", "duckduckgo"], "shared": None}
+    browser_tools = ["calculator", "duckduckgo"]
+    original = {"personal": None if all_tools else browser_tools, "shared": None}
     assert gateway_client.post(SELECTION, headers=headers, json={"agents": original}).status_code == 200
-    config.agents["personal"].tools = ["calculator"]
+    config.agents["personal"].tools = ["calculator", "shell"]
     assert gateway_client.get(SELECTION, headers=headers).json()["agents"] == {
-        "personal": ["calculator"],
+        "personal": None if all_tools else ["calculator"],
         "shared": None,
     }
     response = gateway_client.post(
         SELECTION,
         headers=headers,
-        json={"agents": {"personal": original["personal"]}},
+        json={"agents": {"personal": browser_tools}},
     )
     assert response.status_code == 200, response.text
     assert response.json()["agents"] == {"personal": ["calculator"]}
@@ -173,6 +176,14 @@ def test_selection_rejects_invalid_or_unauthorized_names(
     body: object,
 ) -> None:
     """Browser input can narrow current authority but cannot invent agent access or owner IDs."""
+    assert (
+        gateway_client.post(
+            SELECTION,
+            headers={**signed_headers("alice"), "Origin": ORIGIN},
+            json={"agents": {}},
+        ).status_code
+        == 200
+    )
     response = gateway_client.post(SELECTION, headers={**signed_headers("alice"), "Origin": ORIGIN}, json=body)
     assert response.status_code in {400, 404}
 

--- a/tests/api/test_mcp_selection.py
+++ b/tests/api/test_mcp_selection.py
@@ -32,6 +32,41 @@ if TYPE_CHECKING:
 SELECTION = "/api/connections/mcp/selection"
 
 
+def test_removed_tools_cannot_block_other_agent_withdrawal(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+) -> None:
+    """Old browser state and fresh reads can both withdraw access after a tool is removed."""
+    config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
+    config.agents["personal"].tools = ["calculator", "duckduckgo"]
+    config.agents["shared"] = AgentConfig(
+        display_name="Shared",
+        role="Shared tools",
+        tools=["calculator"],
+        credential_managers=["@alice:example.org"],
+    )
+    headers = {**signed_headers("alice"), "Origin": ORIGIN}
+    original = {"personal": ["calculator", "duckduckgo"], "shared": None}
+    assert gateway_client.post(SELECTION, headers=headers, json={"agents": original}).status_code == 200
+    config.agents["personal"].tools = ["calculator"]
+    assert gateway_client.get(SELECTION, headers=headers).json()["agents"] == {
+        "personal": ["calculator"],
+        "shared": None,
+    }
+    response = gateway_client.post(
+        SELECTION,
+        headers=headers,
+        json={"agents": {"personal": original["personal"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["agents"] == {"personal": ["calculator"]}
+    config.agents["personal"].tools = []
+    assert gateway_client.get(SELECTION, headers=headers).json()["agents"] == {}
+    response = gateway_client.post(SELECTION, headers=headers, json={"agents": {"personal": ["calculator"]}})
+    assert response.status_code == 200, response.text
+    assert response.json()["agents"] == {}
+
+
 def test_withdrawal_does_not_require_plugin_metadata(
     gateway_client: TestClient,
     signed_headers: Callable[[str], dict[str, str]],

--- a/tests/api/test_mcp_selection.py
+++ b/tests/api/test_mcp_selection.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from mindroom import agents
-from mindroom.api import config_lifecycle
+from mindroom.api import config_lifecycle, mcp_selection
 from mindroom.config.agent import AgentConfig
 from tests.api.test_mcp_clients import _connect
 from tests.api.test_mcp_gateway_api import (
@@ -32,6 +32,52 @@ if TYPE_CHECKING:
 SELECTION = "/api/connections/mcp/selection"
 
 
+def test_withdrawal_does_not_require_plugin_metadata(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken plugin cannot prevent withdrawing all tool access."""
+    alice = signed_headers("alice")
+    assert gateway_client.get(SELECTION, headers=alice).status_code == 200
+
+    def unavailable(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("Withdrawing access must not load plugins")
+
+    monkeypatch.setattr(mcp_selection, "resolved_tool_metadata_for_runtime", unavailable)
+    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {}})
+    assert response.status_code == 200, response.text
+    assert response.json()["agents"] == {}
+
+
+def test_tool_selection_filters_discovery_and_blocks_unselected_dispatch(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+) -> None:
+    """Hidden tools cannot be discovered, inspected, or invoked by any connected client."""
+    config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
+    config.agents["personal"].tools = ["calculator", "duckduckgo"]
+    alice = signed_headers("alice")
+    token = _connect(gateway_client, alice)["access_token"]
+    response = gateway_client.post(
+        SELECTION,
+        headers={**alice, "Origin": ORIGIN},
+        json={"agents": {"personal": ["duckduckgo"]}},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"enabled": True, "agents": {"personal": ["duckduckgo"]}}
+    for arguments in ({"limit": 1}, {"agent": "personal", "limit": 1}):
+        result = _call(gateway_client, token, "search_tools", arguments)["structuredContent"]
+        assert [(item["agent"], item["toolkit"]) for item in result["results"]] == [("personal", "duckduckgo")]
+    for operation, extra in (
+        ("search_tools", {}),
+        ("get_tool", {"function": "add"}),
+        ("invoke_tool", {"function": "add", "arguments": {"a": 1, "b": 2}}),
+    ):
+        result = _call(gateway_client, token, operation, {"agent": "personal", "toolkit": "calculator", **extra})
+        assert result["isError"]
+
+
 def test_selection_defaults_and_empty_are_user_scoped(
     gateway_client: TestClient,
     signed_headers: Callable[[str], dict[str, str]],
@@ -40,13 +86,13 @@ def test_selection_defaults_and_empty_are_user_scoped(
     alice = signed_headers("alice")
     response = gateway_client.get(SELECTION, headers=alice)
     assert response.status_code == 200, response.text
-    assert response.json() == {"enabled": True, "selected_agents": ["personal"]}
+    assert response.json() == {"enabled": True, "agents": {"personal": None}}
     assert "no-store" in response.headers["cache-control"]
-    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": []})
+    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {}})
     assert response.status_code == 200, response.text
-    assert response.json()["selected_agents"] == []
-    assert gateway_client.get(SELECTION, headers=alice).json()["selected_agents"] == []
-    assert gateway_client.get(SELECTION, headers=signed_headers("bob")).json()["selected_agents"] == ["personal"]
+    assert response.json()["agents"] == {}
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    assert gateway_client.get(SELECTION, headers=signed_headers("bob")).json()["agents"] == {"personal": None}
 
 
 def test_shared_only_manager_can_select_assigned_shared_agent(
@@ -63,22 +109,26 @@ def test_shared_only_manager_can_select_assigned_shared_agent(
         credential_managers=["@alice:example.org"],
     )
     alice = signed_headers("alice")
-    assert gateway_client.get(SELECTION, headers=alice).json()["selected_agents"] == []
-    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": ["shared"]})
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {"shared": None}})
     assert response.status_code == 200, response.text
-    assert response.json()["selected_agents"] == ["shared"]
+    assert response.json()["agents"] == {"shared": None}
     config.agents["shared"].credential_managers = []
-    assert gateway_client.get(SELECTION, headers=alice).json()["selected_agents"] == []
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
 
 
 @pytest.mark.parametrize(
     "body",
     [
-        {"agents": ["missing"]},
-        {"agents": ["personal", "personal"]},
+        {"agents": {"missing": None}},
+        {"agents": {"personal": ["calculator", "calculator"]}},
         {"agents": "personal"},
-        {"agents": [1]},
-        {"agents": [], "user": "bob"},
+        {"agents": {"personal": ["unknown"]}},
+        {"agents": {"personal": ["matrix_message"]}},
+        {"agents": {"personal": "calculator"}},
+        {"agents": {"personal": [False]}},
+        {"agents": {1: None}},
+        {"agents": {}, "user": "bob"},
         [],
     ],
 )
@@ -98,7 +148,7 @@ def test_selection_requires_signed_identity_and_same_origin(
 ) -> None:
     """Gateway settings retain the existing signed dashboard and browser CSRF boundaries."""
     assert gateway_client.get(SELECTION).status_code == 401
-    response = gateway_client.post(SELECTION, headers=signed_headers("alice"), json={"agents": []})
+    response = gateway_client.post(SELECTION, headers=signed_headers("alice"), json={"agents": {}})
     assert response.status_code == 403
     response = gateway_client.get(SELECTION + "?agent=personal", headers=signed_headers("alice"))
     assert response.status_code == 400
@@ -136,7 +186,7 @@ def test_all_clients_follow_selection_and_agent_qualified_tools(
         gateway_client.post(
             SELECTION,
             headers={**alice, "Origin": ORIGIN},
-            json={"agents": ["personal", shared_agent]},
+            json={"agents": {"personal": None, shared_agent: None}},
         ).status_code
         == 200
     )
@@ -161,7 +211,7 @@ def test_all_clients_follow_selection_and_agent_qualified_tools(
             {"agent": shared_agent, "toolkit": "calculator", "function": function},
         )["structuredContent"]
         assert schema["agent"] == shared_agent
-    assert gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": []}).status_code == 200
+    assert gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {}}).status_code == 200
     for token in tokens:
         assert _call(gateway_client, token, "search_tools", {})["structuredContent"] == {"results": []}
         rejected = _call(
@@ -173,6 +223,7 @@ def test_all_clients_follow_selection_and_agent_qualified_tools(
         assert rejected["isError"]
 
 
+@pytest.mark.parametrize("keep_agent", [False, True], ids=["agent", "toolkit"])
 @pytest.mark.parametrize("phase", ["build", "connect", "hook"])
 @pytest.mark.parametrize("async_body", [False, True], ids=["sync", "async"])
 def test_deselection_during_preparation_stops_provider_body(
@@ -181,8 +232,11 @@ def test_deselection_during_preparation_stops_provider_body(
     monkeypatch: pytest.MonkeyPatch,
     phase: str,
     async_body: bool,
+    keep_agent: bool,
 ) -> None:
     """A dashboard change wins over a call waiting in preparation, for synchronous and async tools."""
+    config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
+    config.agents["personal"].tools = ["calculator", "duckduckgo"]
     alice = signed_headers("alice")
     token = _connect(gateway_client, alice)["access_token"]
     paused, release = threading.Event(), threading.Event()
@@ -207,7 +261,11 @@ def test_deselection_during_preparation_stops_provider_body(
         )
         try:
             assert paused.wait(10), "Provider preparation never paused"
-            response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": []})
+            response = gateway_client.post(
+                SELECTION,
+                headers={**alice, "Origin": ORIGIN},
+                json={"agents": {"personal": ["duckduckgo"]} if keep_agent else {}},
+            )
             assert response.status_code == 200, response.text
         finally:
             release.set()

--- a/tests/test_mcp_gateway_selection.py
+++ b/tests/test_mcp_gateway_selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import replace
 from typing import TYPE_CHECKING
@@ -24,38 +25,93 @@ pytestmark = pytest.mark.asyncio
 _OWNER = GatewayOwner("@alice:example.org", "@alice:example.org")
 
 
+@pytest.mark.parametrize("legacy_agents", [[], ["personal", "shared"]])
+async def test_legacy_agent_selections_migrate_once_with_exact_accounting(
+    provider: GatewayOAuthProvider,
+    runtime_paths: RuntimePaths,
+    legacy_agents: list[str],
+) -> None:
+    """Existing all-tools and empty choices survive upgrade without changing byte charges twice."""
+    await GatewaySelections(provider.store).set(_OWNER, {})
+    await provider.store.transact(
+        lambda connection: connection.execute("UPDATE gateway_selections SET agents = ?", (json.dumps(legacy_agents),)),
+    )
+
+    def charges(connection: sqlite3.Connection) -> tuple[int, int, int]:
+        return (
+            connection.execute("SELECT bytes_used FROM oauth_usage").fetchone()[0],
+            connection.execute("SELECT bytes_used FROM requester_usage").fetchone()[0],
+            connection.execute("SELECT accounted_bytes FROM gateway_selections").fetchone()[0],
+        )
+
+    before = await provider.store.read(charges)
+    reopened = GatewayOAuthProvider(runtime_paths, public_url="https://example.org")
+    assert await GatewaySelections(reopened.store).get(_OWNER, ("different",)) == dict.fromkeys(legacy_agents)
+    after = await reopened.store.read(charges)
+    assert after[0] - before[0] == after[1] - before[1] == after[2] - before[2]
+    again = GatewayOAuthProvider(runtime_paths, public_url="https://example.org")
+    assert await GatewaySelections(again.store).get(_OWNER, ("different",)) == dict.fromkeys(legacy_agents)
+    assert await again.store.read(charges) == after
+
+
+async def test_tool_choices_are_scoped_to_agent_and_persist(provider: GatewayOAuthProvider) -> None:
+    """The same toolkit can be enabled for one agent and withheld from another."""
+    selections = GatewaySelections(provider.store)
+    choice = {"personal": ("calculator",), "shared": ("duckduckgo",)}
+    assert await selections.set(_OWNER, choice) == choice
+    other_client = GatewaySelections(provider.store)
+    assert await other_client.get(_OWNER, ()) == choice
+    other_client.require_selected(_OWNER, "personal", "calculator")
+    with pytest.raises(SelectionAccessDeniedError):
+        other_client.require_selected(_OWNER, "shared", "calculator")
+    await selections.set(_OWNER, {"personal": None})
+    other_client.require_selected(_OWNER, "personal", "duckduckgo")
+
+
+async def test_tool_withdrawal_remains_possible_over_quota(provider: GatewayOAuthProvider) -> None:
+    """Withdrawing one toolkit preserves other exposure even when storage is over quota."""
+    selections = GatewaySelections(provider.store)
+    await selections.set(_OWNER, {"personal": None})
+    provider.store.user_max_bytes = 1
+    assert await selections.set(_OWNER, {"personal": ("calculator",)}) == {"personal": ("calculator",)}
+    with pytest.raises(GatewayOAuthCapacityError):
+        await selections.set(_OWNER, {"personal": None})
+    with pytest.raises(SelectionAccessDeniedError):
+        selections.require_selected(_OWNER, "personal", "duckduckgo")
+
+
 async def test_default_is_saved_once_and_empty_survives_restart(
     provider: GatewayOAuthProvider,
     runtime_paths: RuntimePaths,
 ) -> None:
     """A changed personal default or another client cannot overwrite an existing choice."""
     selection = GatewaySelections(provider.store)
-    assert await selection.get(_OWNER, ("personal",)) == ("personal",)
-    assert await selection.get(_OWNER, ("replacement",)) == ("personal",)
-    assert await selection.set(_OWNER, ("personal", "shared")) == ("personal", "shared")
+    assert await selection.get(_OWNER, ("personal",)) == {"personal": None}
+    assert await selection.get(_OWNER, ("replacement",)) == {"personal": None}
+    assert await selection.set(_OWNER, {"personal": None, "shared": None}) == {"personal": None, "shared": None}
     second_client = GatewaySelections(provider.store)
-    assert await second_client.get(_OWNER, ()) == ("personal", "shared")
-    assert await second_client.set(_OWNER, ()) == ()
+    assert await second_client.get(_OWNER, ()) == {"personal": None, "shared": None}
+    assert await second_client.set(_OWNER, {}) == {}
     reopened = GatewayOAuthProvider(runtime_paths, public_url="https://example.org")
-    assert await GatewaySelections(reopened.store).get(_OWNER, ("personal",)) == ()
+    assert await GatewaySelections(reopened.store).get(_OWNER, ("personal",)) == {}
 
 
 @pytest.mark.parametrize("field", ["authenticated_user_id", "requester_id"])
 async def test_identity_changes_do_not_inherit_selection(provider: GatewayOAuthProvider, field: str) -> None:
     """Neither an alias nor a canonical identity alone owns another user's settings."""
     selection = GatewaySelections(provider.store)
-    await selection.set(_OWNER, ("shared",))
+    await selection.set(_OWNER, {"shared": None})
     other = replace(_OWNER, **{field: "@other:example.org"})
-    assert await selection.get(other, ()) == ()
-    assert await selection.get(_OWNER, ()) == ("shared",)
+    assert await selection.get(other, ()) == {}
+    assert await selection.get(_OWNER, ()) == {"shared": None}
 
 
 async def test_dispatch_check_reads_committed_selection(provider: GatewayOAuthProvider) -> None:
     """A call prepared before deselection loses authority before the provider starts."""
     selection = GatewaySelections(provider.store)
-    await selection.set(_OWNER, ("shared",))
+    await selection.set(_OWNER, {"shared": None})
     selection.require_selected(_OWNER, "shared")
-    await GatewaySelections(provider.store).set(_OWNER, ())
+    await GatewaySelections(provider.store).set(_OWNER, {})
     with pytest.raises(SelectionAccessDeniedError):
         selection.require_selected(_OWNER, "shared")
 
@@ -66,7 +122,7 @@ async def test_account_disable_and_recreation_cannot_restore_selection(provider:
     account = await accounts.create({"userName": "alice@example.org", "active": True})
     owner = replace(_OWNER, account_id=account["id"])
     selection = GatewaySelections(provider.store)
-    await selection.set(owner, ("shared",))
+    await selection.set(owner, {"shared": None})
     await provider.store.transact(
         lambda connection: connection.execute(
             "UPDATE gateway_accounts SET active = 0 WHERE account_id = ?",
@@ -77,22 +133,22 @@ async def test_account_disable_and_recreation_cannot_restore_selection(provider:
         selection.require_selected(owner, "shared")
     await accounts.delete(account["id"])
     recreated = await accounts.create({"userName": "alice@example.org", "active": True})
-    assert await selection.get(replace(owner, account_id=recreated["id"]), ()) == ()
+    assert await selection.get(replace(owner, account_id=recreated["id"]), ()) == {}
     with pytest.raises(SelectionAccessDeniedError):
-        await selection.set(owner, ("shared",))
+        await selection.set(owner, {"shared": None})
 
 
 async def test_capacity_failure_rolls_back_selection_and_accounting(provider: GatewayOAuthProvider) -> None:
     """Selection writes participate in the same per-user and total storage budgets."""
     selection = GatewaySelections(provider.store)
-    await selection.set(_OWNER, ("personal",))
+    await selection.set(_OWNER, {"personal": None})
     before = await provider.store.read(
         lambda connection: tuple(connection.execute("SELECT * FROM oauth_usage").fetchone()),
     )
     provider.store.user_max_bytes = 1
     with pytest.raises(GatewayOAuthCapacityError):
-        await selection.set(_OWNER, ("shared",))
-    assert await selection.get(_OWNER, ()) == ("personal",)
+        await selection.set(_OWNER, {"shared": None})
+    assert await selection.get(_OWNER, ()) == {"personal": None}
     after = await provider.store.read(
         lambda connection: tuple(connection.execute("SELECT * FROM oauth_usage").fetchone()),
     )
@@ -107,19 +163,19 @@ async def test_over_quota_selection_can_only_be_narrowed(
 ) -> None:
     """Lowered storage budgets cannot prevent users from withdrawing existing exposure."""
     selection = GatewaySelections(provider.store)
-    await selection.set(_OWNER, ("personal", "shared"))
+    await selection.set(_OWNER, {"personal": None, "shared": None})
     if global_limit:
         provider.store.max_bytes = 1
     else:
         provider.store.user_max_bytes = 1
-    assert await selection.set(_OWNER, ("personal",)) == ("personal",)
+    assert await selection.set(_OWNER, {"personal": None}) == {"personal": None}
     with pytest.raises(SelectionAccessDeniedError):
         selection.require_selected(_OWNER, "shared")
     with pytest.raises(GatewayOAuthCapacityError):
-        await selection.set(_OWNER, ("personal", "shared"))
-    assert await selection.set(_OWNER, ()) == ()
+        await selection.set(_OWNER, {"personal": None, "shared": None})
+    assert await selection.set(_OWNER, {}) == {}
     reopened = GatewayOAuthProvider(runtime_paths, public_url="https://example.org")
-    assert await GatewaySelections(reopened.store).get(_OWNER, ("personal",)) == ()
+    assert await GatewaySelections(reopened.store).get(_OWNER, ("personal",)) == {}
     with pytest.raises(SelectionAccessDeniedError):
         selection.require_selected(_OWNER, "personal")
 
@@ -127,9 +183,16 @@ async def test_over_quota_selection_can_only_be_narrowed(
 async def test_selection_rejects_duplicate_or_unbounded_names(provider: GatewayOAuthProvider) -> None:
     """Storage accepts only bounded unique agent names, including an empty selection."""
     selection = GatewaySelections(provider.store)
-    for names in [("shared", "shared"), ("",), ("a" * 257,), tuple(str(i) for i in range(1001))]:
+    for choices in [
+        {"": None},
+        {"a" * 257: None},
+        {str(i): None for i in range(1001)},
+        {"shared": ("calculator", "calculator")},
+        {"shared": ("",)},
+        {"shared": ("a" * 129,)},
+    ]:
         with pytest.raises(ValueError, match="Agent selection"):
-            await selection.set(_OWNER, names)
+            await selection.set(_OWNER, choices)
 
 
 async def test_agent_bound_authority_is_retired_once(runtime_paths: RuntimePaths) -> None:
@@ -148,6 +211,6 @@ async def test_agent_bound_authority_is_retired_once(runtime_paths: RuntimePaths
         assert connection.execute("SELECT COUNT(*) FROM pending").fetchone()[0] == 0
         assert connection.execute("SELECT account_id FROM gateway_accounts").fetchone()[0] == "account"
         assert connection.execute("PRAGMA user_version").fetchone()[0] == 3
-    await GatewaySelections(provider.store).set(_OWNER, ("shared",))
+    await GatewaySelections(provider.store).set(_OWNER, {"shared": None})
     reopened = GatewayOAuthProvider(runtime_paths, public_url="https://example.org")
-    assert await GatewaySelections(reopened.store).get(_OWNER, ()) == ("shared",)
+    assert await GatewaySelections(reopened.store).get(_OWNER, ()) == {"shared": None}

--- a/tests/test_mcp_gateway_tools.py
+++ b/tests/test_mcp_gateway_tools.py
@@ -819,7 +819,7 @@ async def test_mcp_deselection_before_construction_prevents_provider_contact(
     provider = GatewayOAuthProvider(context.runtime_paths, public_url="https://assistant.example.org")
     selections = GatewaySelections(provider.store)
     owner = GatewayOwner(context.requester_id, context.requester_id)
-    await selections.set(owner, (context.agent_name,))
+    await selections.set(owner, {context.agent_name: None})
     waiting, release = threading.Event(), threading.Event()
     require_entry = gateway._require_entry
 
@@ -847,7 +847,7 @@ async def test_mcp_deselection_before_construction_prevents_provider_contact(
         )
         try:
             assert await asyncio.to_thread(waiting.wait, 10)
-            await selections.set(owner, ())
+            await selections.set(owner, {})
         finally:
             release.set()
         result = await asyncio.wait_for(pending, timeout=10)
@@ -871,7 +871,7 @@ async def test_mcp_deselection_while_queued_prevents_remote_dispatch(
     provider = GatewayOAuthProvider(context.runtime_paths, public_url="https://assistant.example.org")
     selections = GatewaySelections(provider.store)
     owner = GatewayOwner(context.requester_id, context.requester_id)
-    await selections.set(owner, (context.agent_name,))
+    await selections.set(owner, {context.agent_name: None})
     waiting = asyncio.Event()
 
     class DispatchGate(asyncio.Semaphore):
@@ -883,7 +883,7 @@ async def test_mcp_deselection_while_queued_prevents_remote_dispatch(
             return await super().acquire()
 
     def require_access() -> None:
-        selections.require_selected(owner, context.agent_name)
+        selections.require_selected(owner, context.agent_name, "mcp_example")
 
     manager = MCPServerManager(context.runtime_paths, validate_agent_function_names=False)
     pending: asyncio.Task[InvocationResult] | None = None
@@ -905,7 +905,7 @@ async def test_mcp_deselection_while_queued_prevents_remote_dispatch(
             ),
         )
         await asyncio.wait_for(waiting.wait(), timeout=10)
-        await selections.set(owner, ())
+        await selections.set(owner, {context.agent_name: ("calculator",)})
         gate.release()
         result = await asyncio.wait_for(pending, timeout=10)
         assert "error" in result


### PR DESCRIPTION
Connections becomes unwieldy when administrators manage many agents and their tools. Replace the cards with a searchable TanStack table: agents start collapsed, connection tools get one row each, and tools without browser setup sit under a separate collapsed “Other tools” row.

MCP access can now be selected per toolkit per agent, with an agent checkbox for all compatible tools. One saved selection still applies to every client for the user. Existing agent selections migrate to “All tools”; custom selections are enforced during discovery and immediately before native or upstream tool dispatch.

Connection status and OAuth actions remain shared per provider, with statuses loaded only for expanded agents. This uses the existing table dependency.

Validation:
- 684 gateway, MCP API, Connections API, and import-contract tests pass.
- After review fixes: 165 focused gateway, selection, external-auth, and storage tests pass, including stale catalog submissions from custom and All tools selections.
- 66 Connections frontend tests, frontend lint, and production build.
- All applicable pre-commit checks, including types and architecture boundaries.
- Chromium checks with mock API data: desktop/mobile rendering, deferred status requests, and persisted per-tool choices.

## Summary by Sourcery

Manage agent connections in a compact searchable table and support secure per-agent MCP tool exposure across discovery and dispatch.

New Features:
- Replace the Connections card layout with a searchable, filterable table that keeps agents and tools collapsed until needed.
- Add per-agent MCP tool exposure with all-tools, custom, and disabled selections shared across the user’s connected clients.
- Enforce selected toolkit access during discovery and dispatch, including support for native and upstream MCP tools.

Bug Fixes:
- Prevent stale or unavailable tool selections from blocking access withdrawal and remove them when selections are saved.
- Defer connection status requests until an agent is expanded while retaining shared provider OAuth actions.

Enhancements:
- Migrate legacy agent-only selections to all-tools selections and preserve quota-safe narrowing behavior.
- Group tools by shared provider connection, separate tools without setup under a collapsed Other tools row, and improve responsive accessibility-oriented Connections presentation.

Documentation:
- Update MCP gateway deployment guidance for per-agent and per-tool exposure, migration behavior, and access enforcement.

Tests:
- Expand frontend and gateway coverage for per-tool selection, filtering, deferred status loading, stale-tool removal, migration, storage limits, discovery, and dispatch enforcement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP access can now be managed per agent and per tool from a searchable, filterable Connections table.
  * Expand agents to view available tools, connection status, sharing details, and individual exposure controls.
  * Added connection, OAuth, disconnect, retry, and error-handling controls within the agent and tool views.
  * MCP searches now respect configured agent and toolkit access selections.

* **Documentation**
  * Updated MCP Gateway guidance to explain per-tool selections, “All tools” behavior, access withdrawal, and upgrade handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
