### PR TITLE
Defer attachment cleanup and supply continuous GPT-Live audio

### DIFF
--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -614,6 +614,7 @@ def register_local_attachment(
     source_event_id: str | None = None,
     sender: str | None = None,
     event_timestamp: int | None = None,
+    cleanup_loop: asyncio.AbstractEventLoop | None = None,
 ) -> AttachmentRecord | None:
     """Register a local file as an attachment and persist metadata."""
     if not local_path.is_file():
@@ -666,7 +667,11 @@ def register_local_attachment(
             tmp_path.unlink(missing_ok=True)
         return None
 
-    _maybe_cleanup_attachment_storage(storage_path)
+    if cleanup_loop is None:
+        _maybe_cleanup_attachment_storage(storage_path)
+    else:
+        # Hand off inside the worker, even when its awaiting caller was cancelled.
+        cleanup_loop.call_soon_threadsafe(_maybe_cleanup_attachment_storage, storage_path)
 
     return record
 
@@ -724,6 +729,7 @@ async def _register_media_attachment(
             source_event_id=event_id,
             sender=sender,
             event_timestamp=event_timestamp,
+            cleanup_loop=asyncio.get_running_loop(),
         ),
     )
 

--- a/src/mindroom/matrix_rtc/voice_agent.py
+++ b/src/mindroom/matrix_rtc/voice_agent.py
@@ -17,6 +17,7 @@ import importlib.util
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
+from mindroom.background_tasks import wait_for_future_until_complete
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
@@ -80,17 +81,30 @@ class _AudioFrameStream:
 class _AuthorizedParticipantAudioInput:
     """Mix microphone audio only from identities in the Matrix call roster."""
 
-    def __init__(self, room: rtc.Room, rtc_module: ModuleType, participant_identities: frozenset[str]) -> None:
+    def __init__(
+        self,
+        room: rtc.Room,
+        rtc_module: ModuleType,
+        participant_identities: frozenset[str],
+        *,
+        continuous_audio: bool = False,
+    ) -> None:
         self._room = room
         self._rtc = rtc_module
         self._participant_identities = participant_identities
+        self._continuous_audio = continuous_audio
+        self._pending_frame: asyncio.Task[rtc.AudioFrame] | None = None
+        self._next_frame_at = 0.0
+        self._closed_event = asyncio.Event()
         self._mixer = rtc_module.AudioMixer(
             _AUDIO_SAMPLE_RATE,
             _AUDIO_CHANNELS,
             blocksize=_AUDIO_SAMPLE_RATE * _AUDIO_FRAME_SIZE_MS // 1000,
+            capacity=1 if continuous_audio else 100,
         )
         self._streams: dict[str, tuple[str, _AudioFrameStream]] = {}
         self._close_tasks: set[asyncio.Task[None]] = set()
+        self._close_task: asyncio.Task[None] | None = None
         self._closed = False
         room.on("participant_connected", self._on_participant_connected)
         room.on("participant_disconnected", self._on_participant_disconnected)
@@ -110,7 +124,38 @@ class _AuthorizedParticipantAudioInput:
         return "authorized MatrixRTC participants"
 
     async def __anext__(self) -> rtc.AudioFrame:
