### PR TITLE
Preserve full agent context in GPT-Live calls

### DIFF
--- a/docs/voice-calls.md
+++ b/docs/voice-calls.md
@@ -20,7 +20,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
+Live receives the normal agent's full rendered system prompt, including its configured context files and caller-specific workspace, followed by voice delivery and delegation guidance. It can answer from that context directly and delegates requests needing tools, research, additional memory, or actions to the normal MindRoom agent. Tool schemas and execution remain in the delegated agent. The prompt is prepared before the first greeting, and the prepared agent is reused for delegated turns.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14944,7 +14944,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
+Live receives the normal agent's full rendered system prompt, including its configured context files and caller-specific workspace, followed by voice delivery and delegation guidance. It can answer from that context directly and delegates requests needing tools, research, additional memory, or actions to the normal MindRoom agent. Tool schemas and execution remain in the delegated agent. The prompt is prepared before the first greeting, and the prepared agent is reused for delegated turns.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/skills/mindroom-docs/references/page__voice-calls__index.md
+++ b/skills/mindroom-docs/references/page__voice-calls__index.md
@@ -20,7 +20,7 @@ When a call starts in a room, the configured agent:
 
 The voice agent is the same agent you chat with.
 Realtime carries the agent's rendered prompt and effective tools into OpenAI Realtime.
-Live uses a short voice prompt and delegates questions, research, memory, and supported actions to the normal MindRoom agent, which retains the instructions, knowledge, skills, hooks, and tools available during voice calls.
+Live receives the normal agent's full rendered system prompt, including its configured context files and caller-specific workspace, followed by voice delivery and delegation guidance. It can answer from that context directly and delegates requests needing tools, research, additional memory, or actions to the normal MindRoom agent. Tool schemas and execution remain in the delegated agent. The prompt is prepared before the first greeting, and the prepared agent is reused for delegated turns.
 The voice model relays the agent's results conversationally.
 Cascaded sends each finalized transcript through the normal MindRoom agent response path, preserving model resolution, the rendered system prompt, instructions, knowledge, skills, hooks, tools, requester identity, history storage, and tool execution behavior.
 A cascaded profile may explicitly override the resolved LLM while preserving all other agent behavior.

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -111,9 +111,11 @@ _VOICE_STYLE_ADDENDUM = (
 )
 
 _LIVE_VOICE_INSTRUCTIONS = (
-    "You are the voice interface for a MindRoom agent. Speak briefly and naturally. "
-    "Delegate every substantive request to the agent, including questions, research, "
-    "memory, and actions. Relay its answer conversationally. Never claim to have "
+    "You are speaking as this agent in a live voice call. Use the identity, instructions, "
+    "and context above. Speak briefly and naturally, without markdown. "
+    "Answer directly when the answer is already in the supplied context or conversation. "
+    "Delegate requests needing tools, research, additional memory, or actions to the agent; "
+    "it executes the tool workflows described above. Relay its answer conversationally. Never claim to have "
     "checked information or completed work until the agent returns the result."
 )
 
@@ -1181,11 +1183,16 @@ class CallManager:
             )
         if self._call_config.backend == "live":
             live_config = cast("LiveCallProfile", self._call_config)
-            if backend.realtime_api_key is None or tooling.responder is None:
+            get_system_prompt = tooling.get_system_prompt
+            if backend.realtime_api_key is None or tooling.responder is None or get_system_prompt is None:
                 msg = "Live call agent was not fully materialized"
                 raise RuntimeError(msg)
