### PR TITLE
Add parent-proxy bypass domains to the runtime Helm chart

### DIFF
--- a/cluster/k8s/runtime/README.md
+++ b/cluster/k8s/runtime/README.md
@@ -347,6 +347,25 @@ approvedEgress:
 
 With this setup, workers mint Agent Vault tokens through the API port (`14321`), workers proxy tool egress to the approved egress Service, Squid enforces allowlists and dynamic grants using the real worker IP, and Squid forwards requests carrying `Proxy-Authorization` to Agent Vault (`login=PASSTHRU`) for credential injection.
 Tokenless traffic egresses directly from Squid after the normal policy check.
+For signed URLs or other destinations that must skip parent-proxy credential injection, set `approvedEgress.parentProxy.bypassDomains`:
+
+```yaml
+approvedEgress:
+  parentProxy:
+    enabled: true
+    bypassDomains:
+      - downloads.example.test
+      - .objects.example.test
+```
+
+This list defaults to empty and applies only when chart-managed approved egress and its parent proxy are enabled.
+An entry without a leading dot matches that exact hostname; a leading dot matches the domain and its subdomains, following [Squid domain ACL syntax](https://www.squid-cache.org/Doc/config/acl/).
+Use ASCII domain names (Punycode for internationalized names), without URL schemes, ports, paths, `*` wildcards, or whitespace; invalid entries fail chart rendering.
+Matching uses the request hostname without reverse DNS lookups.
+Bypass destinations still require the normal allowlist or dynamic grant and remain subject to the proxy's destination and port restrictions.
+Other token-bearing requests continue through the configured parent.
+Changing the list changes the chart's Squid config checksum and rolls the proxy Deployment automatically.
+
 When `agentVault.accessTool.enabled` is set, self-service vault grants also keep `agentVault.ownerEmail` as an admin on each worker vault; the Kubernetes worker init container uses that owner account to mint and attach the proxy-role agent token.
 The chart rejects the unsafe default combination of chart-managed approved egress plus Agent Vault without `approvedEgress.parentProxy`, because that would be vault-first and break dynamic grants.
 

--- a/cluster/k8s/runtime/templates/_helpers.tpl
+++ b/cluster/k8s/runtime/templates/_helpers.tpl
@@ -227,11 +227,20 @@ app.kubernetes.io/component: runtime
 include /etc/squid/squid.conf
 
 acl egress_has_token req_header Proxy-Authorization .
+{{- with .Values.approvedEgress.parentProxy.bypassDomains }}
+acl egress_bypass_parent dstdomain -n {{ join " " . }}
+{{- end }}
 dns_defnames on
 cache_peer {{ .Values.approvedEgress.parentProxy.host }} parent {{ .Values.approvedEgress.parentProxy.port }} 0 no-query no-digest login=PASSTHRU
+{{- if .Values.approvedEgress.parentProxy.bypassDomains }}
+cache_peer_access {{ .Values.approvedEgress.parentProxy.host }} deny egress_bypass_parent
+{{- end }}
 cache_peer_access {{ .Values.approvedEgress.parentProxy.host }} allow egress_has_token
 cache_peer_access {{ .Values.approvedEgress.parentProxy.host }} deny all
 nonhierarchical_direct off
+{{- if .Values.approvedEgress.parentProxy.bypassDomains }}
+always_direct allow egress_bypass_parent
+{{- end }}
 always_direct allow !egress_has_token
 never_direct allow egress_has_token
 {{- end -}}

--- a/cluster/k8s/runtime/templates/validate.yaml
+++ b/cluster/k8s/runtime/templates/validate.yaml
@@ -216,6 +216,20 @@
 {{- if or (lt $parentProxyPort 1) (gt $parentProxyPort 65535) -}}
 {{- fail "approvedEgress.parentProxy.port must be between 1 and 65535 when approvedEgress.parentProxy.enabled=true" -}}
 {{- end -}}
+{{- $bypassDomains := .Values.approvedEgress.parentProxy.bypassDomains -}}
+{{- if not (kindIs "invalid" $bypassDomains) -}}
+{{- if not (kindIs "slice" $bypassDomains) -}}
+{{- fail "approvedEgress.parentProxy.bypassDomains must be a list of domain names" -}}
+{{- end -}}
+{{- range $index, $domain := $bypassDomains -}}
+{{- if not (kindIs "string" $domain) -}}
+{{- fail (printf "approvedEgress.parentProxy.bypassDomains[%d] must be a domain name string" $index) -}}
+{{- end -}}
+{{- if or (gt (len (trimPrefix "." $domain)) 253) (not (regexMatch "^\\.?[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$" $domain)) -}}
+{{- fail (printf "approvedEgress.parentProxy.bypassDomains[%d] must be a domain name with an optional leading dot, without a scheme, port, path, wildcard, or whitespace" $index) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- $agentVault := .Values.workers.kubernetes.agentVault -}}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -638,6 +638,10 @@ approvedEgress:
     enabled: false
     host: agent-vault
     port: 14322
+    # Route these destinations directly after the normal allowlist/grant check.
+    # Use an exact hostname or a leading dot for a domain and its subdomains.
+    # Useful for signed URLs that must skip parent-proxy credential injection.
+    bypassDomains: []
   resources:
     requests:
       cpu: 100m

--- a/docs/deployment/approved-egress.md
+++ b/docs/deployment/approved-egress.md
@@ -86,6 +86,23 @@ When `parentProxy.enabled` is true, workers use the approved egress Service for 
 Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
 Tokenless traffic remains direct from Squid after the policy check.
 
+Use `approvedEgress.parentProxy.bypassDomains` for signed URLs that must skip the credential-injecting parent:
+
+```yaml
+approvedEgress:
+  parentProxy:
+    enabled: true
+    bypassDomains:
+      - downloads.example.test
+      - .objects.example.test
+```
+
+The default empty list preserves the normal parent routing.
+Plain hostnames match exactly; a leading dot includes the domain and its subdomains.
+Use ASCII domain names without schemes, ports, paths, `*` wildcards, or whitespace; matching does not perform reverse DNS lookups.
+These destinations still pass the normal allowlist or dynamic-grant checks and destination/port restrictions before Squid connects directly.
+Changing bypass domains updates the chart-managed config checksum so the proxy restarts with the new routing rules.
+
 Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
 That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
 The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -20330,6 +20330,23 @@ When `parentProxy.enabled` is true, workers use the approved egress Service for 
 Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
 Tokenless traffic remains direct from Squid after the policy check.
 
+Use `approvedEgress.parentProxy.bypassDomains` for signed URLs that must skip the credential-injecting parent:
+
+```yaml
+approvedEgress:
+  parentProxy:
+    enabled: true
+    bypassDomains:
+      - downloads.example.test
+      - .objects.example.test
+```
+
+The default empty list preserves the normal parent routing.
+Plain hostnames match exactly; a leading dot includes the domain and its subdomains.
+Use ASCII domain names without schemes, ports, paths, `*` wildcards, or whitespace; matching does not perform reverse DNS lookups.
+These destinations still pass the normal allowlist or dynamic-grant checks and destination/port restrictions before Squid connects directly.
+Changing bypass domains updates the chart-managed config checksum so the proxy restarts with the new routing rules.
+
 Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
 That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
 The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.

--- a/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
+++ b/skills/mindroom-docs/references/page__deployment__approved-egress__index.md
@@ -82,6 +82,23 @@ When `parentProxy.enabled` is true, workers use the approved egress Service for 
 Squid enforces the allowlist and dynamic grants, then forwards requests that carry `Proxy-Authorization` to the Agent Vault parent with `login=PASSTHRU` so the vault still validates the worker's proxy-role token and injects credentials.
 Tokenless traffic remains direct from Squid after the policy check.
 
+Use `approvedEgress.parentProxy.bypassDomains` for signed URLs that must skip the credential-injecting parent:
+
+```yaml
+approvedEgress:
+  parentProxy:
+    enabled: true
+    bypassDomains:
+      - downloads.example.test
+      - .objects.example.test
+```
+
+The default empty list preserves the normal parent routing.
+Plain hostnames match exactly; a leading dot includes the domain and its subdomains.
+Use ASCII domain names without schemes, ports, paths, `*` wildcards, or whitespace; matching does not perform reverse DNS lookups.
+These destinations still pass the normal allowlist or dynamic-grant checks and destination/port restrictions before Squid connects directly.
+Changing bypass domains updates the chart-managed config checksum so the proxy restarts with the new routing rules.
+
 Do not leave Agent Vault tool traffic pointed directly at the chart-managed Agent Vault MITM Service when chart-managed approved egress is enabled.
 That path either bypasses Squid, or forces Squid behind the vault where worker identity is lost.
 The chart rejects direct URLs to the chart-managed Agent Vault proxy Service, including short and cluster-local DNS names, unless `approvedEgress.parentProxy` is enabled.

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -1403,7 +1403,11 @@ def test_runtime_chart_approved_egress_can_opt_out_of_runtime_config_overlay(tmp
     assert "MINDROOM_APPROVED_EGRESS_TOKEN" in runtime_env
 
 
-def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Path) -> None:
+@pytest.mark.parametrize("bypass_domains", [[], ["downloads.example.test", ".objects.example.test"]])
+def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(
+    tmp_path: Path,
+    bypass_domains: list[str],
+) -> None:
     """Tokened Agent Vault traffic should chain through Squid while grants keep worker IPs."""
     values_path = tmp_path / "values.yaml"
     values_path.write_text(
@@ -1416,6 +1420,7 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
                         "enabled": True,
                         "host": "agent-vault",
                         "port": 14322,
+                        "bypassDomains": bypass_domains,
                     },
                 },
                 "eventCache": {"postgres": {"auth": {"password": "test-password"}}},
