### PR TITLE
Separate Connections tool access from credential management

### DIFF
--- a/docs/deployment/mcp-gateway.md
+++ b/docs/deployment/mcp-gateway.md
@@ -35,9 +35,11 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 ```
 
 The configured personal agent must use `private.per: user` or `private.per: user_agent`.
-Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
+Access follows the agent's existing authorization rules: matching `access.users`, administrator authority, or verified membership in an `access.members_of_rooms` grant room (including default grants from configured agent rooms).
+`access.current_room_members` alone does not grant MCP access because MCP requests have no current Matrix conversation.
+Unknown or revoked grant-room membership cannot authorize a call.
 Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
-Shared agents are eligible when the user is a credential manager or administrator; ordinary reply access is insufficient.
+Shared agents use the same access rules; credential management alone does not grant tool execution.
 Private agents belonging to other users are never eligible.
 Clients can address only agents in the signed-in user's saved selection and cannot choose another user or credential owner.
 
@@ -49,6 +51,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 ## Choose exposed agents and tools
 
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
 Under **MCP access**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
@@ -65,9 +68,12 @@ The page lists all assigned tools, including those without browser authenticatio
 Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
+Users can inspect shared connection availability without seeing the connected account identity or changing its credentials.
+Only credential managers and administrators can change shared connections; users manage their own requester-scoped connections.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
+Live membership revocation also takes effect at this boundary without a configuration change.
 Upstream service credentials are validated after admission and before using the remote session.
 Calls already admitted may finish after an agent or tool is turned off.
 Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.

--- a/docs/deployment/trusted-upstream-auth.md
+++ b/docs/deployment/trusted-upstream-auth.md
@@ -78,10 +78,10 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents the authenticated user can use or manage credentials for.
 Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Tools without browser authentication also appear, and room-dependent tools are marked **MindRoom only**.
-Each service card loads independently, so a failed or unconnected service does not block the others.
+Each service status loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
 ```bash
@@ -108,10 +108,12 @@ agents:
         defer: true
 ```
 
-Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
-Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
-Reply access alone does not grant shared connection management.
+Agent use requires a matching `access.users` grant, configured administrator authority, or verified membership in a configured grant room.
+Conversation-only `access.current_room_members` grants do not apply because browser and MCP requests have no current Matrix room.
+Shared agents also appear when the user is listed in `agents.<name>.credential_managers`, even when they cannot use that agent.
+Users with agent access can select its compatible MCP tools and see shared connection availability without the connected account identity.
+Credential managers and administrators can manage shared connections; users can manage their own requester-scoped connections.
+Credential management alone does not grant MCP tool access.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.

--- a/frontend/src/connections/AgentTable.tsx
+++ b/frontend/src/connections/AgentTable.tsx
@@ -87,6 +87,12 @@ const columns: ColumnDef<AgentTableRow>[] = [
     header: "MCP access",
     cell: ({ row }) => {
       const mcp = row.original.mcp;
+      if (!row.original.can_use)
+        return (
+          <span className="text-xs text-muted-foreground">
+            Credential management only
+          </span>
+        );
       if (!mcp.selection?.enabled)
         return <span className="text-muted-foreground">—</span>;
       const choice = mcp.selectedTools(row.original.agent_name);

--- a/frontend/src/connections/ConnectionServiceRows.tsx
+++ b/frontend/src/connections/ConnectionServiceRows.tsx
@@ -160,11 +160,15 @@ export function ConnectionServiceRows({
                             aria-hidden="true"
                           />
                         )}
-                        {status.reset_required
-                          ? "Reset required"
-                          : status.connected
-                            ? "Connected"
-                            : "Not connected"}
+                        {!service.can_manage
+                          ? status.connected
+                            ? "Shared connection configured"
+                            : "Shared connection unavailable"
+                          : status.reset_required
+                            ? "Reset required"
+                            : status.connected
+                              ? "Connected"
+                              : "Not connected"}
                       </span>
                       {status.account_label && (
                         <p className="mt-1 max-w-56 break-all text-xs text-muted-foreground">
@@ -194,7 +198,12 @@ export function ConnectionServiceRows({
                     Retry status
                   </Button>
                 )}
-                {!loading && status && (
+                {!loading && status && !service.can_manage && (
+                  <span className="text-xs text-muted-foreground">
+                    Managed by credential managers
+                  </span>
+                )}
+                {!loading && status && service.can_manage && (
                   <div className="flex flex-wrap items-center justify-end gap-2">
                     {status.reset_required ? (
                       <Button

--- a/frontend/src/connections/Connections.test.tsx
+++ b/frontend/src/connections/Connections.test.tsx
@@ -15,6 +15,7 @@ const service: ConnectionService = {
   icon: null,
   provider: "mail",
   is_shared: false,
+  can_manage: true,
   display_name: "Mail",
   description: "Read your email.",
   tools: ["mail"],
@@ -35,6 +36,7 @@ const catalog = (services: (typeof service)[]) => ({
       agent_name: "personal",
       agent_display_name: "Personal assistant",
       is_shared: false,
+      can_use: true,
       services,
       tools: services.flatMap((item) =>
         item.tools.map((name) => ({
@@ -48,6 +50,52 @@ const catalog = (services: (typeof service)[]) => ({
       ),
     },
   ],
+});
+
+it("shows shared connection availability without account controls for agent users", async () => {
+  installApi({
+    "/api/connections": async () =>
+      json(catalog([{ ...service, is_shared: true, can_manage: false }])),
+    "/api/connections/mcp/selection": async () =>
+      json({ enabled: true, agents: {} }),
+    "/api/connections/agents/personal/mail/status": async () =>
+      json({ ...status, connected: true, can_connect: false }),
+  });
+  render(<Connections />);
+  await expandAgent();
+  expect(
+    await screen.findByText("Shared connection configured"),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Disconnect Mail" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "Connect Mail" }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("checkbox", {
+      name: "Expose Mail for Personal assistant through MCP",
+    }),
+  ).toBeEnabled();
+});
+
+it("keeps account management available without offering MCP access to management-only agents", async () => {
+  const data = catalog([service]);
+  data.agents[0].can_use = false;
+  installApi({
+    "/api/connections": async () => json(data),
+    "/api/connections/mcp/selection": async () =>
+      json({ enabled: true, agents: {} }),
+  });
+  render(<Connections />);
+  await expandAgent();
+  expect(
+    await screen.findByRole("button", { name: "Connect Mail" }),
+  ).toBeEnabled();
+  expect(
+    screen.queryAllByRole("checkbox", { name: /Expose .* through MCP/ }),
+  ).toHaveLength(0);
+  expect(screen.getByText("Credential management only")).toBeInTheDocument();
 });
 
 function installApi(overrides: Record<string, () => Promise<Response>> = {}) {
@@ -561,6 +609,7 @@ describe("MCP agent selection", () => {
         agent_name: "shared",
         agent_display_name: "Research Team",
         is_shared: true,
+        can_use: true,
         services: [],
         tools: [
           {

--- a/frontend/src/connections/ToolRow.tsx
+++ b/frontend/src/connections/ToolRow.tsx
@@ -33,6 +33,10 @@ export function ToolExposure({
   tool: ConnectionTool;
   mcp: McpSelectionState;
 }) {
+  if (!agent.can_use)
+    return (
+      <span className="text-xs text-muted-foreground">No tool access</span>
+    );
   if (tool.requires_room_context)
     return <span className="text-xs text-muted-foreground">MindRoom only</span>;
   if (!mcp.selection?.enabled)

--- a/frontend/src/connections/types.ts
+++ b/frontend/src/connections/types.ts
@@ -1,6 +1,7 @@
 export interface ConnectionService {
   provider: string;
   is_shared: boolean;
+  can_manage: boolean;
   display_name: string;
   description: string;
   icon: string | null;
@@ -11,6 +12,7 @@ export interface AgentConnections {
   agent_name: string;
   agent_display_name: string;
   is_shared: boolean;
+  can_use: boolean;
   services: ConnectionService[];
   tools: ConnectionTool[];
 }

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -18908,10 +18908,10 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents the authenticated user can use or manage credentials for.
 Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Tools without browser authentication also appear, and room-dependent tools are marked **MindRoom only**.
-Each service card loads independently, so a failed or unconnected service does not block the others.
+Each service status loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
 ```bash