+
+            async def get_live_instructions() -> str:
+                return f"{await get_system_prompt()}\n\n{_LIVE_VOICE_INSTRUCTIONS}"
+
             return LiveVoiceAgentOptions(
-                instructions=_LIVE_VOICE_INSTRUCTIONS,
+                get_instructions=get_live_instructions,
                 model=live_config.model,
                 api_key=backend.realtime_api_key,
                 voice=live_config.voice,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -116,6 +116,7 @@ class CallAgentTooling:
     responder: Callable[[str, Callable[[list[str]], None] | None], Awaitable[CallAgentResponse]] | None = None
     finalize_spoken_response: Callable[[str | None, str, bool], Awaitable[None] | None] | None = None
     close: Callable[[], Awaitable[None]] | None = None
+    get_system_prompt: Callable[[], Awaitable[str]] | None = None
 
 
 @dataclass(frozen=True)
@@ -221,7 +222,7 @@ class _CallResponseTracker:
 
 @dataclass
 class _CallAgentCache:
-    """Own one serially reused cascaded agent for the lifetime of a call."""
+    """Own one serially reused delegate for the lifetime of a call."""
 
     agent_name: str
     config: Config
@@ -234,6 +235,35 @@ class _CallAgentCache:
     knowledge_identity: tuple[int, ...] = ()
     refresh_scheduler: KnowledgeRefreshScheduler | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def get_system_prompt(self, *, requester_id: str) -> str:
+        """Prepare the full caller-bound prompt and retain its agent for delegation."""
+        scheduler = (
+            self.context.orchestrator.knowledge_refresh_scheduler if self.context.orchestrator is not None else None
+        )
+        resolution = await resolve_agent_knowledge_access_async(
+            self.agent_name,
+            self.config,
+            self.runtime_paths,
+            refresh_scheduler=scheduler,
+            execution_identity=self.execution_identity,
+        )
+
+        async def render(agent: AgnoAgent) -> str:
+            session, run_context, tools = await _prepare_call_agent_tools(
+                agent,
+                agent_name=self.agent_name,
+                session_id=self.session_id,
+                requester_id=requester_id,
+            )
+            return await _render_system_prompt(agent, session, run_context, tools)
+
+        return await self.run(
+            knowledge=resolution.knowledge,
+            knowledge_identity=knowledge_runtime_identity(resolution.knowledge),
+            refresh_scheduler=scheduler,
+            operation=render,
+        )
 
     async def run(
         self,
@@ -470,6 +500,7 @@ async def build_call_tools(
             responder=responder,
             finalize_spoken_response=response_tracker.finalize if reconcile_spoken_response else None,
             close=functools.partial(_close_cascaded_call_resources, response_tracker, agent_cache),
+            get_system_prompt=functools.partial(agent_cache.get_system_prompt, requester_id=requester_id),
         )
 
     refresh_scheduler = context.orchestrator.knowledge_refresh_scheduler if context.orchestrator is not None else None
@@ -497,6 +528,49 @@ async def build_call_tools(
             eager_deferred_tools=True,
         ),
     )
+    session, run_context, effective_tools = await _prepare_call_agent_tools(
+        agent,
+        agent_name=agent_name,
+        session_id=session_id,
+        requester_id=requester_id,
+    )
+    tools: list[Any] = []
+    visible_functions: list[Function | dict[Any, Any]] = []
+    for tool in effective_tools:
+        if not isinstance(tool, Function):
+            msg = f"Voice calls cannot expose provider-native tool definitions for agent {agent_name}"
+            raise TypeError(msg)
+        if _function_requires_text_chat(tool, config):
+            logger.info("call_tool_hidden_needs_text_chat", tool=tool.name, agent=agent_name)
+            continue
+        visible_functions.append(tool)
+        tools.append(
+            _wrap_agno_function(
+                tool,
+                context=context,
+                agent_name=agent_name,
+                config=config,
+                authorize_operation=authorize_operation,
+            ),
+        )
+    instructions = await _render_system_prompt(agent, session, run_context, visible_functions)
+    logger.info("call_tools_built", agent=agent_name, room_id=room_id, tool_count=len(tools))
+    return CallAgentTooling(
+        tools=tuple(tools),
+        instructions=instructions,
+        execution_identity=execution_identity,
+    )
+
+
+async def _prepare_call_agent_tools(
+    agent: AgnoAgent,
+    *,
+    agent_name: str,
+    session_id: str,
+    requester_id: str,
+) -> tuple[AgnoAgentSession, RunContext, list[Function | dict[Any, Any]]]:
+    """Prepare canonical tool instructions before rendering a call's system prompt."""
+    assert agent.model is not None
     run_id = f"{session_id}:voice"
     session = AgnoAgentSession(session_id=session_id, agent_id=agent_name, user_id=requester_id)
     run_output = RunOutput(
@@ -527,32 +601,7 @@ async def build_call_tools(
         session=session,
         async_mode=True,
     )
-    tools: list[Any] = []
-    visible_functions: list[Function | dict[Any, Any]] = []
-    for tool in effective_tools:
-        if not isinstance(tool, Function):
-            msg = f"Voice calls cannot expose provider-native tool definitions for agent {agent_name}"
-            raise TypeError(msg)
-        if _function_requires_text_chat(tool, config):
-            logger.info("call_tool_hidden_needs_text_chat", tool=tool.name, agent=agent_name)
-            continue
-        visible_functions.append(tool)
-        tools.append(
-            _wrap_agno_function(
-                tool,
-                context=context,
-                agent_name=agent_name,
-                config=config,
-                authorize_operation=authorize_operation,
-            ),
-        )
-    instructions = await _render_system_prompt(agent, session, run_context, visible_functions)
-    logger.info("call_tools_built", agent=agent_name, room_id=room_id, tool_count=len(tools))
-    return CallAgentTooling(
-        tools=tuple(tools),
-        instructions=instructions,
-        execution_identity=execution_identity,
-    )
+    return session, run_context, effective_tools
 
 
 async def _run_call_agent(

--- a/src/mindroom/matrix_rtc/live_voice_agent.py
+++ b/src/mindroom/matrix_rtc/live_voice_agent.py
@@ -161,14 +161,14 @@ class _LiveDelegationRunner:
             await asyncio.gather(*self._tasks, return_exceptions=True)
 
 
-def _build_live_agent(options: LiveVoiceAgentOptions) -> Agent:  # noqa: C901 - SDK class is defined lazily
+def _build_live_agent(options: LiveVoiceAgentOptions, instructions: str) -> Agent:  # noqa: C901 - SDK class is defined lazily
     """Load the optional SDK only when a Live call starts."""
     from livekit.agents import Agent  # noqa: PLC0415
     from livekit.plugins.openai.realtime import GPTLiveSession  # noqa: PLC0415
 
     class LiveCallAgent(Agent):
         def __init__(self) -> None:
-            super().__init__(instructions=options.instructions, tools=[])
+            super().__init__(instructions=instructions, tools=[])
             self._delegations: _LiveDelegationRunner | None = None
             self._live_session: GPTLiveSession | None = None
             self._provider_close_task: asyncio.Task[None] | None = None
@@ -240,6 +240,7 @@ class LiveVoiceBridge(RealtimeVoiceBridge):
             raise TypeError(msg)
         if options.close_responder is not None:
             self._owned_speech_resource_closers += (options.close_responder,)
+        instructions = await options.get_instructions()
         model = GPTLiveModel(
             model=options.model,
             api_key=options.api_key,
@@ -252,7 +253,7 @@ class LiveVoiceBridge(RealtimeVoiceBridge):
         )
         self._owned_speech_resource_closers += (model.aclose,)
         session = AgentSession(llm=model)
-        self._live_agent = _build_live_agent(options)
+        self._live_agent = _build_live_agent(options, instructions)
         await self._start_session(session, self._live_agent, options, rtc_module=rtc, room_io_module=room_io)
         if options.greeting_instructions:
             session.generate_reply(instructions=options.greeting_instructions)

--- a/src/mindroom/matrix_rtc/voice_agent.py
+++ b/src/mindroom/matrix_rtc/voice_agent.py
@@ -364,7 +364,7 @@ class CascadedVoiceAgentOptions:
 class LiveVoiceAgentOptions:
     """GPT-Live speech with delegation to the normal MindRoom agent."""
 
-    instructions: str
+    get_instructions: Callable[[], Awaitable[str]]
     model: str
     api_key: str
     voice: str

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -456,6 +456,7 @@ def _stub_join_externals(monkeypatch: pytest.MonkeyPatch) -> None:
             instructions="You are Helper.",
             execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
             responder=AsyncMock(return_value=CallAgentResponse("answer")),
+            get_system_prompt=AsyncMock(return_value="You are Helper."),
         )
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.build_call_tools", fake_tools)
@@ -747,7 +748,8 @@ async def test_manager_selects_live_backend_with_normal_agent_delegate(
         tooling_kwargs.update(kwargs)
         return CallAgentTooling(
             tools=(),
-            instructions="Detailed private agent workspace instructions.",
+            instructions="",
+            get_system_prompt=AsyncMock(return_value="Detailed agent workspace instructions."),
             execution_identity=_call_execution_identity_from_tool_kwargs(kwargs),
             responder=respond,
             close=close_responder,
@@ -775,7 +777,7 @@ async def test_manager_selects_live_backend_with_normal_agent_delegate(
     assert options.voice == "marin"
     assert options.respond is respond
     assert options.close_responder is close_responder
-    assert "Detailed private agent workspace instructions." not in options.instructions
+    assert (await options.get_instructions()).startswith("Detailed agent workspace instructions.")
     assert await options.respond("Check status", None) == CallAgentResponse("Completed: Check status")
     assert services == ["openai_live"]
     assert tooling_kwargs["enable_responder"] is True

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -20,7 +20,7 @@ from agno.tools.function import Function
 from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent
 from mindroom.bedrock_claude import MindRoomBedrockClaude
 from mindroom.claude_prompt_cache import install_claude_prompt_cache_hook
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig
 from mindroom.config.approval import ApprovalRuleConfig, ToolApprovalConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -39,6 +39,7 @@ from mindroom.matrix_rtc.call_tools import (
     build_call_tools,
 )
 from mindroom.memory import MemoryPromptParts
+from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
@@ -55,6 +56,8 @@ from tests.conftest import bind_runtime_paths, make_conversation_reader_mock, ma
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable
     from pathlib import Path
+
+    from agno.agent import Agent as AgnoAgent
 
     from mindroom.message_target import MessageTarget
     from mindroom.response_turn import ResponseTurnContext
@@ -764,6 +767,98 @@ def test_wrap_processes_unprocessed_toolkit_function_schema() -> None:
     _wrap(function)
     assert set(function.parameters["properties"]) == {"a", "b"}
     assert set(function.parameters["required"]) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_call_responder_prepares_full_requester_prompt_before_first_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live must receive every context file before delegating, without crossing caller scopes."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                AGENT: AgentConfig(
+                    display_name="Helper",
+                    instructions=["Keep the caller's preferences."],
+                    private=AgentPrivateConfig(per="user_agent", context_files=["USER.md", "SOUL.md"]),
+                ),
+            },
+            models={"default": ModelConfig(provider="ollama", id="test")},
+        ),
+        runtime_paths,
+    )
+
+    async def respond(_turn: ResponseTurnContext, **kwargs: object) -> str:
+        return cast("AgnoAgent", kwargs["reusable_agent"]).role or ""
+
+    monkeypatch.setattr("mindroom.ai.ai_response", respond)
+    for requester, name, other in (("@alice:example.org", "Alice", "Bob"), ("@bob:example.org", "Bob", "Alice")):
+        identity = build_tool_execution_identity(
+            channel="matrix",
+            agent_name=AGENT,
+            runtime_paths=runtime_paths,
+            requester_id=requester,
+            room_id="!call:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=requester,
+        )
+        workspace = resolve_agent_runtime(
+            AGENT,
+            config,
+            runtime_paths,
+            execution_identity=identity,
+            create=True,
+        ).workspace
+        assert workspace is not None
+        (workspace.root / "USER.md").write_text(f"The caller is {name}.")
+        (workspace.root / "SOUL.md").write_text("Use a warm, concise voice.")
+        support = SimpleNamespace(
+            build_context=lambda target, *, user_id, **_kwargs: make_test_tool_runtime_context(
+                agent_name=AGENT,
+                target=target,
+                requester_id=user_id,
+                client=MagicMock(),
+                config=config,
+                runtime_paths=runtime_paths,
+                relations=make_relation_lookup(),
+                conversation_reader=make_conversation_reader_mock(),
+                hook_registry=MagicMock(),
+            ),
+            build_execution_identity=lambda identity=identity, **_kwargs: identity,
+            run_in_context=lambda *, operation, **_kwargs: operation(),
+        )
+        tooling = await build_call_tools(
+            agent_name=AGENT,
+            config=config,
+            runtime_paths=runtime_paths,
+            tool_support=support,
+            room_id="!call:example.org",
+            requester_id=requester,
+            session_id=requester,
+            authorize_operation=_authorized_call_operation,
+            enable_responder=True,
+            reconcile_spoken_response=False,
+        )
+        assert tooling.close is not None
+        try:
+            assert tooling.get_system_prompt is not None
+            prompt = await tooling.get_system_prompt()
+            assert f"The caller is {name}." in prompt
+            assert f"The caller is {other}." not in prompt
+            assert "Use a warm, concise voice." in prompt
+            assert "Keep the caller's preferences." in prompt
+            assert tooling.tools == ()
+            # The first delegated turn reuses the prepared agent and its context snapshot.
+            (workspace.root / "USER.md").write_text("This file changed after the call started.")
+            assert tooling.responder is not None
+            response = await tooling.responder("Who am I?", None)
+            assert f"The caller is {name}." in response.text
+            assert "This file changed" not in response.text
+        finally:
+            await tooling.close()
 
 
 @pytest.mark.asyncio
@@ -1748,7 +1843,13 @@ async def test_build_call_tools_hides_agno_added_knowledge_function_needing_appr
     knowledge = Knowledge(name="docs")
 
     def create_knowledge_agent(*_args: object, **kwargs: object) -> KnowledgeToolDescribingAgent:
-        agent = KnowledgeToolDescribingAgent(name="Helper", id=AGENT, knowledge=knowledge, search_knowledge=True)
+        agent = KnowledgeToolDescribingAgent(
+            name="Helper",
+            id=AGENT,
+            model=Claude(id="claude-sonnet-5"),
+            knowledge=knowledge,
+            search_knowledge=True,
+        )
         agent.tool_function_filter = cast("Callable[[Function], bool]", kwargs["tool_function_filter"])
         monkeypatch.setattr(
             agent,

--- a/tests/test_matrix_rtc_continuous_audio.py
+++ b/tests/test_matrix_rtc_continuous_audio.py
@@ -64,7 +64,7 @@ async def start_audio(
     session.start = AsyncMock()
     options = (
         LiveVoiceAgentOptions(
-            instructions="Speak.",
+            get_instructions=AsyncMock(return_value="Speak."),
             model="gpt-live-1",
             api_key="test",
             voice="marin",

--- a/tests/test_matrix_rtc_live_voice_agent.py
+++ b/tests/test_matrix_rtc_live_voice_agent.py
@@ -32,7 +32,7 @@ class CommentarySink:
 
 def _options(respond: object, **kwargs: object) -> LiveVoiceAgentOptions:
     return LiveVoiceAgentOptions(
-        instructions="Delegate tasks to the backend.",
+        get_instructions=AsyncMock(return_value="Delegate tasks to the backend."),
         model="gpt-live-1",
         api_key="test-key",
         voice="marin",

--- a/tests/test_matrix_rtc_live_voice_sdk.py
+++ b/tests/test_matrix_rtc_live_voice_sdk.py
@@ -136,8 +136,9 @@ async def test_live_sdk_routes_delegation_and_closes_owned_work(provider: _Provi
     async def close_responder() -> None:
         order.append("responder_closed")
 
+    system_prompt = "You are Helper. The caller is Alice.\n" + "Preserve every context section.\n" * 1200
     options = LiveVoiceAgentOptions(
-        instructions="Delegate substantive requests to the configured agent.",
+        get_instructions=AsyncMock(return_value=system_prompt),
         model="gpt-live-1",
         api_key="test-api-key",
         voice="vesper",
@@ -153,15 +154,13 @@ async def test_live_sdk_routes_delegation_and_closes_owned_work(provider: _Provi
         start = await provider.socket.next_event("session.start")
         assert start["session"]["model"] == "gpt-live-1"
         assert start["session"]["audio"]["output"]["voice"] == "vesper"
-        assert start["session"]["instructions"] == options.instructions
+        assert start["session"]["instructions"] == system_prompt
         assert start["session"]["delegation"] == {"type": "client"}
         assert provider.connection is not None
         url, headers = provider.connection
         assert url == "wss://api.openai.com/v1/live/sessions"
         assert headers["Authorization"] == "Bearer test-api-key"
 
-        agent = cast("Agent", bridge._live_agent)
-        assert isinstance(agent.duplex_session, GPTLiveSession)
         provider.socket.feed(
             {"type": "session.input_transcript.delta", "delta": "Check status.", "start_ms": 0, "end_ms": 100},
         )
@@ -209,7 +208,7 @@ async def test_live_sdk_identical_spoken_retry_survives_delegate_failure(
             retry_transcribed.set()
 
     options = LiveVoiceAgentOptions(
-        instructions="Delegate requests.",
+        get_instructions=AsyncMock(return_value="Delegate requests."),
         model="gpt-live-1",
         api_key="test-api-key",
         voice="marin",
@@ -256,6 +255,34 @@ async def test_live_sdk_identical_spoken_retry_survives_delegate_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("cancelled", [False, True], ids=["failed", "cancelled"])
+async def test_live_prompt_preparation_failure_closes_responder_before_provider_start(
+    provider: _ProviderHTTP,
+    cancelled: bool,
+) -> None:
+    """Preparing the full prompt must not leak the cached agent on failed call startup."""
+    error = asyncio.CancelledError if cancelled else RuntimeError
+    close_responder = AsyncMock()
+    options = LiveVoiceAgentOptions(
+        get_instructions=AsyncMock(side_effect=error("prompt preparation stopped")),
+        model="gpt-live-1",
+        api_key="test-api-key",
+        voice="marin",
+        respond=AsyncMock(),
+        close_responder=close_responder,
+    )
+    bridge = LiveVoiceBridge(local_identity="@bot:example.org:DEVICE", e2ee_enabled=False)
+    bridge._room = SimpleNamespace(disconnect=AsyncMock())
+    try:
+        with pytest.raises(error, match="prompt preparation stopped"):
+            await bridge.start_agent(options)
+    finally:
+        await bridge.aclose()
+    close_responder.assert_awaited_once()
+    assert provider.connection is None
+
+
+@pytest.mark.asyncio
 async def test_live_sdk_configuration_failure_releases_owned_resources(
     provider: _ProviderHTTP,
     monkeypatch: pytest.MonkeyPatch,
@@ -269,7 +296,7 @@ async def test_live_sdk_configuration_failure_releases_owned_resources(
     monkeypatch.setattr(GPTLiveSession, "_update_instructions", reject_configuration)
     close_responder = AsyncMock()
     options = LiveVoiceAgentOptions(
-        instructions="Delegate requests.",
+        get_instructions=AsyncMock(return_value="Delegate requests."),
         model="gpt-live-1",
         api_key="test-api-key",
         voice="marin",
@@ -319,7 +346,7 @@ async def test_live_sdk_disconnect_returns_control_without_reusing_delegations(
         terminated.set()
 
     options = LiveVoiceAgentOptions(
-        instructions="Delegate requests.",
+        get_instructions=AsyncMock(return_value="Delegate requests."),
         model="gpt-live-1",
         api_key="test-api-key",
         voice="marin",


### PR DESCRIPTION
GPT-Live calls previously received only generic voice instructions, leaving agent identity and context unavailable until a delegated turn. Give Live the normal agent's full rendered system prompt before its first greeting, followed by voice and delegation guidance, so it can answer directly from supplied context.

Prepare and reuse the cached agent for delegated turns, with cleanup ownership established before prompt preparation. Tool schemas and execution remain in the delegate; the existing canonical context preload policy is unchanged.

Validation:
- Full Python test suite: 18,425 passed, 22 skipped.
- All 300 voice-call tests and all pre-commit hooks passed.
- Independent code review passed with no findings. Regression coverage checks caller isolation, cached reuse, complete SDK request instructions, and failed/cancelled startup cleanup.
- A bounded real GPT-Live session accepted a 31,731-character synthetic canonical prompt and recalled its caller name and project codename with zero delegations and no provider errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice calls now receive the agent’s full, caller-specific context before the first greeting.
  * Live voice can answer directly using that context and delegates tool, research, memory, or action requests to the main agent.
  * Prepared agent context is reused across delegated turns.

* **Documentation**
  * Updated voice-call documentation to describe the expanded context and delegation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->