@@ -1501,6 +1506,134 @@ def test_runtime_chart_approved_egress_can_chain_agent_vault_parent(tmp_path: Pa
     assert "always_direct allow !egress_has_token" in conf
     assert "never_direct allow egress_has_token" in conf
     assert "name=agentvault" not in conf
+    if bypass_domains:
+        assert "acl egress_bypass_parent dstdomain -n downloads.example.test .objects.example.test" in conf
+        assert conf.index("cache_peer_access agent-vault deny egress_bypass_parent") < conf.index(
+            "cache_peer_access agent-vault allow egress_has_token",
+        )
+        assert conf.index("always_direct allow egress_bypass_parent") < conf.index(
+            "always_direct allow !egress_has_token",
+        )
+    else:
+        assert "egress_bypass_parent" not in conf
+
+
+def test_runtime_chart_parent_bypass_domains_change_proxy_rollout_checksum(tmp_path: Path) -> None:
+    """Changing bypass routing updates the mounted config and forces the proxy to restart."""
+    checksums = set()
+    configs = set()
+    for domains in ([], ["downloads.example.test"], ["downloads.example.test", ".objects.example.test"]):
+        values_path = tmp_path / "values.yaml"
+        values_path.write_text(yaml.safe_dump({"approvedEgress": {"parentProxy": {"bypassDomains": domains}}}))
+        docs = _render_chart(
+            Path("cluster/k8s/runtime"),
+            "workers.backend=kubernetes",
+            "workers.sandbox.proxyToken.value=test-token",
+            "approvedEgress.enabled=true",
+            "approvedEgress.image.tag=v0.1.0",
+            "approvedEgress.parentProxy.enabled=true",
+            values_files=(values_path,),
+        )
+        deployment = _resource(docs, "Deployment", "mindroom-demo-mindroom-runtime-egress-proxy")
+        checksum = deployment["spec"]["template"]["metadata"]["annotations"]["checksum/squid-config"]
+        config = _resource(docs, "ConfigMap", "mindroom-demo-mindroom-runtime-egress-proxy-squid-config")["data"][
+            "squid.conf"
+        ]
+        configs.add(config)
+        checksums.add(checksum)
+    assert len(configs) == 3
+    assert len(checksums) == 3
+
+
+@pytest.mark.parametrize(
+    "bypass_domains",
+    [
+        "downloads.example.test",
+        {"downloads.example.test": True},
+        False,
+        0,
+        [False],
+        [42],
+        [None],
+        [{}],
+        [[]],
+        [""],
+        ["https://downloads.example.test"],
+        ["downloads.example.test:443"],
+        ["downloads.example.test/path"],
+        ["*.example.test"],
+        [".example..test"],
+        ["-n"],
+        ["/etc/passwd"],
+        ["example.test other.test"],
+        ["example.test\nhttp_access allow all"],
+        ["example.test\tother.test"],
+        ["example.test#comment"],
+        ["example.test\\other.test"],
+        ["-example.test"],
+        ["example-.test"],
+        [f"{'a' * 64}.test"],
+        [".".join(["a" * 63] * 4)],
+    ],
+)
+def test_runtime_chart_rejects_invalid_parent_bypass_domains(tmp_path: Path, bypass_domains: object) -> None:
+    """Malformed values cannot add Squid directives or silently widen parent bypass rules."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(yaml.safe_dump({"approvedEgress": {"parentProxy": {"bypassDomains": bypass_domains}}}))
+    completed = _run_helm_template(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        "approvedEgress.parentProxy.enabled=true",
+        values_files=(values_path,),
+    )
+    assert completed.returncode != 0
+    assert "approvedEgress.parentProxy.bypassDomains" in completed.stderr
+
+
+@pytest.mark.parametrize(
+    "domain",
+    [
+        "CDN.example.test",
+        "xn--bcher-kva.example.test",
+        f"{'a' * 63}.example.test",
+        "." + ".".join(["a" * 63] * 3 + ["b" * 61]),
+    ],
+)
+def test_runtime_chart_accepts_valid_parent_bypass_domain_boundaries(domain: str) -> None:
+    """Valid DNS labels, ASCII internationalized names, and maximum lengths remain usable."""
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        "approvedEgress.parentProxy.enabled=true",
+        set_string_args=(f"approvedEgress.parentProxy.bypassDomains[0]={domain}",),
+    )
+    config = _resource(docs, "ConfigMap", "mindroom-demo-mindroom-runtime-egress-proxy-squid-config")
+    assert f"acl egress_bypass_parent dstdomain -n {domain}" in config["data"]["squid.conf"]
+
+
+def test_runtime_chart_parent_bypass_domains_are_inactive_without_parent(tmp_path: Path) -> None:
+    """Preconfigured bypass domains cannot enable a parent or change egress authorization."""
+    values_path = tmp_path / "values.yaml"
+    values_path.write_text(
+        yaml.safe_dump({"approvedEgress": {"parentProxy": {"bypassDomains": ["downloads.example.test"]}}}),
+    )
+    docs = _render_chart(
+        Path("cluster/k8s/runtime"),
+        "workers.backend=kubernetes",
+        "workers.sandbox.proxyToken.value=test-token",
+        "approvedEgress.enabled=true",
+        "approvedEgress.image.tag=v0.1.0",
+        values_files=(values_path,),
+    )
+    deployment = _resource(docs, "Deployment", "mindroom-demo-mindroom-runtime-egress-proxy")
+    assert "checksum/squid-config" not in deployment["spec"]["template"]["metadata"].get("annotations", {})
+    assert not any(doc["kind"] == "ConfigMap" and doc["metadata"]["name"].endswith("-squid-config") for doc in docs)
 
 
 @pytest.mark.parametrize("deadline", [None, 1, 1800, 2147483647])


### PR DESCRIPTION
Selected destinations, such as signed object URLs, need to reach their origin without a credential-injecting parent proxy after passing approved-egress authorization.

Add optional `approvedEgress.parentProxy.bypassDomains` to the runtime Helm chart. Exact hostnames and leading-dot domain/subdomain entries route directly; other token-bearing traffic continues through the configured parent. The empty default preserves existing manifests. Bypass does not grant network access or weaken destination/port restrictions, and matching does not use reverse DNS lookups.

Validate list types and domain syntax to prevent malformed Squid configuration or directive injection. Reuse the existing Squid config checksum so changes roll the proxy automatically. Document synthetic examples and regenerate the documentation references.

Validation:
- 180 chart tests passed; new routing, validation, and checksum checks were verified failing before implementation.
- Helm lint and all repository pre-commit hooks passed.
- Default manifests matched the baseline with the parent enabled and disabled.
- Independent code review approved with no findings.
- 17 native Squid 6.13 HTTP/CONNECT checks passed using the published proxy base configuration with isolated loopback fixtures and a deterministic denying dynamic helper. Covered exact/subdomain routing, signed query preservation, parent-only proxy credentials, and allowlist/destination/port denial.
- Full non-Matrix suite: 18,310 passed, 10 skipped with four workers.

## Summary by Sourcery

Support securely routing selected approved egress destinations directly instead of through the credential-injecting parent proxy.

New Features:
- Add optional parent-proxy bypass domains to the runtime Helm chart for approved egress destinations.

Enhancements:
- Preserve existing routing by default while keeping bypass traffic subject to normal authorization and destination restrictions.
- Automatically roll the egress proxy when bypass-domain configuration changes.
- Validate bypass-domain values and support exact-hostname and domain/subdomain matching without reverse DNS lookups.

Documentation:
- Document bypass-domain configuration, matching behavior, validation rules, and security constraints in deployment and chart references.

Tests:
- Add chart coverage for bypass routing, configuration checksums, inactive behavior without the parent proxy, and valid and invalid domain values.