@@ -18938,10 +18938,12 @@ agents:
         defer: true
 ```
 
-Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
-Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
-Reply access alone does not grant shared connection management.
+Agent use requires a matching `access.users` grant, configured administrator authority, or verified membership in a configured grant room.
+Conversation-only `access.current_room_members` grants do not apply because browser and MCP requests have no current Matrix room.
+Shared agents also appear when the user is listed in `agents.<name>.credential_managers`, even when they cannot use that agent.
+Users with agent access can select its compatible MCP tools and see shared connection availability without the connected account identity.
+Credential managers and administrators can manage shared connections; users can manage their own requester-scoped connections.
+Credential management alone does not grant MCP tool access.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.
@@ -19058,9 +19060,11 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 ```
 
 The configured personal agent must use `private.per: user` or `private.per: user_agent`.
-Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
+Access follows the agent's existing authorization rules: matching `access.users`, administrator authority, or verified membership in an `access.members_of_rooms` grant room (including default grants from configured agent rooms).
+`access.current_room_members` alone does not grant MCP access because MCP requests have no current Matrix conversation.
+Unknown or revoked grant-room membership cannot authorize a call.
 Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
-Shared agents are eligible when the user is a credential manager or administrator; ordinary reply access is insufficient.
+Shared agents use the same access rules; credential management alone does not grant tool execution.
 Private agents belonging to other users are never eligible.
 Clients can address only agents in the signed-in user's saved selection and cannot choose another user or credential owner.
 
@@ -19072,6 +19076,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 ## Choose exposed agents and tools
 
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
 Under **MCP access**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
@@ -19088,9 +19093,12 @@ The page lists all assigned tools, including those without browser authenticatio
 Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
+Users can inspect shared connection availability without seeing the connected account identity or changing its credentials.
+Only credential managers and administrators can change shared connections; users manage their own requester-scoped connections.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
+Live membership revocation also takes effect at this boundary without a configuration change.
 Upstream service credentials are validated after admission and before using the remote session.
 Calls already admitted may finish after an agent or tool is turned off.
 Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.

--- a/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
@@ -31,9 +31,11 @@ MINDROOM_MCP_GATEWAY_ENABLED=true
 ```
 
 The configured personal agent must use `private.per: user` or `private.per: user_agent`.
-Access requires an explicit matching `access.users` grant or administrator authority; room membership alone is insufficient.
+Access follows the agent's existing authorization rules: matching `access.users`, administrator authority, or verified membership in an `access.members_of_rooms` grant room (including default grants from configured agent rooms).
+`access.current_room_members` alone does not grant MCP access because MCP requests have no current Matrix conversation.
+Unknown or revoked grant-room membership cannot authorize a call.
 Both eager and deferred assigned tools are discoverable when their metadata permits execution without a Matrix room runtime.
-Shared agents are eligible when the user is a credential manager or administrator; ordinary reply access is insufficient.
+Shared agents use the same access rules; credential management alone does not grant tool execution.
 Private agents belonging to other users are never eligible.
 Clients can address only agents in the signed-in user's saved selection and cannot choose another user or credential owner.
 
@@ -45,6 +47,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 ## Choose exposed agents and tools
 
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
+The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
 Under **MCP access**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
@@ -61,9 +64,12 @@ The page lists all assigned tools, including those without browser authenticatio
 Tools sharing a service connection share its OAuth controls, and room-dependent tools are labeled **MindRoom only**.
 The gateway exposes compatible native and upstream MCP tools; it does not start conversations with the agents themselves.
 A shared agent's authored worker and credential scopes still determine whose service connection executes a call.
+Users can inspect shared connection availability without seeing the connected account identity or changing its credentials.
+Only credential managers and administrators can change shared connections; users manage their own requester-scoped connections.
 Your selection changes only your clients, without changing another user's selection or disconnecting services.
 
 Eligibility and selection are checked again when a prepared call is admitted for execution, after hooks and any upstream MCP call queue.
+Live membership revocation also takes effect at this boundary without a configuration change.
 Upstream service credentials are validated after admission and before using the remote session.
 Calls already admitted may finish after an agent or tool is turned off.
 Previously saved agent selections become **All tools** selections on upgrade; empty selections stay empty.

--- a/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
+++ b/skills/mindroom-docs/references/page__deployment__trusted-upstream-auth__index.md
@@ -74,10 +74,10 @@ When no Matrix user ID claim or email-to-Matrix template is configured, strict m
 ## Connections Portal
 
 Set `MINDROOM_CONNECTIONS_AGENT` to the name of a private agent to enable `/connections`.
-The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents for which the authenticated user is a credential manager or administrator.
+The portal lists assigned tools and groups OAuth services by agent: the selected private agent and shared agents the authenticated user can use or manage credentials for.
 Services come from each authorized agent's available tools, including deferred tools and registered plugin or MCP OAuth providers.
 Tools without browser authentication also appear, and room-dependent tools are marked **MindRoom only**.
-Each service card loads independently, so a failed or unconnected service does not block the others.
+Each service status loads independently, so a failed or unconnected service does not block the others.
 The portal does not expose model configuration, generic credential editing, or OAuth client administration.
 
 ```bash