-        return await self._mixer.__anext__()
+        if not self._continuous_audio:
+            return await self._mixer.__anext__()
+        if self._closed:
+            raise StopAsyncIteration
+        if self._pending_frame is None:
+            self._pending_frame = asyncio.create_task(self._mixer.__anext__())
+
+        # Keep one mixer read across silence deadlines and consumer cancellation.
+        # Cancelling and restarting reads can lose a frame arriving at the boundary.
+        loop = asyncio.get_running_loop()
+        try:
+            async with asyncio.timeout(max(0.0, self._next_frame_at - loop.time())):
+                await self._closed_event.wait()
+        except TimeoutError:
+            pass
+        if self._closed:
+            raise StopAsyncIteration
+        # Carry ordinary late wakeups forward without accumulating audio latency.
+        # After a full missed frame, rebase rather than emitting a catch-up burst.
+        now = loop.time()
+        frame_duration = _AUDIO_FRAME_SIZE_MS / 1000
+        if self._next_frame_at < now - frame_duration:
+            self._next_frame_at = now
+        self._next_frame_at += frame_duration
+        if self._pending_frame.done():
+            pending_frame, self._pending_frame = self._pending_frame, None
+            return pending_frame.result()
+        return self._rtc.AudioFrame.create(
+            _AUDIO_SAMPLE_RATE,
+            _AUDIO_CHANNELS,
+            _AUDIO_SAMPLE_RATE * _AUDIO_FRAME_SIZE_MS // 1000,
+        )
 
     @property
     def source(self) -> AudioInput | None:
@@ -161,6 +206,8 @@ class _AuthorizedParticipantAudioInput:
                 sample_rate=_AUDIO_SAMPLE_RATE,
                 num_channels=_AUDIO_CHANNELS,
                 frame_size_ms=_AUDIO_FRAME_SIZE_MS,
+                # Keep at most 500 ms of recent microphone audio if Live stalls.
+                capacity=10 if self._continuous_audio else 0,
             ),
             participant_identity,
         )
@@ -226,9 +273,14 @@ class _AuthorizedParticipantAudioInput:
 
     async def aclose(self) -> None:
         """Unregister room listeners and close every participant stream."""
-        if self._closed:
-            return
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._close())
+        await wait_for_future_until_complete(self._close_task)
+
+    async def _close(self) -> None:
+        """Own teardown until every audio resource has settled, even on cancellation."""
         self._closed = True
+        self._closed_event.set()
         self._room.off("participant_connected", self._on_participant_connected)
         self._room.off("participant_disconnected", self._on_participant_disconnected)
         self._room.off("track_published", self._on_track_published)
@@ -237,6 +289,10 @@ class _AuthorizedParticipantAudioInput:
         self._room.off("track_unsubscribed", self._on_track_unsubscribed)
         for publication_sid in list(self._streams):
             self._remove_stream(publication_sid)
+        if self._pending_frame is not None:
+            self._pending_frame.cancel()
+            await asyncio.gather(self._pending_frame, return_exceptions=True)
+            self._pending_frame = None
         await self._mixer.aclose()
         if self._close_tasks:
             await asyncio.gather(*self._close_tasks, return_exceptions=True)
@@ -437,7 +493,12 @@ class RealtimeVoiceBridge:
             msg = "connect() must succeed before start_agent()"
             raise RuntimeError(msg)
         self._session = session
-        audio_input = _AuthorizedParticipantAudioInput(self._room, rtc_module, self._participant_identities)
+        audio_input = _AuthorizedParticipantAudioInput(
+            self._room,
+            rtc_module,
+            self._participant_identities,
+            continuous_audio=isinstance(options, LiveVoiceAgentOptions),
+        )
         self._audio_input = audio_input
         session.input.audio = cast("AudioInput", audio_input)
         self._register_session_listeners(session, options)

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -185,7 +185,9 @@ async def test_register_media_attachment_offloads_registration_work(tmp_path: Pa
         source_event_id: str | None = None,
         sender: str | None = None,
         event_timestamp: int | None = None,
+        cleanup_loop: asyncio.AbstractEventLoop | None = None,
     ) -> AttachmentRecord:
+        assert cleanup_loop is not None
         registration_thread_ids.append(threading.get_ident())
         return AttachmentRecord(
             attachment_id=attachment_id or "att_generated",
@@ -529,20 +531,28 @@ async def test_attachment_cleanup_failure_retries_without_throttle_or_stranded_c
 
 
 @pytest.mark.asyncio
-async def test_media_registration_cancellation_drains_attachment_cleanup_worker(tmp_path: Path) -> None:
-    """Cancelling media registration waits for its cleanup worker to finish."""
+async def test_media_registration_cancellation_hands_cleanup_to_shutdown_owner(tmp_path: Path) -> None:
+    """Cancelled registration drains persistence, while shutdown owns the cleanup scan."""
+    persistence_started = threading.Event()
+    release_persistence = threading.Event()
     cleanup_started = threading.Event()
     release_cleanup = threading.Event()
     cleanup_finished = threading.Event()
-    cleanup_claims: dict[Path, object] = {}
+    original_replace = Path.replace
+
+    def blocking_replace(path: Path, target: Path) -> Path:
+        if target.suffix == ".json":
+            persistence_started.set()
+            assert release_persistence.wait(timeout=5)
+        return original_replace(path, target)
 
     def blocking_cleanup(_storage_path: Path) -> None:
         cleanup_started.set()
-        assert release_cleanup.wait(timeout=2)
+        assert release_cleanup.wait(timeout=5)
         cleanup_finished.set()
 
     with (
-        patch("mindroom.attachments._attachment_cleanup_claim_tokens_by_storage_path", cleanup_claims),
+        patch.object(Path, "replace", new=blocking_replace),
         patch("mindroom.attachments._cleanup_attachment_storage", side_effect=blocking_cleanup),
     ):
         registration_task = asyncio.create_task(
@@ -559,17 +569,86 @@ async def test_media_registration_cancellation_drains_attachment_cleanup_worker(
                 kind="file",
             ),
         )
-        assert await asyncio.to_thread(cleanup_started.wait, 2)
-        registration_task.cancel()
-        await asyncio.sleep(0)
-        assert not registration_task.done()
-        release_cleanup.set()
-        with pytest.raises(asyncio.CancelledError):
-            await registration_task
+        try:
+            assert await asyncio.to_thread(persistence_started.wait, 2)
+            registration_task.cancel()
+            await asyncio.sleep(0)
+            assert not registration_task.done()
+            release_persistence.set()
+            assert await asyncio.to_thread(cleanup_started.wait, 2)
+            done, _ = await asyncio.wait({registration_task}, timeout=1)
+            assert done, "Registration cancellation still waits for cleanup"
+            with pytest.raises(asyncio.CancelledError):
+                await registration_task
+            record = load_attachment(tmp_path, _attachment_id_for_event("$cancel_cleanup"))
+            assert record is not None
+            assert record.local_path.read_bytes() == b"payload"
+            assert not cleanup_finished.is_set()
+        finally:
+            release_persistence.set()
+            release_cleanup.set()
+            await asyncio.gather(registration_task, return_exceptions=True)
+            assert await attachments_module.wait_for_attachment_cleanup_tasks()
 
     assert cleanup_finished.is_set()
-    assert await attachments_module.wait_for_attachment_cleanup_tasks()
-    assert cleanup_claims == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["audio", "image", "file", "video"])
+async def test_media_registration_returns_before_cleanup_and_deduplicates_scans(
+    tmp_path: Path,
+    kind: _AttachmentKind,
+) -> None:
+    """Persisted incoming media is usable while a single owned cleanup scan is blocked."""
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    cleanup_calls = 0
+
+    def blocking_cleanup(_storage_path: Path) -> None:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=5)
+
+    async def register(event_id: str) -> AttachmentRecord | None:
+        return await _register_media_attachment(
+            storage_path=tmp_path,
+            event_id=event_id,
+            media_bytes=b"payload",
+            mime_type="application/octet-stream",
+            room_id="!room:localhost",
+            thread_id=None,
+            sender="@sender:localhost",
+            event_timestamp=1,
+            filename="payload.bin",
+            kind=kind,
+        )
+
+    with patch("mindroom.attachments._cleanup_attachment_storage", side_effect=blocking_cleanup):
+        registration = asyncio.create_task(register("$first"))
+        drain = None
+        try:
+            assert await asyncio.to_thread(cleanup_started.wait, 2)
+            done, _ = await asyncio.wait({registration}, timeout=1)
+            assert done, "Incoming media registration still waits for cleanup"
+            first = registration.result()
+            assert first is not None
+            assert first.local_path.read_bytes() == b"payload"
+            assert load_attachment(tmp_path, first.attachment_id) == first
+            assert await asyncio.wait_for(register("$second"), timeout=1) is not None
+            drain = asyncio.create_task(attachments_module.wait_for_attachment_cleanup_tasks())
+            await asyncio.sleep(0)
+            assert not drain.done()
+            assert cleanup_calls == 1
+        finally:
+            release_cleanup.set()
+            await registration
+            assert await attachments_module.wait_for_attachment_cleanup_tasks()
+            if drain is not None:
+                assert await drain
+        assert await register("$third") is not None
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+        assert cleanup_calls == 1
 
 
 def test_attachment_cleanup_logs_scan_and_deletion_counts(tmp_path: Path) -> None:

--- a/tests/test_matrix_rtc_continuous_audio.py
+++ b/tests/test_matrix_rtc_continuous_audio.py
@@ -1,0 +1,418 @@
+"""GPT-Live input stays paced across microphone arrival and stream gaps."""
+
+from __future__ import annotations
+
+import asyncio
+from itertools import pairwise
+from types import ModuleType, SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from livekit import rtc
+from livekit.agents import room_io
+from livekit.rtc._utils import RingQueue
+
+import mindroom.matrix_rtc.voice_agent as voice_agent_module
+from mindroom.matrix_rtc.voice_agent import (
+    LiveVoiceAgentOptions,
+    RealtimeVoiceBridge,
+    VoiceAgentOptions,
+    _AuthorizedParticipantAudioInput,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Microphone:
+    """A controllable external microphone stream with observable read lifetime."""
+
+    def __init__(self) -> None:
+        self.frames: asyncio.Queue[rtc.AudioFrame] = asyncio.Queue()
+        self.reading = asyncio.Event()
+        self.closed = False
+        self.pending_reads = 0
+
+    async def __anext__(self) -> SimpleNamespace:
+        """Wait for one external audio frame and expose pending reads."""
+        self.pending_reads += 1
+        self.reading.set()
+        try:
+            return SimpleNamespace(frame=await self.frames.get())
+        finally:
+            self.pending_reads -= 1
+
+    async def aclose(self) -> None:
+        """Record closure of the external stream."""
+        self.closed = True
+
+
+async def start_audio(
+    *,
+    live: bool = True,
+    stream_factory: Callable[..., object] | None = None,
+) -> tuple[_AuthorizedParticipantAudioInput, MagicMock]:
+    """Exercise session input wiring with the real RTC mixer and no network."""
+    room = MagicMock()
+    room.remote_participants = {}
+    room.local_participant.track_publications = {}
+    bridge = RealtimeVoiceBridge(local_identity="bot", e2ee_enabled=False)
+    bridge._room = room
+    bridge._participant_identities = frozenset({"alice"})
+    session = MagicMock()
+    session.start = AsyncMock()
+    options = (
+        LiveVoiceAgentOptions(
+            instructions="Speak.",
+            model="gpt-live-1",
+            api_key="test",
+            voice="marin",
+            respond=AsyncMock(),
+        )
+        if live
+        else VoiceAgentOptions(instructions="Speak.", model="realtime", api_key="test")
+    )
+    rtc_module = cast(
+        "ModuleType",
+        SimpleNamespace(
+            AudioMixer=rtc.AudioMixer,
+            AudioFrame=rtc.AudioFrame,
+            AudioStream=stream_factory or (lambda track, **_kwargs: track),
+            TrackKind=rtc.TrackKind,
+            TrackSource=rtc.TrackSource,
+        ),
+    )
+    await bridge._start_session(
+        session,
+        MagicMock(),
+        options,
+        rtc_module=rtc_module,
+        room_io_module=room_io,
+    )
+    return session.input.audio, room
+
+
+def subscribe(room: MagicMock, identity: str, microphone: Microphone) -> None:
+    """Deliver the same subscription event emitted by the RTC room."""
+    publication = SimpleNamespace(
+        sid=f"{identity}-mic",
+        kind=rtc.TrackKind.KIND_AUDIO,
+        source=rtc.TrackSource.SOURCE_MICROPHONE,
+        set_subscribed=MagicMock(),
+    )
+    participant = SimpleNamespace(identity=identity)
+    for call in room.on.call_args_list:
+        if call.args[0] == "track_subscribed":
+            callback = cast("Callable[..., None]", call.args[1])
+            callback(microphone, publication, participant)
+
+
+def frame(value: int) -> rtc.AudioFrame:
+    """Use distinct fixed PCM samples to detect duplicates and dropped frames."""
+    return rtc.AudioFrame(value.to_bytes(2, "little", signed=True) * 1200, 24000, 1, 1200)
+
+
+@pytest.mark.asyncio
+async def test_live_input_emits_paced_silence_before_any_participant_joins() -> None:
+    """Starting with an empty RTC room must still deliver valid realtime PCM."""
+    audio, _room = await start_audio()
+    try:
+        started = asyncio.get_running_loop().time()
+        frames = [await asyncio.wait_for(anext(audio), timeout=1) for _ in range(4)]
+        elapsed = asyncio.get_running_loop().time() - started
+        assert elapsed >= 0.15
+        assert elapsed < 0.8
+        for item in frames:
+            assert (item.sample_rate, item.num_channels, item.samples_per_channel) == (24000, 1, 1200)
+            assert item.data.tobytes() == bytes(2400)
+    finally:
+        await audio.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_input_resumes_real_frames_after_late_microphone_and_stream_gap() -> None:
+    """Late and resumed audio reaches the model once, in order, between silence frames."""
+    audio, room = await start_audio()
+    microphone = Microphone()
+    try:
+        assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        subscribe(room, "alice", microphone)
+        await asyncio.wait_for(microphone.reading.wait(), timeout=1)
+        assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        for value in (17, 29):
+            microphone.frames.put_nowait(frame(value))
+        received = []
+        async with asyncio.timeout(2):
+            while len(received) < 2:
+                item = await anext(audio)
+                if any(item.data):
+                    received.append(item.data.tobytes())
+        assert received == [frame(17).data.tobytes(), frame(29).data.tobytes()]
+        for _ in range(3):
+            assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        microphone.frames.put_nowait(frame(43))
+        async with asyncio.timeout(2):
+            while not any((resumed := await anext(audio)).data):
+                pass
+        assert resumed.data.tobytes() == frame(43).data.tobytes()
+        assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+    finally:
+        await audio.aclose()
+    assert microphone.closed
+    assert microphone.pending_reads == 0
+
+
+@pytest.mark.asyncio
+async def test_live_silence_never_admits_an_unauthorized_microphone() -> None:
+    """A remote track outside the roster cannot replace silence with its samples."""
+    audio, room = await start_audio()
+    microphone = Microphone()
+    microphone.frames.put_nowait(frame(71))
+    subscribe(room, "outsider", microphone)
+    try:
+        for _ in range(3):
+            assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        assert not microphone.reading.is_set()
+        assert microphone.frames.qsize() == 1
+    finally:
+        await audio.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_cancelled_consumer_keeps_real_frame_and_close_ends_pending_read() -> None:
+    """Cancelling one consumer cannot discard a mixer frame or leave a read after close."""
+    audio, room = await start_audio()
+    microphone = Microphone()
+    subscribe(room, "alice", microphone)
+    pending = asyncio.create_task(anext(audio))
+    try:
+        await asyncio.wait_for(microphone.reading.wait(), timeout=1)
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        microphone.frames.put_nowait(frame(89))
+        async with asyncio.timeout(2):
+            while not any((item := await anext(audio)).data):
+                pass
+        assert item.data.tobytes() == frame(89).data.tobytes()
+        assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        pending = asyncio.create_task(anext(audio))
+        await asyncio.sleep(0)
+        await audio.aclose()
+        with pytest.raises(StopAsyncIteration):
+            await asyncio.wait_for(pending, timeout=1)
+        with pytest.raises(StopAsyncIteration):
+            await anext(audio)
+    finally:
+        pending.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+        await audio.aclose()
+    assert microphone.closed
+    assert microphone.pending_reads == 0
+
+
+@pytest.mark.asyncio
+async def test_other_voice_models_keep_waiting_for_real_audio() -> None:
+    """Only GPT-Live receives synthesized silence at the shared session seam."""
+    audio, _room = await start_audio(live=False)
+    pending = asyncio.create_task(anext(audio))
+    try:
+        done, _ = await asyncio.wait({pending}, timeout=0.15)
+        assert not done
+    finally:
+        pending.cancel()
+        await asyncio.gather(pending, return_exceptions=True)
+        await audio.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_input_paces_buffered_real_frames_without_duplicates() -> None:
+    """A ready microphone backlog cannot bypass the realtime output cadence."""
+    audio, room = await start_audio()
+    microphone = Microphone()
+    for value in (11, 22, 33, 44):
+        microphone.frames.put_nowait(frame(value))
+    subscribe(room, "alice", microphone)
+    received = []
+    delivered_at = []
+    try:
+        async with asyncio.timeout(2):
+            while len(received) < 4:
+                item = await anext(audio)
+                if any(item.data):
+                    received.append(item.data.tobytes())
+                    delivered_at.append(asyncio.get_running_loop().time())
+        assert received == [frame(value).data.tobytes() for value in (11, 22, 33, 44)]
+        assert all(after - before >= 0.045 for before, after in pairwise(delivered_at))
+    finally:
+        await audio.aclose()
+
+
+@pytest.mark.asyncio
+async def test_live_input_owns_one_stalled_mixer_read_until_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence ticks must neither cancel/restart the mixer read nor leak it at close."""
+    pending_reads = 0
+    read_calls = 0
+    read_finished = asyncio.Event()
+    original_next = rtc.AudioMixer.__anext__
+
+    async def observed_next(mixer: rtc.AudioMixer) -> rtc.AudioFrame:
+        nonlocal pending_reads, read_calls
+        pending_reads += 1
+        read_calls += 1
+        try:
+            return await original_next(mixer)
+        finally:
+            pending_reads -= 1
+            read_finished.set()
+
+    monkeypatch.setattr(rtc.AudioMixer, "__anext__", observed_next)
+    audio, _room = await start_audio()
+    try:
+        for _ in range(3):
+            assert (await asyncio.wait_for(anext(audio), timeout=1)).data.tobytes() == bytes(2400)
+        assert pending_reads == 1
+        assert read_calls == 1
+        assert not read_finished.is_set()
+    finally:
+        await audio.aclose()
+    assert pending_reads == 0
+    assert read_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_live_cancelled_close_drains_mixer_and_can_be_awaited_again(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cancellation while draining a mixer read cannot skip the remaining teardown."""
+    read_cancelled = asyncio.Event()
+    release_read = asyncio.Event()
+    mixer_closed = asyncio.Event()
+    mixers = []
+    original_next = rtc.AudioMixer.__anext__
+    original_close = rtc.AudioMixer.aclose
+
+    async def gated_next(mixer: rtc.AudioMixer) -> rtc.AudioFrame:
+        mixers.append(mixer)
+        try:
+            return await original_next(mixer)
+        finally:
+            read_cancelled.set()
+            await release_read.wait()
+
+    async def observed_close(mixer: rtc.AudioMixer) -> None:
+        await original_close(mixer)
+        mixer_closed.set()
+
+    monkeypatch.setattr(rtc.AudioMixer, "__anext__", gated_next)
+    monkeypatch.setattr(rtc.AudioMixer, "aclose", observed_close)
+    audio, _room = await start_audio()
+    closing = None
+    retry = None
+    try:
+        await asyncio.wait_for(anext(audio), timeout=1)
+        closing = asyncio.create_task(audio.aclose())
+        await asyncio.wait_for(read_cancelled.wait(), timeout=1)
+        closing.cancel()
+        done, _ = await asyncio.wait({closing}, timeout=0.05)
+        assert not done, "Cancelled close abandoned mixer teardown"
+        retry = asyncio.create_task(audio.aclose())
+        done, _ = await asyncio.wait({retry}, timeout=0.05)
+        assert not done, "Concurrent close did not join the owned teardown"
+        release_read.set()
+        with pytest.raises(asyncio.CancelledError):
+            await closing
+        await retry
+        assert mixer_closed.is_set()
+    finally:
+        release_read.set()
+        if closing is not None:
+            await asyncio.gather(closing, return_exceptions=True)
+        if retry is not None:
+            await asyncio.gather(retry, return_exceptions=True)
+        await audio.aclose()
+        for mixer in mixers:
+            await original_close(mixer)
+
+
+@pytest.mark.asyncio
+async def test_live_audio_deadlines_absorb_jitter_and_rebase_after_long_pause(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ordinary late wakeups must not compound into latency, and a pause must not cause a burst."""
+    audio, _room = await start_audio()
+    clock = SimpleNamespace(now=0.0)
+
+    class LateDeadline:
+        def __init__(self, delay: float) -> None:
+            self.delay = delay
+
+        async def __aenter__(self) -> None:
+            """Wake five milliseconds late without waiting for wall clock time."""
+            clock.now += self.delay + 0.005
+            raise TimeoutError
+
+        async def __aexit__(self, *_args: object) -> None:
+            """Satisfy the timeout context interface."""
+
+    monkeypatch.setattr(
+        voice_agent_module,
+        "asyncio",
+        SimpleNamespace(
+            create_task=asyncio.create_task,
+            gather=asyncio.gather,
+            get_running_loop=lambda: SimpleNamespace(time=lambda: clock.now),
+            timeout=LateDeadline,
+        ),
+    )
+    try:
+        delivered_at = []
+        for _ in range(40):
+            assert (await anext(audio)).data.tobytes() == bytes(2400)
+            delivered_at.append(clock.now)
+        # 39 frame intervals, with at most one late wakeup rather than 39 of them.
+        assert delivered_at[-1] - delivered_at[0] <= 1.956
+        clock.now += 1.0
+        await anext(audio)
+        after_pause = clock.now
+        await anext(audio)
+        assert clock.now - after_pause >= 0.05
+    finally:
+        await audio.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("live", [True, False], ids=["live", "other-model"])
+async def test_only_live_audio_bounds_upstream_backlog_to_recent_frames(live: bool) -> None:
+    """A paused Live consumer retains recent audio instead of accumulating an unbounded backlog."""
+    streams = []
+
+    class BufferedMicrophone:
+        def __init__(self, capacity: int) -> None:
+            # Use the SDK's actual drop-oldest queue to exercise the configured bound.
+            self.frames: RingQueue[rtc.AudioFrame] = RingQueue(capacity)
+
+        async def __anext__(self) -> SimpleNamespace:
+            """Deliver one queued microphone frame."""
+            return SimpleNamespace(frame=await self.frames.get())
+
+        async def aclose(self) -> None:
+            """No external resources are held by the synthetic microphone."""
+
+    def stream_factory(_track: object, *, capacity: int = 0, **_kwargs: object) -> BufferedMicrophone:
+        stream = BufferedMicrophone(capacity)
+        streams.append(stream)
+        return stream
+
+    audio, room = await start_audio(live=live, stream_factory=stream_factory)
+    subscribe(room, "alice", Microphone())
+    for value in range(1, 21):
+        streams[0].frames.put(frame(value))
+    expected_values = list(range(11, 21)) if live else list(range(1, 21))
+    received = []
+    try:
+        async with asyncio.timeout(2):
+            while len(received) < len(expected_values):
+                item = await anext(audio)
+                if any(item.data):
+                    received.append(item.data.tobytes())
+        assert received == [frame(value).data.tobytes() for value in expected_values]
+    finally:
+        await audio.aclose()

--- a/tests/test_matrix_rtc_voice_agent.py
+++ b/tests/test_matrix_rtc_voice_agent.py
@@ -197,7 +197,7 @@ async def test_agent_session_uses_group_safe_room_options(monkeypatch: pytest.Mo
     monkeypatch.setattr("livekit.plugins.openai.realtime.RealtimeModel", lambda **_kwargs: fake_model)
     monkeypatch.setattr(
         "mindroom.matrix_rtc.voice_agent._AuthorizedParticipantAudioInput",
-        lambda *_args: fake_audio_input,
+        lambda *_args, **_kwargs: fake_audio_input,
     )
     bridge = RealtimeVoiceBridge(local_identity="@bot:example.org:BOTDEV", e2ee_enabled=False)
     bridge._room = MagicMock()
@@ -325,7 +325,7 @@ async def test_cascaded_session_wires_stt_normal_agent_and_tts(  # noqa: C901, P
     fake_audio_input.aclose = AsyncMock()
     monkeypatch.setattr(
         "mindroom.matrix_rtc.voice_agent._AuthorizedParticipantAudioInput",
-        lambda *_args: fake_audio_input,
+        lambda *_args, **_kwargs: fake_audio_input,
     )
     bridge = CascadedVoiceBridge(local_identity="@bot:example.org:BOTDEV", e2ee_enabled=False)
     bridge._room = MagicMock()
@@ -1025,7 +1025,7 @@ async def test_start_agent_logs_detailed_media_snapshot_once(monkeypatch: pytest
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.voice_agent._AuthorizedParticipantAudioInput",
-        lambda *_args: MagicMock(),
+        lambda *_args, **_kwargs: MagicMock(),
     )
     alice_identity = "@alice:example.org:ALICEDEV"
     bob_identity = "@bob:example.org:BOBDEV"


### PR DESCRIPTION
Incoming audio, images, files, and video can wait for a full attachment cleanup scan because registration invokes the cleanup scheduler from a worker thread without an event loop. Hand cleanup back to its existing loop owner after metadata persistence, including when the registering caller is cancelled.

GPT-Live also needs continuous input audio before a microphone appears or while microphone audio pauses. Supply paced PCM silence through the authorized input path, switch to authorized microphone frames as they arrive, bound buffering, and keep audio reads and shutdown owned through cancellation. Other voice models retain their existing input behavior.

Validation: the full runtime suite passed (18,288 tests, 22 skipped), followed by 440 affected-area tests on the final changes and all repository pre-commit hooks. Regression coverage uses gated cleanup and the real RTC mixer; independent review covers cancellation, cadence, authorization, and bounded buffering. A synthetic live OpenAI API comparison reproduced the greeting timeout without input audio and received greeting speech with continuous silence. This tests provider generation; it is not an end-to-end call or concurrency benchmark.

## Summary by Sourcery

Decouple attachment cleanup from media registration and maintain continuous, cancellation-safe authorized audio input for GPT-Live.

New Features:
- Provide GPT-Live with continuous, paced PCM input that bridges microphone gaps with silence while preserving authorized microphone audio.

Bug Fixes:
- Prevent attachment registration from waiting on cleanup scans and ensure cleanup is handed back to the owning event loop even when registration is cancelled.
- Preserve audio frames and complete mixer and stream teardown across consumer cancellation and shutdown.

Enhancements:
- Bound GPT-Live microphone buffering and retain existing real-audio behavior for other voice models.

Tests:
- Add regression coverage for deferred attachment cleanup, cancellation, authorization, pacing, buffering, frame preservation, and audio shutdown.