@@ -104,10 +104,12 @@ agents:
         defer: true
 ```
 
-Access to the selected private agent requires an explicit matching `access.users` grant or configured administrator authority.
-Room-membership grants alone do not grant portal access because browser requests have no conversation membership context.
-Shared agents appear when the user is listed in `agents.<name>.credential_managers` or has configured administrator authority, even when they cannot access the selected private agent.
-Reply access alone does not grant shared connection management.
+Agent use requires a matching `access.users` grant, configured administrator authority, or verified membership in a configured grant room.
+Conversation-only `access.current_room_members` grants do not apply because browser and MCP requests have no current Matrix room.
+Shared agents also appear when the user is listed in `agents.<name>.credential_managers`, even when they cannot use that agent.
+Users with agent access can select its compatible MCP tools and see shared connection availability without the connected account identity.
+Credential managers and administrators can manage shared connections; users can manage their own requester-scoped connections.
+Credential management alone does not grant MCP tool access.
 The server resolves canonical Matrix aliases and rechecks agent and provider authorization for every status, connect, and disconnect request.
 The browser selects an authorized agent; it cannot override the credential owner or execution scope.
 Shared connections keep their configured credential scope: `worker_scope: shared` is per agent, while an unset scope uses the installation-wide store.

--- a/src/mindroom/api/config_lifecycle.py
+++ b/src/mindroom/api/config_lifecycle.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, HTTPException, Request
 from pydantic import ValidationError
 
 from mindroom import constants
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
 from mindroom.config.legacy_access import validate_access_migration_source
 from mindroom.config.main import (
     CONFIG_LOAD_USER_ERROR_TYPES,
@@ -37,7 +38,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
     from pathlib import Path
 
-    from mindroom.agent_reply_membership import AgentReplyMembershipIndex
     from mindroom.api.mcp_gateway import GatewayRuntime
     from mindroom.external_triggers.store import TriggerDeliverySnapshot
     from mindroom.knowledge.refresh_scheduler import KnowledgeRefreshScheduler
@@ -123,6 +123,7 @@ class _MindroomAppState:
     thread_export_runner: WorkspaceThreadExportRunner | None = None
     leave_matrix_room: Callable[[str, str], Awaitable[bool]] | None = None
     external_trigger_runtime: ExternalTriggerRuntime | None = None
+    agent_reply_memberships: AgentReplyMembershipIndex = field(default_factory=AgentReplyMembershipIndex)
     response_admission_gate: ResponseAdmissionGate | None = None
     openai_responses: set[ResponseIdentity] = field(default_factory=set)
     script_worker_keepalive: Callable[[WorkerBackend], None] | None = None

--- a/src/mindroom/api/connection_agents.py
+++ b/src/mindroom/api/connection_agents.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from fnmatch import fnmatchcase
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
 
-from mindroom.access_policy import resolve_responder_access
-from mindroom.authorization import is_sender_allowed_for_agent_credential_management
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
+from mindroom.authorization import is_sender_allowed_for_agent_credential_management, is_sender_allowed_for_responder
 from mindroom.matrix.identity import try_parse_historical_matrix_user_id
 from mindroom.mcp_gateway.types import GatewayOwner
 from mindroom.requester_identity import resolve_human_requester_alias
@@ -45,6 +44,14 @@ class ConnectionUserContext:
     runtime_paths: RuntimePaths
     agent_names: tuple[str, ...]
     personal_agent_name: str | None
+    credential_agent_names: tuple[str, ...]
+
+    @property
+    def visible_agent_names(self) -> tuple[str, ...]:
+        """Show agents the user can execute or whose credentials they can manage."""
+        eligible = set(self.agent_names) | set(self.credential_agent_names)
+        personal = (self.personal_agent_name,) if self.personal_agent_name is not None else ()
+        return personal + tuple(name for name in self.config.agents if name in eligible and name not in personal)
 
 
 def resolve_connection_user(
@@ -52,6 +59,7 @@ def resolve_connection_user(
     authenticated_user_id: str,
     *,
     account_id: str | None = None,
+    membership_index: AgentReplyMembershipIndex | None = None,
 ) -> ConnectionUserContext:
     """Resolve current agent eligibility without constructing execution targets."""
     paths = snapshot.runtime_paths
@@ -71,25 +79,30 @@ def resolve_connection_user(
             headers=CONNECTIONS_HEADERS,
         )
     requester_id = resolve_human_requester_alias(authenticated_user_id, config, paths)
-    access = resolve_responder_access(config, agent_name)
-    # API callers have no conversation membership context. Require explicit grants.
-    personal_agent_name = (
-        agent_name
-        if requester_id in config.administrators or any(fnmatchcase(requester_id, pattern) for pattern in access.users)
-        else None
-    )
-    shared = tuple(
+    memberships = membership_index if membership_index is not None else AgentReplyMembershipIndex()
+    candidates = (agent_name, *(name for name, candidate in config.agents.items() if candidate.private is None))
+    usable = tuple(
         name
-        for name, shared_agent in config.agents.items()
-        if shared_agent.private is None
-        and is_sender_allowed_for_agent_credential_management(requester_id, name, config, paths)
+        for name in candidates
+        if is_sender_allowed_for_responder(requester_id, name, None, config, paths, memberships)
+    )
+    personal_agent_name = agent_name if agent_name in usable else None
+    managed = tuple(
+        name
+        for name in candidates
+        if name == personal_agent_name
+        or (
+            config.agents[name].private is None
+            and is_sender_allowed_for_agent_credential_management(requester_id, name, config, paths)
+        )
     )
     return ConnectionUserContext(
         GatewayOwner(authenticated_user_id, requester_id, account_id),
         config,
         paths,
-        ((personal_agent_name,) if personal_agent_name is not None else ()) + shared,
+        usable,
         personal_agent_name,
+        managed,
     )
 
 

--- a/src/mindroom/api/connections.py
+++ b/src/mindroom/api/connections.py
@@ -11,13 +11,15 @@ from pydantic import BaseModel, ConfigDict
 
 from mindroom.api import config_lifecycle, oauth
 from mindroom.api.auth import require_connections_user
-from mindroom.api.connection_agents import CONNECTIONS_HEADERS, resolve_connection_user
+from mindroom.api.connection_agents import CONNECTIONS_HEADERS, resolve_connection_agent, resolve_connection_user
+from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.oauth.credential_lifecycle import resolve_oauth_credential_context
 from mindroom.oauth.registry import load_oauth_providers_for_snapshot
 from mindroom.oauth.service import oauth_provider_service_account_configured
 from mindroom.tool_system.catalog import resolved_tool_metadata_for_runtime
 
 if TYPE_CHECKING:
-    from mindroom.config.main import Config
+    from mindroom.api.connection_agents import ConnectionUserContext
     from mindroom.constants import RuntimePaths
     from mindroom.oauth import OAuthProvider
     from mindroom.tool_system.catalog import ToolMetadata
@@ -30,6 +32,7 @@ class ConnectionService(BaseModel):
 
     provider: str
     is_shared: bool
+    can_manage: bool
     display_name: str
     description: str
     icon: str | None
@@ -53,12 +56,13 @@ class AgentConnections(BaseModel):
     agent_name: str
     agent_display_name: str
     is_shared: bool
+    can_use: bool
     services: list[ConnectionService]
     tools: list[ConnectionTool]
 
 
 class ConnectionsCatalog(BaseModel):
-    """Agents whose connections the authenticated user may manage."""
+    """Agents the authenticated user may use or manage connections for."""
 
     agents: list[AgentConnections]
 
@@ -80,6 +84,7 @@ class _EmptyMutation(BaseModel):
 @dataclass(frozen=True)
 class _Connections:
     runtime_paths: RuntimePaths
+    user: ConnectionUserContext
     catalog: ConnectionsCatalog
     providers: dict[str, OAuthProvider]
 
@@ -95,15 +100,20 @@ async def _connections(request: Request, response: Response) -> _Connections:
     if request.query_params:
         raise HTTPException(400, "Connection target overrides are not accepted", headers=CONNECTIONS_HEADERS)
     requester_id = cast("str", auth_user["matrix_user_id"])
-    user = resolve_connection_user(snapshot, requester_id)
+    user = resolve_connection_user(
+        snapshot,
+        requester_id,
+        membership_index=config_lifecycle.app_state(request.app).agent_reply_memberships,
+    )
     config = user.config
-    if not user.agent_names:
+    if not user.visible_agent_names:
         raise HTTPException(403, "No connections are available for this account", headers=CONNECTIONS_HEADERS)
     providers = load_oauth_providers_for_snapshot(snapshot)
     metadata = resolved_tool_metadata_for_runtime(snapshot.runtime_paths, config, tolerate_plugin_load_errors=True)
-    agents = [_agent_connections(name, config, providers, metadata) for name in user.agent_names]
+    agents = [_agent_connections(name, user, providers, metadata) for name in user.visible_agent_names]
     return _Connections(
         runtime_paths=snapshot.runtime_paths,
+        user=user,
         catalog=ConnectionsCatalog(agents=agents),
         providers=providers,
     )
@@ -111,13 +121,14 @@ async def _connections(request: Request, response: Response) -> _Connections:
 
 def _agent_connections(
     agent_name: str,
-    config: Config,
+    user: ConnectionUserContext,
     providers: dict[str, OAuthProvider],
     metadata: dict[str, ToolMetadata],
 ) -> AgentConnections:
     """List assigned toolkits and group their browser connections by provider."""
     services: dict[str, ConnectionService] = {}
     tools: list[ConnectionTool] = []
+    config = user.config
     entity = config.resolve_entity(agent_name)
     for tool_name in entity.available_tools:
         tool = metadata.get(tool_name)
@@ -136,11 +147,13 @@ def _agent_connections(
         )
         if provider is None:
             continue
+        shared = not provider.requester_scoped_credentials and entity.execution_scope in {None, "shared"}
         service = services.setdefault(
             provider.id,
             ConnectionService(
                 provider=provider.id,
-                is_shared=not provider.requester_scoped_credentials and entity.execution_scope in {None, "shared"},
+                is_shared=shared,
+                can_manage=agent_name in user.credential_agent_names or not shared,
                 display_name=provider.display_name,
                 description=tool.description,
                 icon=tool.icon,
@@ -154,6 +167,7 @@ def _agent_connections(
         agent_name=agent_name,
         agent_display_name=agent.display_name,
         is_shared=agent.private is None,
+        can_use=agent_name in user.agent_names,
         services=list(services.values()),
         tools=tools,
     )
@@ -162,11 +176,20 @@ def _agent_connections(
 _ConnectionsContext = Annotated[_Connections, Depends(_connections)]
 
 
-def _require_provider(context: _Connections, agent_name: str, provider_id: str) -> OAuthProvider:
+def _service(context: _Connections, agent_name: str, provider_id: str) -> ConnectionService:
+    """Resolve the displayed service permissions before account operations."""
     for agent in context.catalog.agents:
-        if agent.agent_name == agent_name and any(service.provider == provider_id for service in agent.services):
-            return context.providers[provider_id]
+        if agent.agent_name == agent_name:
+            for service in agent.services:
+                if service.provider == provider_id:
+                    return service
     raise HTTPException(404, "Connection is not available", headers=CONNECTIONS_HEADERS)
+
+
+def _require_management(context: _Connections, agent_name: str, provider_id: str) -> OAuthProvider:
+    if not _service(context, agent_name, provider_id).can_manage:
+        raise HTTPException(403, "Credential management is required", headers=CONNECTIONS_HEADERS)
+    return context.providers[provider_id]
 
 
 def _require_same_origin(request: Request, context: _Connections) -> None:
@@ -192,9 +215,22 @@ async def catalog(context: _ConnectionsContext) -> ConnectionsCatalog:
 @router.get("/agents/{agent_name}/{provider_id}/status")
 async def status(agent_name: str, provider_id: str, request: Request, context: _ConnectionsContext) -> ConnectionStatus:
     """Load status for one authorized agent and provider."""
-    _require_provider(context, agent_name, provider_id)
+    service = _service(context, agent_name, provider_id)
+    provider = context.providers[provider_id]
     try:
-        result = await oauth.status(provider_id, request, agent_name=agent_name)
+        if service.can_manage:
+            result = await oauth.status(provider_id, request, agent_name=agent_name)
+        else:
+            agent = resolve_connection_agent(context.user, agent_name)
+            credential_context = resolve_oauth_credential_context(
+                provider,
+                context.runtime_paths,
+                get_runtime_credentials_manager(context.runtime_paths),
+                agent.worker_target,
+                execution_identity=agent.execution_identity,
+                config=agent.config,
+            )
+            result = await oauth.connection_status(request, credential_context)
     except HTTPException as exc:
         raise HTTPException(
             exc.status_code,
@@ -205,10 +241,10 @@ async def status(agent_name: str, provider_id: str, request: Request, context: _
     personal = not result.has_service_account_config
     return ConnectionStatus(
         provider=provider_id,
-        connected=result.connected and personal,
-        can_connect=result.has_client_config and personal,
+        connected=result.connected and (personal or not service.can_manage),
+        can_connect=result.has_client_config and personal and service.can_manage,
         reset_required=result.reset_required,
-        account_label=result.email if personal else None,
+        account_label=result.email if personal and service.can_manage else None,
     )
 
 
@@ -222,7 +258,7 @@ async def connect(
 ) -> oauth.OAuthConnectResponse:
     """Start existing OAuth state handling with an authorized agent target."""
     _require_same_origin(request, context)
-    provider = _require_provider(context, agent_name, provider_id)
+    provider = _require_management(context, agent_name, provider_id)
     if oauth_provider_service_account_configured(provider, context.runtime_paths):
         raise HTTPException(
             409,
@@ -249,7 +285,7 @@ async def disconnect(
 ) -> dict[str, str]:
     """Reset the authorized agent's scoped provider credentials."""
     _require_same_origin(request, context)
-    _require_provider(context, agent_name, provider_id)
+    _require_management(context, agent_name, provider_id)
     try:
         return await oauth.disconnect(provider_id, request, agent_name=agent_name)
     except HTTPException as exc:

--- a/src/mindroom/api/credentials_target.py
+++ b/src/mindroom/api/credentials_target.py
@@ -146,27 +146,30 @@ def resolve_request_credentials_target(
             allowed_shared_services=None,
         )
     execution_scope = scope_request.requested_execution_scope
-    allow_private_agent_requester = (
+    allow_requester_scope = (
         allow_private_scopes
         and scope_request.persisted_policy is not None
-        and scope_request.persisted_policy.is_private
         and execution_scope in {"user", "user_agent"}
         and not any(
             credential_service_policy(service, execution_scope).uses_primary_runtime_global_credentials
             for service in service_names
         )
     )
-    authorize = (
-        require_agent_oauth_connection_authorized
-        if allow_private_agent_requester
-        else require_agent_credential_management_authorized
-    )
-    execution_identity = authorize(
-        request,
-        config=config,
-        runtime_paths=runtime_paths,
-        agent_name=scope_request.agent_name,
-    )
+    if allow_requester_scope:
+        execution_identity = require_agent_oauth_connection_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
+            agent_name=scope_request.agent_name,
+            requester_owned=True,
+        )
+    else:
+        execution_identity = require_agent_credential_management_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
+            agent_name=scope_request.agent_name,
+        )
     if execution_scope is None:
         return RequestCredentialsTarget(
             runtime_paths=runtime_paths,
@@ -233,18 +236,28 @@ def resolve_requester_credentials_target(
     """Resolve credentials that must follow the authenticated requester, independent of worker reuse."""
     base_target = resolve_request_credentials_target(
         request,
-        agent_name=agent_name,
+        agent_name=None,
         service_names=service_names,
         execution_scope_override_provided=False,
         execution_scope_override=None,
         allow_private_scopes=True,
     )
-    execution_identity = build_dashboard_execution_identity(
-        request,
-        agent_name or "oauth",
-        config=config_lifecycle.bind_current_request_snapshot(request).runtime_config,
-        runtime_paths=base_target.runtime_paths,
-    )
+    if agent_name is not None:
+        config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
+        execution_identity = require_agent_oauth_connection_authorized(
+            request,
+            agent_name=agent_name,
+            config=config,
+            runtime_paths=runtime_paths,
+            requester_owned=True,
+        )
+    else:
+        execution_identity = build_dashboard_execution_identity(
+            request,
+            "oauth",
+            config=config_lifecycle.bind_current_request_snapshot(request).runtime_config,
+            runtime_paths=base_target.runtime_paths,
+        )
     reject_unbound_private_dashboard_requester("user", execution_identity)
     worker_key = require_worker_key_for_scope(
         "user",

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import HTTPException, Request
 
 from mindroom.agent_policy import ResolvedAgentPolicy, resolve_agent_policy_from_data
+from mindroom.api import config_lifecycle
 from mindroom.authorization import (
     is_platform_administrator,
     is_sender_allowed_for_agent_credential_management,
     is_sender_allowed_for_agent_oauth_connection_management,
+    is_sender_allowed_for_responder,
 )
 from mindroom.matrix.identity import try_parse_historical_matrix_user_id
 from mindroom.requester_identity import resolve_human_requester_alias
@@ -255,6 +257,7 @@ def require_agent_oauth_connection_authorized(
     config: Config,
     runtime_paths: RuntimePaths,
     agent_name: str,
+    requester_owned: bool = False,
 ) -> ToolExecutionIdentity:
     """Require requester-private or managed-agent authority for OAuth connections."""
     execution_identity = build_dashboard_execution_identity(
@@ -264,11 +267,26 @@ def require_agent_oauth_connection_authorized(
         runtime_paths=runtime_paths,
     )
     requester_id = execution_identity.requester_id
-    if requester_id is None or not is_sender_allowed_for_agent_oauth_connection_management(
-        requester_id,
-        agent_name=agent_name,
-        config=config,
-        runtime_paths=runtime_paths,
+    if requester_id is None or not (
+        is_sender_allowed_for_agent_oauth_connection_management(
+            requester_id,
+            agent_name=agent_name,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+        or (
+            requester_owned
+            and try_parse_historical_matrix_user_id(requester_id) is not None
+            and agent_name in config.agents
+            and is_sender_allowed_for_responder(
+                requester_id,
+                agent_name,
+                None,
+                config,
+                runtime_paths,
+                config_lifecycle.app_state(request.app).agent_reply_memberships,
+            )
+        )
     ):
         raise HTTPException(
             status_code=403,

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from mindroom import constants, file_watcher
 from mindroom.agent_policy import build_agent_policy_seeds, resolve_agent_policy_index
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
 from mindroom.api import config_lifecycle
 from mindroom.api.auth import ApiAuthState, verify_user  # noqa: F401
 from mindroom.api.auth import router as auth_router
@@ -64,7 +65,6 @@ if TYPE_CHECKING:
 
     from starlette.types import ASGIApp, Receive, Scope, Send
 
-    from mindroom.agent_reply_membership import AgentReplyMembershipIndex
     from mindroom.config.main import Config
     from mindroom.external_triggers.store import TriggerDeliverySnapshot
     from mindroom.response_admission import ResponseAdmissionGate
@@ -297,6 +297,7 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
         app_state.thread_export_runner = None
         app_state.leave_matrix_room = None
         app_state.external_trigger_runtime = None
+        app_state.agent_reply_memberships = AgentReplyMembershipIndex()
         app_state.script_worker_keepalive = None
         bind_script_tool_broker(api_app, None)
         app_state.api_state = ApiState(
@@ -329,6 +330,7 @@ def initialize_api_app(api_app: FastAPI, runtime_paths: constants.RuntimePaths) 
             app_state.thread_export_runner = None
             app_state.leave_matrix_room = None
             app_state.external_trigger_runtime = None
+            app_state.agent_reply_memberships = AgentReplyMembershipIndex()
             app_state.script_worker_keepalive = None
             bind_script_tool_broker(api_app, None)
         previous_state.snapshot = config_lifecycle._published_snapshot(

--- a/src/mindroom/api/mcp_gateway.py
+++ b/src/mindroom/api/mcp_gateway.py
@@ -206,7 +206,12 @@ class GatewayRuntime:
         snapshot = rebind_current_request_snapshot(request)
         _runtime(request, paths=snapshot.runtime_paths)
         try:
-            context = resolve_connection_user(snapshot, identity.matrix_user_id, account_id=account_id)
+            context = resolve_connection_user(
+                snapshot,
+                identity.matrix_user_id,
+                account_id=account_id,
+                membership_index=app_state(request.app).agent_reply_memberships,
+            )
         except HTTPException as exc:
             raise HTTPException(401, "External principal is no longer authorized", headers=headers) from exc
 
@@ -247,6 +252,7 @@ class GatewayRuntime:
                 snapshot,
                 token.authenticated_user_id,
                 account_id=token.account_id,
+                membership_index=app_state(request.app).agent_reply_memberships,
             )
         except HTTPException as exc:
             raise HTTPException(401, "Gateway grant is no longer authorized", headers=headers) from exc
@@ -303,6 +309,14 @@ class GatewayRuntime:
                     raise GatewayError(GatewayErrorCode.TOOL_UNAVAILABLE)
                 require_authority()
                 if agent_name is not None:
+                    current_user = resolve_connection_user(
+                        current,
+                        user.owner.authenticated_user_id,
+                        account_id=user.owner.account_id,
+                        membership_index=app_state(request.app).agent_reply_memberships,
+                    )
+                    if agent_name not in current_user.agent_names:
+                        raise GatewayError(GatewayErrorCode.UNAUTHORIZED)
                     self.selections.require_selected(user.owner, agent_name, toolkit)
 
         return require_current_access
@@ -547,6 +561,7 @@ async def _consent(request: Request) -> Response:
         rebind_current_request_snapshot(request),
         owner.authenticated_user_id,
         account_id=owner.account_id,
+        membership_index=app_state(request.app).agent_reply_memberships,
     )
     if not context.agent_names:
         raise HTTPException(403, "Agent access is required", headers=CONNECTIONS_HEADERS)

--- a/src/mindroom/api/mcp_selection.py
+++ b/src/mindroom/api/mcp_selection.py
@@ -10,7 +10,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from mindroom.api.auth import require_connections_user
-from mindroom.api.config_lifecycle import rebind_current_request_snapshot
+from mindroom.api.config_lifecycle import app_state, rebind_current_request_snapshot
 from mindroom.api.connection_agents import CONNECTIONS_HEADERS, resolve_connection_user
 from mindroom.api.mcp_identity import resolve_gateway_browser_owner
 from mindroom.mcp_gateway.selection import SelectionAccessDeniedError
@@ -113,6 +113,7 @@ async def _handle_selection(
         rebind_current_request_snapshot(request),
         owner.authenticated_user_id,
         account_id=owner.account_id,
+        membership_index=app_state(request.app).agent_reply_memberships,
     )
     runtime_for_request(request)
     defaults = (context.personal_agent_name,) if context.personal_agent_name is not None else ()

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -906,6 +906,12 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
         agent_name=agent_name,
     )
     context = _credential_context(provider, runtime_paths, target)
+    return await connection_status(request, context)
+
+
+async def connection_status(request: Request, context: OAuthCredentialContext) -> OAuthStatusResponse:
+    """Load connection state after the caller has authorized the credential target."""
+    provider, runtime_paths = context.provider, context.runtime_paths
     credential_status: OAuthCredentialsStatus = await load_oauth_credentials_status(context)
     credentials = credential_status.credentials or {}
     has_service_account_config = oauth_provider_service_account_configured(provider, runtime_paths)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2634,6 +2634,7 @@ async def _run_api_server(
     thread_export_runner: WorkspaceThreadExportRunner | None = None,
     leave_matrix_room: Callable[[str, str], Awaitable[bool]] | None = None,
     response_admission_gate: ResponseAdmissionGate | None = None,
+    agent_reply_memberships: AgentReplyMembershipIndex | None = None,
 ) -> None:
     """Run the bundled dashboard/API server as an asyncio task."""
     from mindroom.api import main as api_main  # noqa: PLC0415
@@ -2644,6 +2645,8 @@ async def _run_api_server(
     api_state.thread_export_runner = thread_export_runner
     api_state.leave_matrix_room = leave_matrix_room
     api_state.response_admission_gate = response_admission_gate
+    if agent_reply_memberships is not None:
+        api_state.agent_reply_memberships = agent_reply_memberships
     if script_runtime is not None:
         api_main.bind_script_runtime(
             api_main.app,
@@ -2676,6 +2679,7 @@ async def _run_api_server(
         api_state.thread_export_runner = None
         api_state.leave_matrix_room = None
         api_state.response_admission_gate = None
+        api_state.agent_reply_memberships = AgentReplyMembershipIndex()
         if script_runtime is not None:
             await script_runtime.unbind_api()
             api_main.unbind_script_runtime(api_main.app)
@@ -3036,6 +3040,7 @@ async def main(
                     thread_export_runner=orchestrator._thread_export_runner,
                     leave_matrix_room=orchestrator.leave_matrix_room,
                     response_admission_gate=orchestrator._response_admission_gate,
+                    agent_reply_memberships=orchestrator.agent_reply_memberships,
                 ),
                 name="api_server",
             )

--- a/tach.toml
+++ b/tach.toml
@@ -850,6 +850,7 @@ depends_on = [
     "mindroom.tool_system.worker_routing",
 ]
 visibility = [
+    "mindroom.api.connections",
     "mindroom.api.oauth",
     "mindroom.api.tools",
     "mindroom.custom_tools.config_manager",
@@ -1120,6 +1121,7 @@ depends_on = [
     "mindroom.api.connection_agents",
     "mindroom.constants",
     "mindroom.oauth",
+    "mindroom.oauth.credential_lifecycle",
     "mindroom.oauth.service",
     "mindroom.tool_system.catalog",
 ]
@@ -1258,6 +1260,7 @@ depends_on = [
 path = "mindroom.api.dashboard_credential_scope"
 depends_on = [
     "mindroom.agent_policy",
+    "mindroom.api.config_lifecycle",
     "mindroom.authorization",
     "mindroom.matrix.identity",
     "mindroom.tool_system.worker_routing",

--- a/tests/api/test_connection_agents.py
+++ b/tests/api/test_connection_agents.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def personal_snapshot(tmp_path: Path) -> ApiSnapshot:
+def personal_snapshot(tmp_path: Path, enforce_turn_authorization: None) -> ApiSnapshot:  # noqa: ARG001
     """Build two explicit personal users without a live chat or owner fallback."""
     paths = constants.resolve_primary_runtime_paths(
         config_path=tmp_path / "config.yaml",
@@ -46,7 +46,7 @@ def personal_snapshot(tmp_path: Path) -> ApiSnapshot:
 
 @pytest.mark.parametrize("scope", [None, "shared", "user", "user_agent"])
 def test_shared_tool_target_uses_authored_scope(personal_snapshot: ApiSnapshot, scope: str | None) -> None:
-    """Credential managers may use a shared target without access to the personal agent."""
+    """Agent users receive the authored shared target without needing personal-agent access."""
     config = personal_snapshot.runtime_config
     assert config is not None
     config.agents["shared"] = AgentConfig.model_validate(
@@ -55,7 +55,7 @@ def test_shared_tool_target_uses_authored_scope(personal_snapshot: ApiSnapshot, 
             "role": "Shared tools",
             "tools": ["calculator"],
             "worker_scope": scope,
-            "credential_managers": ["@manager:example.org"],
+            "access": {"users": ["@manager:example.org"]},
         },
     )
     user = connection_agents.resolve_connection_user(personal_snapshot, "@manager:example.org")
@@ -79,6 +79,30 @@ def test_connection_user_has_no_implicit_agent_authority(personal_snapshot: ApiS
     assert user.personal_agent_name is None
     with pytest.raises(HTTPException) as denied:
         connection_agents.resolve_connection_agent(user, "personal")
+    assert denied.value.status_code == 404
+
+
+def test_shared_access_and_credential_management_are_independent(personal_snapshot: ApiSnapshot) -> None:
+    """Agent users can execute tools; credential managers without agent access cannot."""
+    config = personal_snapshot.runtime_config
+    assert config is not None
+    config.agents["shared"] = AgentConfig.model_validate(
+        {
+            "display_name": "Shared tools",
+            "role": "Shared tools",
+            "tools": ["calculator"],
+            "access": {"users": ["@alice:example.org"]},
+            "credential_managers": ["@manager:example.org"],
+        },
+    )
+    alice = connection_agents.resolve_connection_user(personal_snapshot, "@alice:example.org")
+    assert alice.agent_names == ("personal", "shared")
+    assert connection_agents.resolve_connection_agent(alice, "shared").requester_id == "@alice:example.org"
+    manager = connection_agents.resolve_connection_user(personal_snapshot, "@manager:example.org")
+    assert manager.agent_names == ()
+    assert manager.visible_agent_names == ("shared",)
+    with pytest.raises(HTTPException) as denied:
+        connection_agents.resolve_connection_agent(manager, "shared")
     assert denied.value.status_code == 404
 
 

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def portal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+def portal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, enforce_turn_authorization: None) -> dict[str, Any]:  # noqa: ARG001
     """Serve the real API with signed users and one private agent."""
     key = _trusted_upstream_jwt_key()
     monkeypatch.setattr(jwt.PyJWKClient, "fetch_data", lambda _client: _trusted_upstream_jwks(key))
@@ -397,6 +397,101 @@ def test_catalog_lists_only_authorized_agents(shared_portal: dict[str, Any], use
     agents = response.json()["agents"]
     assert [agent["agent_name"] for agent in agents] == expected
     assert all(agent["is_shared"] == (agent["agent_name"] != "personal") for agent in agents)
+
+
+def test_agent_user_sees_shared_connection_without_management(shared_portal: dict[str, Any]) -> None:
+    """Using a shared agent reveals availability without shared-account mutation authority."""
+    shared_portal["payload"]["agents"]["research"]["access"] = {"users": ["@bob:example.org"]}
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    client, headers = shared_portal["client"], shared_portal["headers"]
+    response = client.get("/api/connections", headers=headers["bob"])
+    research = next(agent for agent in response.json()["agents"] if agent["agent_name"] == "research")
+    assert research["can_use"] is True
+    assert research["services"][0]["can_manage"] is False
+    base = "/api/connections/agents/research/google_drive"
+    connect = client.post(f"{base}/connect", headers=headers["alice"], json={})
+    state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
+    assert (
+        client.get(
+            "/api/oauth/google_drive/callback",
+            params={"code": "test-code", "state": state},
+            headers=headers["alice"],
+            follow_redirects=False,
+        ).status_code
+        == 307
+    )
+    status = client.get(f"{base}/status", headers=headers["bob"])
+    assert status.status_code == 200, status.text
+    assert status.json()["connected"] is True
+    assert status.json()["account_label"] is None
+    assert status.json()["can_connect"] is False
+    for action in ("connect", "disconnect"):
+        assert client.post(f"{base}/{action}", headers=headers["bob"], json={}).status_code == 403
+        assert (
+            client.post(f"/api/oauth/google_drive/{action}?agent_name=research", headers=headers["bob"]).status_code
+            == 403
+        )
+    assert client.get(f"{base}/status", headers=headers["alice"]).json()["connected"] is True
+
+
+@pytest.mark.parametrize("requester_provider", [False, True])
+def test_agent_user_can_manage_only_their_personal_connection(
+    shared_portal: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    requester_provider: bool,
+) -> None:
+    """A shared agent's user credentials remain owned by each authorized requester."""
+    agent = shared_portal["payload"]["agents"]["research"]
+    agent["access"] = {"users": ["@alice:example.org", "@bob:example.org"]}
+    agent["worker_scope"] = "shared" if requester_provider else "user_agent"
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        requester_scoped_credentials=requester_provider,
+    )
+    monkeypatch.setattr(oauth_registry, "_builtin_oauth_providers", lambda: (provider,))
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    client, headers = shared_portal["client"], shared_portal["headers"]
+    base = "/api/connections/agents/research/google_drive"
+    response = client.get("/api/connections", headers=headers["bob"])
+    research = next(agent for agent in response.json()["agents"] if agent["agent_name"] == "research")
+    assert research["services"][0]["can_manage"] is True
+    connect = client.post(f"{base}/connect", headers=headers["bob"], json={})
+    assert connect.status_code == 200, connect.text
+    state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
+    assert (
+        client.get(
+            "/api/oauth/google_drive/callback",
+            params={"code": "test-code", "state": state},
+            headers=headers["bob"],
+            follow_redirects=False,
+        ).status_code
+        == 307
+    )
+    assert client.get(f"{base}/status", headers=headers["bob"]).json()["connected"] is True
+    assert client.get(f"{base}/status", headers=headers["alice"]).json()["connected"] is False
+    assert client.post(f"{base}/disconnect", headers=headers["alice"], json={}).status_code == 200
+    assert client.get(f"{base}/status", headers=headers["bob"]).json()["connected"] is True
+    assert client.post(f"{base}/disconnect", headers=headers["bob"], json={}).status_code == 200
+
+    connect = client.post(f"{base}/connect", headers=headers["bob"], json={})
+    state = parse_qs(urlparse(connect.json()["auth_url"]).query)["state"][0]
+    agent["access"]["users"] = ["@alice:example.org"]
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    callback = client.get(
+        "/api/oauth/google_drive/callback",
+        params={"code": "test-code", "state": state},
+        headers=headers["bob"],
+        follow_redirects=False,
+    )
+    assert callback.status_code == 403
+    agent["access"]["users"].append("@bob:example.org")
+    _publish_config(main.app, shared_portal["paths"], shared_portal["payload"])
+    _use_runtime_auth_settings(main.app)
+    assert client.get(f"{base}/status", headers=headers["bob"]).json()["connected"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -1735,6 +1735,7 @@ class TestCredentialsAPI:
         assert token_response.status_code == 403
         assert copy_response.status_code == 403
 
+    @pytest.mark.usefixtures("enforce_turn_authorization")
     def test_unregistered_agent_oauth_token_service_authorizes_before_generic_rejection(
         self,
         client: TestClient,

--- a/tests/api/test_mcp_external_auth.py
+++ b/tests/api/test_mcp_external_auth.py
@@ -22,6 +22,7 @@ from fastapi.testclient import TestClient
 
 from mindroom import agents
 from mindroom.api import config_lifecycle
+from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig
 from mindroom.mcp_gateway import accounts, external_auth
 from mindroom.tool_system.worker_routing import get_tool_execution_identity
@@ -74,7 +75,7 @@ def test_external_clients_share_dashboard_agent_selection(
         display_name="Research",
         role="Shared tools",
         tools=["calculator"],
-        credential_managers=["@alice:example.org"],
+        access=ResponderAccessConfig(users=["@alice:example.org"]),
     )
     selection = "/api/connections/mcp/selection"
     assert external_client.get(selection, headers=headers).json()["agents"] == {"personal": None}
@@ -97,6 +98,30 @@ def test_external_clients_share_dashboard_agent_selection(
         assert response.status_code == 200, response.text
         results = response.json()["result"]["structuredContent"]["results"]
         assert {(item["agent"], item["toolkit"]) for item in results} == {("shared", "calculator")}
+
+    # Retaining credential management cannot preserve execution after access is revoked.
+    config.agents["shared"].access.users = []
+    config.agents["shared"].credential_managers = ["@alice:example.org"]
+    response = external_client.post(
+        "/mcp",
+        headers={**MCP_HEADERS, **credential()},
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "invoke_tool",
+                "arguments": {
+                    "agent": "shared",
+                    "toolkit": "calculator",
+                    "function": "add",
+                    "arguments": {"a": 1, "b": 2},
+                },
+            },
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["result"]["isError"] is True
 
 
 @pytest.fixture(params=PROFILES, ids=["bearer", "signed-assertion"])

--- a/tests/api/test_mcp_gateway_api.py
+++ b/tests/api/test_mcp_gateway_api.py
@@ -76,7 +76,7 @@ def signed_headers(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], dict[str,
 
 
 @pytest.fixture
-def gateway_app(tmp_path: Path) -> FastAPI:
+def gateway_app(tmp_path: Path, enforce_turn_authorization: None) -> FastAPI:  # noqa: ARG001
     """Build the production gateway routes without starting Matrix or an LLM."""
     env = {
         "MINDROOM_PUBLIC_URL": ORIGIN,

--- a/tests/api/test_mcp_selection.py
+++ b/tests/api/test_mcp_selection.py
@@ -5,15 +5,20 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
+import nio
 import pytest
 
 from mindroom import agents
 from mindroom.api import config_lifecycle, mcp_selection
+from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig
+from tests.access_schema_support import membership_index
 from tests.api.test_mcp_clients import _connect
 from tests.api.test_mcp_gateway_api import (
     MCP_HEADERS,
@@ -23,6 +28,7 @@ from tests.api.test_mcp_gateway_api import (
     gateway_client,  # noqa: F401
     signed_headers,  # noqa: F401
 )
+from tests.conftest import bind_runtime_paths
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -30,6 +36,125 @@ if TYPE_CHECKING:
     from fastapi.testclient import TestClient
 
 SELECTION = "/api/connections/mcp/selection"
+
+
+@pytest.mark.parametrize("current_room_only", [False, True])
+def test_room_membership_grants_require_room_independent_access(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+    current_room_only: bool,
+) -> None:
+    """Named room grants allow MCP tools; conversation-only grants do not escape the room."""
+    snapshot = config_lifecycle.require_api_state(gateway_client.app).snapshot
+    config = bind_runtime_paths(snapshot.runtime_config, snapshot.runtime_paths)
+    snapshot.runtime_config = config
+    config.agents["shared"] = AgentConfig(
+        display_name="Shared",
+        role="Shared tools",
+        tools=["calculator"],
+        rooms=["project"],
+        access=ResponderAccessConfig(
+            current_room_members=current_room_only,
+            members_of_rooms=[] if current_room_only else ["project"],
+        ),
+    )
+    memberships = asyncio.run(membership_index(config, {"project": {"@alice:example.org"}}))
+    config_lifecycle.app_state(gateway_client.app).agent_reply_memberships = memberships
+    alice = signed_headers("alice")
+    token = _connect(gateway_client, alice)["access_token"]
+    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {"shared": None}})
+    if current_room_only:
+        assert response.status_code == 404
+        return
+    assert response.status_code == 200, response.text
+    result = _call(
+        gateway_client,
+        token,
+        "invoke_tool",
+        {
+            "agent": "shared",
+            "toolkit": "calculator",
+            "function": "add",
+            "arguments": {"a": 1, "b": 2},
+        },
+    )
+    assert not result["isError"]
+    assert json.loads(result["structuredContent"]["result"])["result"] == 3
+    memberships.mark_room_unready(config, snapshot.runtime_paths, "!project:example.com", reason="membership_unknown")
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    assert _call(gateway_client, token, "search_tools", {})["structuredContent"] == {"results": []}
+    assert _call(
+        gateway_client,
+        token,
+        "get_tool",
+        {
+            "agent": "shared",
+            "toolkit": "calculator",
+            "function": "add",
+        },
+    )["isError"]
+
+
+@pytest.mark.parametrize("async_body", [False, True], ids=["sync", "async"])
+def test_membership_revocation_during_preparation_stops_tool_body(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    async_body: bool,
+) -> None:
+    """A live room departure revokes a prepared call without a config or selection change."""
+    snapshot = config_lifecycle.require_api_state(gateway_client.app).snapshot
+    config = bind_runtime_paths(snapshot.runtime_config, snapshot.runtime_paths)
+    snapshot.runtime_config = config
+    config.agents["personal"].access = ResponderAccessConfig(members_of_rooms=["project"])
+    memberships = asyncio.run(membership_index(config, {"project": {"@alice:example.org"}}))
+    config_lifecycle.app_state(gateway_client.app).agent_reply_memberships = memberships
+    token = _connect(gateway_client, signed_headers("alice"))["access_token"]
+    paused, release = threading.Event(), threading.Event()
+    events: list[str] = []
+    monkeypatch.setattr(
+        agents,
+        "build_agent_toolkit",
+        _native_dispatch_builder("hook", async_body, paused, release, events),
+    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        pending = executor.submit(
+            _call,
+            gateway_client,
+            token,
+            "invoke_tool",
+            {
+                "agent": "personal",
+                "toolkit": "calculator",
+                "function": "async_account" if async_body else "account",
+                "arguments": {},
+            },
+        )
+        try:
+            assert paused.wait(10), "Tool hook never paused"
+            event = nio.RoomMemberEvent.from_dict(
+                {
+                    "type": "m.room.member",
+                    "state_key": "@alice:example.org",
+                    "sender": "@alice:example.org",
+                    "event_id": "$departure",
+                    "origin_server_ts": 1,
+                    "content": {"membership": "leave"},
+                },
+            )
+            assert isinstance(event, nio.RoomMemberEvent)
+            memberships.apply_member_event(
+                config,
+                snapshot.runtime_paths,
+                "!project:example.com",
+                event,
+                control_user_id="@router:example.org",
+            )
+        finally:
+            release.set()
+        assert pending.result(timeout=10)["isError"]
+    assert "body" not in events
+    assert "close" in events
 
 
 @pytest.mark.parametrize("all_tools", [False, True], ids=["custom", "all-tools"])
@@ -45,7 +170,7 @@ def test_removed_tools_cannot_block_access_withdrawal(
         display_name="Shared",
         role="Shared tools",
         tools=["calculator"],
-        credential_managers=["@alice:example.org"],
+        access=ResponderAccessConfig(users=["@alice:example.org"]),
     )
     headers = {**signed_headers("alice"), "Origin": ORIGIN}
     browser_tools = ["calculator", "duckduckgo"]
@@ -133,13 +258,34 @@ def test_selection_defaults_and_empty_are_user_scoped(
     assert gateway_client.get(SELECTION, headers=signed_headers("bob")).json()["agents"] == {"personal": None}
 
 
-def test_shared_only_manager_can_select_assigned_shared_agent(
+def test_shared_only_user_can_select_assigned_shared_agent(
     gateway_client: TestClient,
     signed_headers: Callable[[str], dict[str, str]],
 ) -> None:
-    """Shared selection needs credential management, independently of personal-agent access."""
+    """Shared selection follows agent access independently of personal-agent access."""
     config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
     config.agents["personal"].access.users = ["@bob:example.org"]
+    config.agents["shared"] = AgentConfig(
+        display_name="Shared",
+        role="Shared tools",
+        tools=["calculator"],
+        access=ResponderAccessConfig(users=["@alice:example.org"]),
+    )
+    alice = signed_headers("alice")
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {"shared": None}})
+    assert response.status_code == 200, response.text
+    assert response.json()["agents"] == {"shared": None}
+    config.agents["shared"].access.users = []
+    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+
+
+def test_credential_manager_without_agent_access_cannot_select_tools(
+    gateway_client: TestClient,
+    signed_headers: Callable[[str], dict[str, str]],
+) -> None:
+    """Account management alone cannot authorize a direct MCP call."""
+    config = config_lifecycle.require_api_state(gateway_client.app).snapshot.runtime_config
     config.agents["shared"] = AgentConfig(
         display_name="Shared",
         role="Shared tools",
@@ -147,12 +293,20 @@ def test_shared_only_manager_can_select_assigned_shared_agent(
         credential_managers=["@alice:example.org"],
     )
     alice = signed_headers("alice")
-    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    token = _connect(gateway_client, alice)["access_token"]
     response = gateway_client.post(SELECTION, headers={**alice, "Origin": ORIGIN}, json={"agents": {"shared": None}})
-    assert response.status_code == 200, response.text
-    assert response.json()["agents"] == {"shared": None}
-    config.agents["shared"].credential_managers = []
-    assert gateway_client.get(SELECTION, headers=alice).json()["agents"] == {}
+    assert response.status_code == 404
+    assert _call(
+        gateway_client,
+        token,
+        "invoke_tool",
+        {
+            "agent": "shared",
+            "toolkit": "calculator",
+            "function": "add",
+            "arguments": {"a": 1, "b": 2},
+        },
+    )["isError"]
 
 
 @pytest.mark.parametrize(
@@ -222,7 +376,7 @@ def test_all_clients_follow_selection_and_agent_qualified_tools(
         display_name="Shared",
         role="Shared tools",
         tools=["calculator"],
-        credential_managers=["@alice:example.org"],
+        access=ResponderAccessConfig(users=["@alice:example.org"]),
     )
     alice = signed_headers("alice")
     tokens = [_connect(gateway_client, alice)["access_token"] for _ in range(2)]

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -24,6 +24,9 @@ from structlog.testing import capture_logs
 import mindroom.orchestrator as orchestrator_module
 import mindroom.tool_system.plugin_imports as plugin_module
 import mindroom.workers.runtime as workers_runtime_module
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
+from mindroom.api import config_lifecycle as api_config_lifecycle
+from mindroom.api import main as api_main
 from mindroom.approval_manager import (
     _ApprovalStartupSweep,
     get_approval_store,
@@ -559,6 +562,44 @@ class TestAgentBot(AgentBotTestBase):
         assert get_api_server_address() is None
 
     @pytest.mark.asyncio
+    async def test_run_api_server_binds_live_memberships_and_clears_on_shutdown(self, tmp_path: Path) -> None:
+        """Roomless API authorization follows the orchestrator's live membership index."""
+        memberships = AgentReplyMembershipIndex()
+
+        class ReturningServer:
+            should_exit = True
+            force_exit = False
+
+            def __init__(
+                self,
+                _config: object,
+                _shutdown_requested: asyncio.Event | None,
+                *,
+                on_started: Callable[[str, int], Awaitable[None]] | None = None,
+            ) -> None:
+                del on_started
+
+            async def serve(self) -> None:
+                assert api_config_lifecycle.app_state(api_main.app).agent_reply_memberships is memberships
+
+        shutdown_requested = asyncio.Event()
+        shutdown_requested.set()
+        with (
+            patch("mindroom.orchestrator.uvicorn.Config", return_value=object()),
+            patch("mindroom.orchestrator._SignalAwareUvicornServer", ReturningServer),
+        ):
+            await _run_api_server(
+                "127.0.0.1",
+                8765,
+                "INFO",
+                self._runtime_paths(tmp_path),
+                agent_reply_memberships=memberships,
+                shutdown_requested=shutdown_requested,
+            )
+
+        assert api_config_lifecycle.app_state(api_main.app).agent_reply_memberships is not memberships
+
+    @pytest.mark.asyncio
     async def test_run_api_server_binds_process_local_script_runtime(self, tmp_path: Path) -> None:
         """The API gateway must receive the lifecycle-owned broker without replacing it."""
 
@@ -1001,10 +1042,12 @@ class TestAgentBot(AgentBotTestBase):
             thread_export_runner: object,
             leave_matrix_room: object,
             response_admission_gate: object,
+            agent_reply_memberships: AgentReplyMembershipIndex,
         ) -> None:
             assert thread_export_runner is mock_orchestrator._thread_export_runner
             assert leave_matrix_room == mock_orchestrator.leave_matrix_room
             assert response_admission_gate is mock_orchestrator._response_admission_gate
+            assert agent_reply_memberships is mock_orchestrator.agent_reply_memberships
             assert shutdown_requested is not None
             shutdown_requested.set()
             try:
@@ -1084,10 +1127,12 @@ class TestAgentBot(AgentBotTestBase):
             thread_export_runner: object,
             leave_matrix_room: object,
             response_admission_gate: object,
+            agent_reply_memberships: AgentReplyMembershipIndex,
         ) -> None:
             assert thread_export_runner is mock_orchestrator._thread_export_runner
             assert leave_matrix_room == mock_orchestrator.leave_matrix_room
             assert response_admission_gate is mock_orchestrator._response_admission_gate
+            assert agent_reply_memberships is mock_orchestrator.agent_reply_memberships
             assert shutdown_requested is not None
             shutdown_requested.set()
             api_shutdown_started.set()
@@ -1157,10 +1202,12 @@ class TestAgentBot(AgentBotTestBase):
             thread_export_runner: object,
             leave_matrix_room: object,
             response_admission_gate: object,
+            agent_reply_memberships: AgentReplyMembershipIndex,
         ) -> None:
             assert thread_export_runner is mock_orchestrator._thread_export_runner
             assert leave_matrix_room == mock_orchestrator.leave_matrix_room
             assert response_admission_gate is mock_orchestrator._response_admission_gate
+            assert agent_reply_memberships is mock_orchestrator.agent_reply_memberships
             assert shutdown_requested is not None
             shutdown_requested.set()
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -4,6 +4,7 @@
 #   uv run vulture --make-whitelist src/mindroom --min-confidence 60 --sort-by-size | perl -pe 's/\.py:\d+/.py/g' > vulture_whitelist.py
 dashboard_credentials_supported  # unused variable (src/mindroom/agent_policy.py)
 is_shared  # JSON response field consumed by connections portal (src/mindroom/api/connections.py)
+can_use  # JSON response field consumed by connections portal (src/mindroom/api/connections.py)
 can_connect  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 account_label  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 connection_url  # TypedDict field consumed by gateway clients (src/mindroom/mcp_gateway/types.py)


### PR DESCRIPTION
Users who can access a shared agent currently cannot expose its tools through the MCP gateway unless they also manage its credentials. This change separates agent use from credential management and shows both kinds of access in Connections.

MCP discovery, selection, and execution reuse responder authorization, including verified grant-room membership. Current-room-only grants do not authorize roomless calls, and membership revocation is checked again before a prepared call executes. The embedded API receives the orchestrator's live membership index through its existing lifecycle wiring.

Users can inspect shared connection availability and manage their own requester-scoped accounts. Shared credential changes remain restricted to credential managers and administrators; credential management alone grants no MCP execution. Connections hides controls the user cannot use and redacts shared account identity.

Validation:
- Backend coverage for authorization, Connections, MCP selection/execution, OAuth, credentials, membership revocation, API lifecycle, and import boundaries.
- 68 Connections frontend tests.
- Frontend production build and TypeScript checks.
- Repository pre-commit hooks.

## Summary by Sourcery

Separate shared-agent tool access from credential management across the Connections portal and MCP gateway.

New Features:
- Allow users with responder access to shared agents to expose and execute compatible MCP tools independently of credential-management permissions.
- Show shared connection availability to agent users while allowing credential managers, administrators, and requester-scoped users to manage only the connections they are authorized to change.
- Support room-membership-based authorization for roomless Connections and MCP requests, with live membership revocation enforced before execution.

Bug Fixes:
- Prevent credential-management access alone from authorizing MCP discovery, selection, or execution.
- Prevent users without shared-connection management permission from viewing account identity or accessing connect and disconnect controls.

Enhancements:
- Reuse responder authorization across Connections, MCP gateway, and credential flows, including verified grant-room membership and execution-time checks.
- Pass the orchestrator's live agent membership index into the embedded API lifecycle.

Documentation:
- Update MCP gateway and Connections documentation to describe separated agent-use and credential-management permissions, roomless authorization, account redaction, and revocation behavior.

Tests:
- Add backend and frontend coverage for independent agent access and credential management, shared connection visibility, requester-scoped credentials, membership authorization and revocation, MCP selection and execution, OAuth behavior, API lifecycle wiring, and import boundaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Connections now distinguish between agents you can use and agents whose credentials you can manage.
  - Shared connection availability can be viewed without exposing account identities or allowing credential changes.
  - Users with agent access can select compatible MCP tools, while credential-only access is clearly labeled.
  - Personal and requester-scoped connection management remains available where authorized.

- **Bug Fixes**
  - Access changes, including revoked room membership, are rechecked before MCP calls and OAuth operations.

- **Documentation**
  - Updated access, shared-agent, and Connections Portal guidance to reflect the new authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->