### PR TITLE
Recover recurring schedules missed during downtime

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -660,6 +660,7 @@ matrix_sync:
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+scheduler_catch_up_grace_seconds: 3600  # Recurring catch-up window; 0 disables it
 ```
 
 Retired access fields in a monolithic configuration are migrated automatically when the file loads.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -708,6 +708,10 @@ ToolAfterCallContext(
 For `schedule:fired`, `ScheduleFiredContext.thread_id` is the resolved delivery thread.
 This may differ from `workflow.thread_id` when the workflow starts a new thread or resolves to room mode.
 Visible and silent schedules both emit `schedule:fired` before their trigger is sent.
+For recurring schedules, `ctx.correlation_id` identifies the intended occurrence and stays the same across preparation retries.
+A crash or preparation failure before the trigger is durably frozen can invoke the hook again with that ID.
+Side-effecting hooks must use an idempotent destination; use the correlation ID as its idempotency key.
+Once the trigger is frozen, delivery retries reuse its prepared content without invoking hooks again.
 Setting `ctx.suppress = True` cancels the fire, while replacing `ctx.message_text` with an empty or whitespace-only value produces a visible scheduled-task failure notice.
 
 ## Testing

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -165,6 +165,7 @@ On shutdown, the router cancels its in-memory scheduled tasks before exiting.
 
 Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
 After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The same window applies when a live timer wakes late.
 The default window is one hour:
 
 ```yaml
@@ -172,17 +173,25 @@ scheduler_catch_up_grace_seconds: 3600
 ```
 
 Set this to `0` to disable catch-up for unattempted occurrences.
+Ordinary future timers still run when catch-up is disabled.
 Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
 The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
 Normal future occurrences keep their original cron cadence.
 
 Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
 Before sending, MindRoom durably freezes its content and sending device.
+Temporary checkpoint failures keep the timer alive and retry without repeating an acknowledged delivery.
 A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
 Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
 Already-triggered agent work continues through normal event recovery.
+Invalid content discovered before delivery is frozen fails the occurrence and advances the timer.
 If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
 
 The checkpoint directory must survive restarts.
 On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
 Cancelling a schedule still prevents its pending timer from firing.
+Cancellation does not erase Matrix schedule history or local checkpoints.
+
+The trigger transaction does not make arbitrary `schedule:fired` hook side effects exactly-once.
+Hooks can replay after a crash or preparation failure before trigger content is durably frozen.
+Recurring hooks receive a `correlation_id` that is stable for that occurrence and changes for the next one; use it with an idempotent destination when performing side effects.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -160,3 +160,29 @@ Older missed one-time tasks are marked failed instead of executing unexpectedly.
 Only the router restores persisted schedules after startup — individual agents do not restore their own.
 
 On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+
+### Recurring task recovery
+
+Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
+After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The default window is one hour:
+
+```yaml
+scheduler_catch_up_grace_seconds: 3600
+```
+
+Set this to `0` to disable catch-up for unattempted occurrences.
+Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
+The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
+Normal future occurrences keep their original cron cadence.
+
+Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
+Before sending, MindRoom durably freezes its content and sending device.
+A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
+Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
+Already-triggered agent work continues through normal event recovery.
+If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
+
+The checkpoint directory must survive restarts.
+On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
+Cancelling a schedule still prevents its pending timer from firing.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13616,6 +13616,10 @@ ToolAfterCallContext(
 For `schedule:fired`, `ScheduleFiredContext.thread_id` is the resolved delivery thread.
 This may differ from `workflow.thread_id` when the workflow starts a new thread or resolves to room mode.
 Visible and silent schedules both emit `schedule:fired` before their trigger is sent.
+For recurring schedules, `ctx.correlation_id` identifies the intended occurrence and stays the same across preparation retries.
+A crash or preparation failure before the trigger is durably frozen can invoke the hook again with that ID.
+Side-effecting hooks must use an idempotent destination; use the correlation ID as its idempotency key.
+Once the trigger is frozen, delivery retries reuse its prepared content without invoking hooks again.
 Setting `ctx.suppress = True` cancels the fire, while replacing `ctx.message_text` with an empty or whitespace-only value produces a visible scheduled-task failure notice.
 
 ## Testing
@@ -16269,6 +16273,7 @@ On shutdown, the router cancels its in-memory scheduled tasks before exiting.
 
 Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
 After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The same window applies when a live timer wakes late.
 The default window is one hour:
 
 ```yaml
@@ -16276,20 +16281,28 @@ scheduler_catch_up_grace_seconds: 3600
 ```
 
 Set this to `0` to disable catch-up for unattempted occurrences.
+Ordinary future timers still run when catch-up is disabled.
 Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
 The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
 Normal future occurrences keep their original cron cadence.
 
 Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
 Before sending, MindRoom durably freezes its content and sending device.
+Temporary checkpoint failures keep the timer alive and retry without repeating an acknowledged delivery.
 A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
 Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
 Already-triggered agent work continues through normal event recovery.
+Invalid content discovered before delivery is frozen fails the occurrence and advances the timer.
 If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
 
 The checkpoint directory must survive restarts.
 On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
 Cancelling a schedule still prevents its pending timer from firing.
+Cancellation does not erase Matrix schedule history or local checkpoints.
+
+The trigger transaction does not make arbitrary `schedule:fired` hook side effects exactly-once.
+Hooks can replay after a crash or preparation failure before trigger content is durably frozen.
+Recurring hooks receive a `correlation_id` that is stable for that occurrence and changes for the next one; use it with an idempotent destination when performing side effects.
 
 # External Triggers
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1562,6 +1562,7 @@ matrix_sync:
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+scheduler_catch_up_grace_seconds: 3600  # Recurring catch-up window; 0 disables it
 ```
 
 Retired access fields in a monolithic configuration are migrated automatically when the file loads.
@@ -16263,6 +16264,32 @@ Older missed one-time tasks are marked failed instead of executing unexpectedly.
 Only the router restores persisted schedules after startup — individual agents do not restore their own.
 
 On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+
+### Recurring task recovery
+
+Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
+After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The default window is one hour:
+
+```yaml
+scheduler_catch_up_grace_seconds: 3600
+```
+
+Set this to `0` to disable catch-up for unattempted occurrences.
+Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
+The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
+Normal future occurrences keep their original cron cadence.
+
+Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
+Before sending, MindRoom durably freezes its content and sending device.
+A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
+Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
+Already-triggered agent work continues through normal event recovery.
+If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
+
+The checkpoint directory must survive restarts.
+On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
+Cancelling a schedule still prevents its pending timer from firing.
 
 # External Triggers
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -656,6 +656,7 @@ matrix_sync:
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
+scheduler_catch_up_grace_seconds: 3600  # Recurring catch-up window; 0 disables it
 ```
 
 Retired access fields in a monolithic configuration are migrated automatically when the file loads.

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -704,6 +704,10 @@ ToolAfterCallContext(
 For `schedule:fired`, `ScheduleFiredContext.thread_id` is the resolved delivery thread.
 This may differ from `workflow.thread_id` when the workflow starts a new thread or resolves to room mode.
 Visible and silent schedules both emit `schedule:fired` before their trigger is sent.
+For recurring schedules, `ctx.correlation_id` identifies the intended occurrence and stays the same across preparation retries.
+A crash or preparation failure before the trigger is durably frozen can invoke the hook again with that ID.
+Side-effecting hooks must use an idempotent destination; use the correlation ID as its idempotency key.
+Once the trigger is frozen, delivery retries reuse its prepared content without invoking hooks again.
 Setting `ctx.suppress = True` cancels the fire, while replacing `ctx.message_text` with an empty or whitespace-only value produces a visible scheduled-task failure notice.
 
 ## Testing

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -156,3 +156,29 @@ Older missed one-time tasks are marked failed instead of executing unexpectedly.
 Only the router restores persisted schedules after startup — individual agents do not restore their own.
 
 On shutdown, the router cancels its in-memory scheduled tasks before exiting.
+
+### Recurring task recovery
+
+Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
+After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The default window is one hour:
+
+```yaml
+scheduler_catch_up_grace_seconds: 3600
+```
+
+Set this to `0` to disable catch-up for unattempted occurrences.
+Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
+The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
+Normal future occurrences keep their original cron cadence.
+
+Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
+Before sending, MindRoom durably freezes its content and sending device.
+A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
+Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
+Already-triggered agent work continues through normal event recovery.
+If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
+
+The checkpoint directory must survive restarts.
+On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
+Cancelling a schedule still prevents its pending timer from firing.

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -161,6 +161,7 @@ On shutdown, the router cancels its in-memory scheduled tasks before exiting.
 
 Recurring timers save their next due time under the runtime storage directory in `tracking/recurring_schedules/`.
 After a restart, they wait for Matrix sync readiness and run the latest missed occurrence if it falls within the catch-up window.
+The same window applies when a live timer wakes late.
 The default window is one hour:
 
 ```yaml
@@ -168,17 +169,25 @@ scheduler_catch_up_grace_seconds: 3600
 ```
 
 Set this to `0` to disable catch-up for unattempted occurrences.
+Ordinary future timers still run when catch-up is disabled.
 Multiple missed occurrences coalesce into one run; older occurrences outside the window are skipped.
 The checkpoint retains the most recent skipped time and reason, and structured logs report skips and coalescing.
 Normal future occurrences keep their original cron cadence.
 
 Each trigger has a stable Matrix transaction ID derived from its schedule identity and intended execution time.
 Before sending, MindRoom durably freezes its content and sending device.
+Temporary checkpoint failures keep the timer alive and retry without repeating an acknowledged delivery.
 A retry reuses that content and transaction ID, so a restart after Matrix accepts a trigger does not create another trigger on the same device.
 Already-attempted deliveries remain pending until acknowledged, independently of the catch-up window.
 Already-triggered agent work continues through normal event recovery.
+Invalid content discovered before delivery is frozen fails the occurrence and advances the timer.
 If the Matrix login device changes while delivery is unresolved, automatic resending is held and logs report that reconciliation is needed.
 
 The checkpoint directory must survive restarts.
 On first adoption without a checkpoint, or after a workflow edit, MindRoom establishes a future cursor without replaying unknown past occurrences.
 Cancelling a schedule still prevents its pending timer from firing.
+Cancellation does not erase Matrix schedule history or local checkpoints.
+
+The trigger transaction does not make arbitrary `schedule:fired` hook side effects exactly-once.
+Hooks can replay after a crash or preparation failure before trigger content is durably frozen.
+Recurring hooks receive a `correlation_id` that is stable for that occurrence and changes for the next one; use it with an idempotent destination when performing side effects.

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -466,6 +466,11 @@ class Config(BaseModel):
         default="UTC",
         description="Timezone for interpreting scheduling requests and displaying scheduled tasks (e.g., 'America/New_York')",
     )
+    scheduler_catch_up_grace_seconds: int = Field(
+        default=3600,
+        ge=0,
+        description="Maximum lateness for recovering a missed recurring task; 0 disables catch-up",
+    )
     mindroom_user: MindRoomUserConfig | None = Field(
         default=None,
         description="Configuration for the internal MindRoom user account (omit for hosted/public profiles)",

--- a/src/mindroom/hooks/__init__.py
+++ b/src/mindroom/hooks/__init__.py
@@ -44,7 +44,7 @@ from .enrichment import render_enrichment_block, render_system_enrichment_block,
 from .execution import emit, emit_collect, emit_final_response_transform, emit_gate, emit_transform
 from .ingress import HookIngressPolicy, hook_ingress_policy
 from .registry import HookRegistry, HookRegistryPlugin, HookRegistryState
-from .sender import build_hook_message_sender, prepare_matrix_message, send_hook_message, send_matrix_message
+from .sender import build_hook_message_sender, send_hook_message, send_matrix_message
 from .state import build_hook_room_state_putter, build_hook_room_state_querier
 from .types import (
     BUILTIN_EVENT_NAMES,
@@ -165,7 +165,6 @@ __all__ = [
     "is_automation_source_kind",
     "is_voice_event",
     "iter_module_hooks",
-    "prepare_matrix_message",
     "render_enrichment_block",
     "render_system_enrichment_block",
     "render_transient_context",

--- a/src/mindroom/hooks/__init__.py
+++ b/src/mindroom/hooks/__init__.py
@@ -44,7 +44,7 @@ from .enrichment import render_enrichment_block, render_system_enrichment_block,
 from .execution import emit, emit_collect, emit_final_response_transform, emit_gate, emit_transform
 from .ingress import HookIngressPolicy, hook_ingress_policy
 from .registry import HookRegistry, HookRegistryPlugin, HookRegistryState
-from .sender import build_hook_message_sender, send_hook_message, send_matrix_message
+from .sender import build_hook_message_sender, prepare_matrix_message, send_hook_message, send_matrix_message
 from .state import build_hook_room_state_putter, build_hook_room_state_querier
 from .types import (
     BUILTIN_EVENT_NAMES,
@@ -165,6 +165,7 @@ __all__ = [
     "is_automation_source_kind",
     "is_voice_event",
     "iter_module_hooks",
+    "prepare_matrix_message",
     "render_enrichment_block",
     "render_system_enrichment_block",
     "render_transient_context",

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -17,18 +17,43 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_reads import ConversationReader
 
 
+async def prepare_matrix_message(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+) -> dict[str, Any]:
+    """Prepare transport content before freezing a durable delivery."""
+    # why-lazy: client_delivery imports config during hooks facade startup.
+    from mindroom.matrix.client_delivery import MatrixDeliveryFailure, prepare_message_content  # noqa: PLC0415
+
+    prepared = await prepare_message_content(client, room_id, content)
+    if isinstance(prepared, MatrixDeliveryFailure):
+        # The typed result reports a transport failure, not invalid input.
+        raise RuntimeError(prepared.detail)  # noqa: TRY004
+    return prepared
+
+
 async def send_matrix_message(
     client: nio.AsyncClient,
     room_id: str,
     content: dict[str, Any],
     *,
     message_type: str = "m.room.message",
+    transaction_id: str | None = None,
+    content_is_prepared: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Send already-built Matrix content, late-binding to avoid an import cycle."""
     # why-lazy: client_delivery imports config through Matrix formatting helpers during facade startup.
     from mindroom.matrix.client_delivery import send_message_result  # noqa: PLC0415
 
-    return await send_message_result(client, room_id, content, message_type=message_type)
+    return await send_message_result(
+        client,
+        room_id,
+        content,
+        message_type=message_type,
+        transaction_id=transaction_id,
+        content_is_prepared=content_is_prepared,
+    )
 
 
 async def send_hook_message(

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -17,36 +17,12 @@ if TYPE_CHECKING:
     from mindroom.matrix.conversation_reads import ConversationReader
 
 
-async def prepare_matrix_message(
-    client: nio.AsyncClient,
-    room_id: str,
-    content: dict[str, Any],
-) -> dict[str, Any]:
-    """Prepare transport content before freezing a durable delivery."""
-    # why-lazy: client_delivery imports config during hooks facade startup.
-    from mindroom.matrix.client_delivery import (  # noqa: PLC0415
-        MatrixDeliveryFailure,
-        MatrixDeliveryFailureKind,
-        prepare_message_content,
-    )
-
-    prepared = await prepare_message_content(client, room_id, content)
-    if isinstance(prepared, MatrixDeliveryFailure):
-        if prepared.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
-            raise ValueError(prepared.detail)
-        # The typed result reports a transport failure, not invalid input.
-        raise RuntimeError(prepared.detail)  # noqa: TRY004
-    return prepared
-
-
 async def send_matrix_message(
     client: nio.AsyncClient,
     room_id: str,
     content: dict[str, Any],
     *,
     message_type: str = "m.room.message",
-    transaction_id: str | None = None,
-    content_is_prepared: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Send already-built Matrix content, late-binding to avoid an import cycle."""
     # why-lazy: client_delivery imports config through Matrix formatting helpers during facade startup.
@@ -57,8 +33,6 @@ async def send_matrix_message(
         room_id,
         content,
         message_type=message_type,
-        transaction_id=transaction_id,
-        content_is_prepared=content_is_prepared,
     )
 
 

--- a/src/mindroom/hooks/sender.py
+++ b/src/mindroom/hooks/sender.py
@@ -24,10 +24,16 @@ async def prepare_matrix_message(
 ) -> dict[str, Any]:
     """Prepare transport content before freezing a durable delivery."""
     # why-lazy: client_delivery imports config during hooks facade startup.
-    from mindroom.matrix.client_delivery import MatrixDeliveryFailure, prepare_message_content  # noqa: PLC0415
+    from mindroom.matrix.client_delivery import (  # noqa: PLC0415
+        MatrixDeliveryFailure,
+        MatrixDeliveryFailureKind,
+        prepare_message_content,
+    )
 
     prepared = await prepare_message_content(client, room_id, content)
     if isinstance(prepared, MatrixDeliveryFailure):
+        if prepared.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+            raise ValueError(prepared.detail)
         # The typed result reports a transport failure, not invalid input.
         raise RuntimeError(prepared.detail)  # noqa: TRY004
     return prepared

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -413,6 +413,31 @@ async def _prepare_matrix_message(
     return _PreparedMatrixMessage(content_sent, cache_bypass)
 
 
+async def prepare_message_content(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+) -> dict[str, Any] | MatrixDeliveryFailure:
+    """Freeze content safe for delivery even if room encryption later turns on."""
+    encryption_outcome = await resolve_room_encryption_outcome(
+        client,
+        room_id,
+        operation="prepare_message",
+    )
+    if isinstance(encryption_outcome, MatrixDeliveryFailure):
+        return encryption_outcome
+    try:
+        return await prepare_large_message(
+            client,
+            room_id,
+            content,
+            room_encrypted=encryption_outcome,
+            prepare_for_encrypted_delivery=True,
+        )
+    except MatrixEventTooLargeError as error:
+        return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+
+
 async def send_message_outcome(
     client: nio.AsyncClient,
     room_id: str,
@@ -539,6 +564,7 @@ async def send_message_result(
     operation: str = "send_message",
     retry_sync_recovery: bool = False,
     transaction_id: str | None = None,
+    content_is_prepared: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Send a message to a Matrix room and return the exact delivered payload."""
     outcome = await send_message_outcome(
@@ -549,6 +575,7 @@ async def send_message_result(
         operation=operation,
         retry_sync_recovery=retry_sync_recovery,
         transaction_id=transaction_id,
+        content_is_prepared=content_is_prepared,
     )
     return outcome if isinstance(outcome, DeliveredMatrixEvent) else None
 
@@ -915,6 +942,7 @@ __all__ = [
     "can_send_to_encrypted_room",
     "edit_message_outcome",
     "edit_message_result",
+    "prepare_message_content",
     "resolve_room_encryption_for_delivery",
     "resolve_room_encryption_outcome",
     "send_audio_message",

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -451,8 +451,8 @@ async def send_message_outcome(
 ) -> MatrixSendOutcome:
     """Send a message to a Matrix room and return the delivered payload or a typed failure.
 
-    ``content_is_prepared`` is reserved for durable payloads already frozen in
-    the outbox. Those bytes must reach Matrix verbatim so the durable record
+    ``content_is_prepared`` is reserved for payloads already frozen in
+    durable storage. Those bytes must reach Matrix verbatim so the durable record
     remains an exact description of the wire event.
     """
     if not _can_send_to_encrypted_room(client, room_id, operation=operation):
@@ -564,7 +564,6 @@ async def send_message_result(
     operation: str = "send_message",
     retry_sync_recovery: bool = False,
     transaction_id: str | None = None,
-    content_is_prepared: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Send a message to a Matrix room and return the exact delivered payload."""
     outcome = await send_message_outcome(
@@ -575,7 +574,6 @@ async def send_message_result(
         operation=operation,
         retry_sync_recovery=retry_sync_recovery,
         transaction_id=transaction_id,
-        content_is_prepared=content_is_prepared,
     )
     return outcome if isinstance(outcome, DeliveredMatrixEvent) else None
 

--- a/src/mindroom/recurring_schedule.py
+++ b/src/mindroom/recurring_schedule.py
@@ -1,0 +1,188 @@
+"""Durable checkpoints for recurring task timers and their pending Matrix trigger."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta
+from functools import partial
+from typing import TYPE_CHECKING, Any, Literal
+
+from croniter import croniter
+from pydantic import TypeAdapter
+
+from mindroom.background_tasks import run_blocking_until_complete
+from mindroom.durable_write import create_directory_durable, write_json_file_durable
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class _PreparedRecurringDelivery:
+    """Freeze content and the device whose Matrix transaction namespace owns it."""
+
+    content: dict[str, Any]
+    device_id: str
+
+
+@dataclass(frozen=True)
+class _RecurringCheckpoint:
+    """One timer cursor, with at most one unacknowledged trigger."""
+
+    workflow_key: str
+    next_run_at: datetime
+    prepared: _PreparedRecurringDelivery | None = None
+    last_skipped_at: datetime | None = None
+    skip_reason: str | None = None
+    schema_version: Literal[1] = 1
+
+
+_CHECKPOINT_ADAPTER = TypeAdapter(_RecurringCheckpoint)
+
+
+@dataclass(frozen=True)
+class RecurringOccurrence:
+    """One persisted occurrence carried from its timer into Matrix delivery."""
+
+    path: Path
+    checkpoint: _RecurringCheckpoint
+
+    @property
+    def transaction_id(self) -> str:
+        """Identify the schedule and intended time independently of retry time."""
+        identity = f"{self.path.stem}:{self.checkpoint.next_run_at.isoformat()}"
+        return f"schedule_{hashlib.sha256(identity.encode()).hexdigest()}"
+
+
+def _save(path: Path, checkpoint: _RecurringCheckpoint) -> None:
+    create_directory_durable(path.parent, mode=0o700)
+    write_json_file_durable(
+        path,
+        _CHECKPOINT_ADAPTER.dump_python(checkpoint, mode="json"),
+        strict_atomic_replace=True,
+    )
+
+
+def _plan(
+    path: Path,
+    workflow_key: str,
+    cron: str,
+    now: datetime,
+    grace_seconds: int,
+) -> RecurringOccurrence:
+    checkpoint = _CHECKPOINT_ADAPTER.validate_json(path.read_bytes()) if path.exists() else None
+    if checkpoint is not None and checkpoint.next_run_at.tzinfo is None:
+        msg = "Recurring checkpoint requires an aware next_run_at"
+        raise ValueError(msg)
+    if checkpoint is None or checkpoint.workflow_key != workflow_key:
+        # First adoption and edits establish a future cursor. We cannot prove
+        # whether the old runtime fired an earlier occurrence.
+        checkpoint = _RecurringCheckpoint(workflow_key, croniter(cron, now).get_next(datetime))
+        _save(path, checkpoint)
+    elif checkpoint.prepared is None and checkpoint.next_run_at <= now:
+        # Coalesce downtime to its latest occurrence, including an exact cron boundary.
+        latest = croniter(cron, now + timedelta(microseconds=1)).get_prev(datetime)
+        if (now - latest).total_seconds() > grace_seconds:
+            checkpoint = replace(
+                checkpoint,
+                next_run_at=croniter(cron, now).get_next(datetime),
+                last_skipped_at=latest,
+                skip_reason="outside catch-up grace window",
+            )
+            _save(path, checkpoint)
+            logger.warning(
+                "recurring_schedule_skipped",
+                scheduled_at=latest.isoformat(),
+                reason=checkpoint.skip_reason,
+            )
+        elif latest > checkpoint.next_run_at:
+            skipped_at = croniter(cron, latest).get_prev(datetime)
+            checkpoint = replace(
+                checkpoint,
+                next_run_at=latest,
+                last_skipped_at=skipped_at,
+                skip_reason="coalesced missed occurrences into latest run",
+            )
+            _save(path, checkpoint)
+            logger.info(
+                "recurring_schedule_coalesced",
+                scheduled_at=latest.isoformat(),
+                skipped_through=skipped_at.isoformat(),
+            )
+    return RecurringOccurrence(path, checkpoint)
+
+
+async def plan_recurring_occurrence(
+    runtime_paths: RuntimePaths,
+    *,
+    homeserver: str,
+    sender: str,
+    room_id: str,
+    task_id: str,
+    workflow_json: str,
+    cron: str,
+    now: datetime,
+    grace_seconds: int,
+) -> RecurringOccurrence:
+    """Load or advance a timer without losing a previously attempted trigger."""
+    identity = json.dumps([homeserver, sender, room_id, task_id])
+    name = hashlib.sha256(identity.encode()).hexdigest()
+    path = runtime_paths.storage_root / "tracking" / "recurring_schedules" / f"{name}.json"
+    workflow_key = hashlib.sha256(workflow_json.encode()).hexdigest()
+    return await run_blocking_until_complete(partial(_plan, path, workflow_key, cron, now, grace_seconds))
+
+
+async def prepare_recurring_delivery(
+    occurrence: RecurringOccurrence,
+    content: dict[str, Any],
+    device_id: str | None,
+) -> None:
+    """Commit the exact trigger before the first network attempt."""
+    if not device_id:
+        msg = "Recurring delivery requires an authenticated Matrix device"
+        raise ValueError(msg)
+    checkpoint = replace(occurrence.checkpoint, prepared=_PreparedRecurringDelivery(content, device_id))
+    await run_blocking_until_complete(partial(_save, occurrence.path, checkpoint))
+
+
+def recurring_delivery_content(occurrence: RecurringOccurrence, device_id: str | None) -> dict[str, Any] | None:
+    """Resume frozen content only while Matrix can deduplicate its transaction."""
+    prepared = occurrence.checkpoint.prepared
+    if prepared is None:
+        return None
+    if prepared.device_id != device_id:
+        msg = "Pending recurring trigger belongs to another Matrix device; delivery needs reconciliation"
+        raise ValueError(msg)
+    return prepared.content
+
+
+async def complete_recurring_occurrence(occurrence: RecurringOccurrence, cron: str, now: datetime) -> None:
+    """Advance only after delivery or an intentional hook suppression."""
+    completed_at = max(now, occurrence.checkpoint.next_run_at)
+    latest = croniter(cron, completed_at + timedelta(microseconds=1)).get_prev(datetime)
+    checkpoint = replace(
+        occurrence.checkpoint,
+        next_run_at=croniter(cron, completed_at).get_next(datetime),
+        prepared=None,
+    )
+    if latest > occurrence.checkpoint.next_run_at:
+        checkpoint = replace(
+            checkpoint,
+            last_skipped_at=latest,
+            skip_reason="coalesced while previous trigger was pending",
+        )
+    await run_blocking_until_complete(partial(_save, occurrence.path, checkpoint))
+    if latest > occurrence.checkpoint.next_run_at:
+        logger.info(
+            "recurring_schedule_coalesced",
+            scheduled_at=occurrence.checkpoint.next_run_at.isoformat(),
+            skipped_through=checkpoint.last_skipped_at,
+            reason=checkpoint.skip_reason,
+        )

--- a/src/mindroom/recurring_schedule.py
+++ b/src/mindroom/recurring_schedule.py
@@ -31,6 +31,10 @@ class _CheckpointValidationError(ValueError):
     """A persisted cursor cannot safely be used until its storage is repaired."""
 
 
+class RecurringDeliveryHeldError(RuntimeError):
+    """A frozen trigger needs reconciliation before this device can resume it."""
+
+
 class RecurringCheckpointUnavailableError(RuntimeError):
     """The scheduler must refresh time and task state before retrying preparation."""
 
@@ -173,13 +177,14 @@ async def prepare_recurring_delivery(
     occurrence: RecurringOccurrence,
     content: dict[str, Any],
     device_id: str | None,
-) -> None:
-    """Commit the exact trigger before the first network attempt."""
+) -> RecurringOccurrence:
+    """Commit the exact trigger and return the saved state before any network attempt."""
     if not device_id:
         msg = "Recurring delivery requires an authenticated Matrix device"
         raise RuntimeError(msg)
     checkpoint = replace(occurrence.checkpoint, prepared=_PreparedRecurringDelivery(content, device_id))
     await _checkpoint_operation(partial(_save, occurrence.path, checkpoint))
+    return replace(occurrence, checkpoint=checkpoint)
 
 
 def recurring_delivery_content(occurrence: RecurringOccurrence, device_id: str | None) -> dict[str, Any] | None:
@@ -189,12 +194,12 @@ def recurring_delivery_content(occurrence: RecurringOccurrence, device_id: str |
         return None
     if prepared.device_id != device_id:
         msg = "Pending recurring trigger belongs to another Matrix device; delivery needs reconciliation"
-        raise ValueError(msg)
+        raise RecurringDeliveryHeldError(msg)
     return prepared.content
 
 
 async def complete_recurring_occurrence(occurrence: RecurringOccurrence, cron: str, now: datetime) -> None:
-    """Advance only after delivery or an intentional hook suppression."""
+    """Advance after delivery, hook suppression, or a terminal preparation failure."""
     completed_at = max(now, occurrence.checkpoint.next_run_at)
     latest = croniter(cron, completed_at + timedelta(microseconds=1)).get_prev(datetime)
     checkpoint = replace(

--- a/src/mindroom/recurring_schedule.py
+++ b/src/mindroom/recurring_schedule.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 from dataclasses import dataclass, replace
@@ -10,18 +11,47 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, Literal
 
 from croniter import croniter
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from mindroom.background_tasks import run_blocking_until_complete
 from mindroom.durable_write import create_directory_durable, write_json_file_durable
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
 
 logger = get_logger(__name__)
+_CHECKPOINT_RETRY_SECONDS = 30
+
+
+class _CheckpointValidationError(ValueError):
+    """A persisted cursor cannot safely be used until its storage is repaired."""
+
+
+class RecurringCheckpointUnavailableError(RuntimeError):
+    """The scheduler must refresh time and task state before retrying preparation."""
+
+
+async def _checkpoint_operation[Result](operation: Callable[[], Result]) -> Result:
+    """Expose storage failures separately from invalid schedule definitions."""
+    try:
+        return await run_blocking_until_complete(operation)
+    except (OSError, ValidationError, _CheckpointValidationError) as error:
+        logger.exception("recurring_checkpoint_unavailable")
+        msg = "Recurring checkpoint is unavailable"
+        raise RecurringCheckpointUnavailableError(msg) from error
+
+
+async def _retry_checkpoint_operation[Result](operation: Callable[[], Result]) -> Result:
+    """Retry acknowledgement writes in place so delivered triggers are never resent."""
+    while True:
+        try:
+            return await _checkpoint_operation(operation)
+        except RecurringCheckpointUnavailableError:
+            await asyncio.sleep(_CHECKPOINT_RETRY_SECONDS)
 
 
 @dataclass(frozen=True)
@@ -80,7 +110,7 @@ def _plan(
     checkpoint = _CHECKPOINT_ADAPTER.validate_json(path.read_bytes()) if path.exists() else None
     if checkpoint is not None and checkpoint.next_run_at.tzinfo is None:
         msg = "Recurring checkpoint requires an aware next_run_at"
-        raise ValueError(msg)
+        raise _CheckpointValidationError(msg)
     if checkpoint is None or checkpoint.workflow_key != workflow_key:
         # First adoption and edits establish a future cursor. We cannot prove
         # whether the old runtime fired an earlier occurrence.
@@ -136,7 +166,7 @@ async def plan_recurring_occurrence(
     name = hashlib.sha256(identity.encode()).hexdigest()
     path = runtime_paths.storage_root / "tracking" / "recurring_schedules" / f"{name}.json"
     workflow_key = hashlib.sha256(workflow_json.encode()).hexdigest()
-    return await run_blocking_until_complete(partial(_plan, path, workflow_key, cron, now, grace_seconds))
+    return await _checkpoint_operation(partial(_plan, path, workflow_key, cron, now, grace_seconds))
 
 
 async def prepare_recurring_delivery(
@@ -147,9 +177,9 @@ async def prepare_recurring_delivery(
     """Commit the exact trigger before the first network attempt."""
     if not device_id:
         msg = "Recurring delivery requires an authenticated Matrix device"
-        raise ValueError(msg)
+        raise RuntimeError(msg)
     checkpoint = replace(occurrence.checkpoint, prepared=_PreparedRecurringDelivery(content, device_id))
-    await run_blocking_until_complete(partial(_save, occurrence.path, checkpoint))
+    await _checkpoint_operation(partial(_save, occurrence.path, checkpoint))
 
 
 def recurring_delivery_content(occurrence: RecurringOccurrence, device_id: str | None) -> dict[str, Any] | None:
@@ -178,11 +208,12 @@ async def complete_recurring_occurrence(occurrence: RecurringOccurrence, cron: s
             last_skipped_at=latest,
             skip_reason="coalesced while previous trigger was pending",
         )
-    await run_blocking_until_complete(partial(_save, occurrence.path, checkpoint))
+    await _retry_checkpoint_operation(partial(_save, occurrence.path, checkpoint))
     if latest > occurrence.checkpoint.next_run_at:
+        assert checkpoint.last_skipped_at is not None
         logger.info(
             "recurring_schedule_coalesced",
             scheduled_at=occurrence.checkpoint.next_run_at.isoformat(),
-            skipped_through=checkpoint.last_skipped_at,
+            skipped_through=checkpoint.last_skipped_at.isoformat(),
             reason=checkpoint.skip_reason,
         )

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -9,6 +9,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from functools import partial
 from typing import TYPE_CHECKING, Literal, NamedTuple
 from zoneinfo import ZoneInfo
 
@@ -27,6 +28,7 @@ from mindroom.matrix.conversation_reads import complete_thread_history
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import parse_mentions_in_text
 from mindroom.message_target import MessageTarget
+from mindroom.recurring_schedule import complete_recurring_occurrence, plan_recurring_occurrence
 from mindroom.thread_utils import filter_thread_agents_for_sender, get_agents_in_thread
 
 if TYPE_CHECKING:
@@ -56,7 +58,7 @@ _TASK_STATE_POLL_INTERVAL_SECONDS = 30
 # Tasks older than this are marked as failed instead of executed.
 _MISSED_TASK_MAX_AGE_SECONDS = 86400  # 24 hours
 
-# Small pause between draining overdue one-time tasks after sync is ready.
+# Small pause between draining restored tasks after sync is ready.
 _DEFERRED_OVERDUE_TASK_START_DELAY_SECONDS = 0.25
 
 # Global task storage for running asyncio tasks
@@ -198,7 +200,7 @@ class SchedulingRuntime:
 
 @dataclass
 class _DeferredOverdueTaskStart:
-    """A one-time scheduled task that should start after Matrix sync is live."""
+    """A scheduled task that should start after Matrix sync is live."""
 
     task_id: str
     workflow: ScheduledWorkflow
@@ -472,7 +474,7 @@ def _start_scheduled_task(
 
 
 def _queue_deferred_overdue_task(task_id: str, workflow: ScheduledWorkflow) -> bool:
-    """Queue one missed one-time task to be started after Matrix sync is ready."""
+    """Queue one restored task to be started after Matrix sync is ready."""
     existing_task = _running_tasks.get(task_id)
     if existing_task is not None and not existing_task.done():
         logger.debug("Scheduled task already running; skipping deferred queue", task_id=task_id)
@@ -493,7 +495,7 @@ async def drain_deferred_overdue_tasks(
     runtime_paths: RuntimePaths,
     conversation_reader: ConversationReader,
 ) -> int:
-    """Start queued overdue one-time tasks after Matrix sync is ready."""
+    """Start queued restored tasks after Matrix sync is ready."""
     drained_count = 0
     matrix_admin = build_hook_matrix_admin(client, runtime_paths)
 
@@ -528,7 +530,7 @@ async def drain_deferred_overdue_tasks(
 
 
 def clear_deferred_overdue_tasks() -> int:
-    """Clear queued overdue one-time tasks that have not started yet."""
+    """Clear queued restored tasks that have not started yet."""
     queued_count = len(_deferred_overdue_tasks)
     _deferred_overdue_tasks.clear()
     _deferred_overdue_task_ids.clear()
@@ -536,7 +538,7 @@ def clear_deferred_overdue_tasks() -> int:
 
 
 def has_deferred_overdue_tasks() -> bool:
-    """Return whether any overdue one-time tasks are still queued."""
+    """Return whether any restored tasks are still queued."""
     return bool(_deferred_overdue_tasks)
 
 
@@ -1025,7 +1027,19 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     return
 
                 cron_string = cron_schedule.to_cron_string()
-                next_run = croniter(cron_string, datetime.now(UTC)).get_next(datetime)
+                plan_occurrence = partial(
+                    plan_recurring_occurrence,
+                    runtime_paths,
+                    homeserver=client.homeserver,
+                    sender=client.user_id,
+                    room_id=task_room_id,
+                    task_id=task_id,
+                    workflow_json=workflow.model_dump_json(),
+                    cron=cron_string,
+                    grace_seconds=config.scheduler_catch_up_grace_seconds,
+                )
+                occurrence = await plan_occurrence(now=datetime.now(UTC))
+                next_run = occurrence.checkpoint.next_run_at
                 workflow_changed = False
 
                 while True:
@@ -1075,7 +1089,15 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     current_target = MessageTarget.for_scheduled_task(workflow)
                     continue
 
-                await scheduling_executor.execute_scheduled_workflow(
+                # A timer or state read may have stalled across more due slots.
+                # Cron has second precision; normal subsecond wake-up jitter
+                # must still fire a live timer when catch-up is disabled.
+                execute_now = datetime.now(UTC).replace(microsecond=0)
+                occurrence = await plan_occurrence(now=execute_now)
+                if occurrence.checkpoint.next_run_at > execute_now:
+                    continue
+
+                outcome = await scheduling_executor.execute_scheduled_workflow(
                     client,
                     workflow,
                     config,
@@ -1083,7 +1105,12 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     conversation_reader,
                     task_id,
                     matrix_admin,
+                    occurrence=occurrence,
                 )
+                if outcome.retryable:
+                    await asyncio.sleep(_TASK_STATE_POLL_INTERVAL_SECONDS)
+                    continue
+                await complete_recurring_occurrence(occurrence, cron_string, datetime.now(UTC))
                 if task_id not in running_tasks:
                     logger.info("scheduled_task_missing_from_running_tasks", task_id=task_id)
                     return
@@ -1732,7 +1759,7 @@ async def cancel_all_scheduled_tasks(
     return result
 
 
-async def restore_scheduled_tasks(  # noqa: C901
+async def restore_scheduled_tasks(  # noqa: C901, PLR0912
     client: nio.AsyncClient,
     room_id: str,
     config: Config,
@@ -1792,6 +1819,10 @@ async def restore_scheduled_tasks(  # noqa: C901
                 continue
         elif workflow.schedule_type == "cron" and not workflow.cron_schedule:
             logger.warning("skipping_recurring_task_without_cron_schedule", task_id=task_id)
+            continue
+        elif workflow.schedule_type == "cron":
+            if _queue_deferred_overdue_task(task_id, workflow):
+                restored_count += 1
             continue
 
         # Start the appropriate task

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -1119,7 +1119,7 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     matrix_admin,
                     occurrence=occurrence,
                 )
-                if outcome.retryable:
+                if outcome.status in {"retry", "held"}:
                     await asyncio.sleep(_TASK_STATE_POLL_INTERVAL_SECONDS)
                     continue
                 await complete_recurring_occurrence(occurrence, cron_string, datetime.now(UTC))
@@ -1217,7 +1217,7 @@ async def _run_once_task(  # noqa: C901, PLR0912, PLR0915
                 task_id,
                 matrix_admin,
             )
-            final_status = "completed" if outcome.delivered else "failed"
+            final_status = "completed" if outcome.status == "delivered" else "failed"
 
             try:
                 await _save_one_time_task_status(

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -28,7 +28,11 @@ from mindroom.matrix.conversation_reads import complete_thread_history
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.mentions import parse_mentions_in_text
 from mindroom.message_target import MessageTarget
-from mindroom.recurring_schedule import complete_recurring_occurrence, plan_recurring_occurrence
+from mindroom.recurring_schedule import (
+    RecurringCheckpointUnavailableError,
+    complete_recurring_occurrence,
+    plan_recurring_occurrence,
+)
 from mindroom.thread_utils import filter_thread_agents_for_sender, get_agents_in_thread
 
 if TYPE_CHECKING:
@@ -1038,7 +1042,11 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     cron=cron_string,
                     grace_seconds=config.scheduler_catch_up_grace_seconds,
                 )
-                occurrence = await plan_occurrence(now=datetime.now(UTC))
+                try:
+                    occurrence = await plan_occurrence(now=datetime.now(UTC))
+                except RecurringCheckpointUnavailableError:
+                    await asyncio.sleep(_TASK_STATE_POLL_INTERVAL_SECONDS)
+                    continue
                 next_run = occurrence.checkpoint.next_run_at
                 workflow_changed = False
 
@@ -1093,7 +1101,11 @@ async def _run_cron_task(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 # Cron has second precision; normal subsecond wake-up jitter
                 # must still fire a live timer when catch-up is disabled.
                 execute_now = datetime.now(UTC).replace(microsecond=0)
-                occurrence = await plan_occurrence(now=execute_now)
+                try:
+                    occurrence = await plan_occurrence(now=execute_now)
+                except RecurringCheckpointUnavailableError:
+                    await asyncio.sleep(_TASK_STATE_POLL_INTERVAL_SECONDS)
+                    continue
                 if occurrence.checkpoint.next_run_at > execute_now:
                     continue
 

--- a/src/mindroom/scheduling_executor.py
+++ b/src/mindroom/scheduling_executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import typing
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
@@ -23,14 +23,17 @@ from mindroom.hooks import (
     build_hook_room_state_putter,
     build_hook_room_state_querier,
     emit,
-    prepare_matrix_message,
-    send_matrix_message,
 )
 from mindroom.logging_config import bound_log_context, get_logger
+from mindroom.matrix import client_delivery
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.message_target import MessageTarget
-from mindroom.recurring_schedule import prepare_recurring_delivery, recurring_delivery_content
+from mindroom.recurring_schedule import (
+    RecurringDeliveryHeldError,
+    prepare_recurring_delivery,
+    recurring_delivery_content,
+)
 
 if TYPE_CHECKING:
     import nio
@@ -56,22 +59,19 @@ def set_scheduling_hook_registry(hook_registry: HookRegistry) -> None:
 class ScheduledWorkflowOutcome:
     """Typed result of firing one scheduled workflow."""
 
-    delivered: bool
+    status: Literal["delivered", "suppressed", "failed", "retry", "held"]
     failure_reason: str | None = None
-    retryable: bool = False
 
 
-def _raise_scheduled_workflow_send_error() -> typing.NoReturn:
-    """Raise when a scheduled workflow message cannot be sent."""
-    msg = "Failed to send scheduled workflow message to Matrix"
-    raise RuntimeError(msg)
+class _InvalidScheduledTriggerError(ValueError):
+    """The authored trigger cannot be delivered for this occurrence."""
 
 
 def _validate_scheduled_workflow_message(message_text: str) -> None:
     """Reject an empty trigger body before Matrix accepts it as delivered."""
     if not message_text.strip():
         msg = "Scheduled workflow message is empty after hooks"
-        raise ValueError(msg)
+        raise _InvalidScheduledTriggerError(msg)
 
 
 async def _build_workflow_message_content(
@@ -145,14 +145,14 @@ async def send_scheduled_failure_notice(
         error_message,
         conversation_reader,
     )
-    await send_matrix_message(client, workflow.room_id, error_content)
+    await client_delivery.send_message_outcome(client, workflow.room_id, error_content)
 
 
 async def _notify_scheduled_workflow_failure(
     client: nio.AsyncClient,
     workflow: ScheduledWorkflow,
     target: MessageTarget,
-    error: Exception,
+    error: str,
     conversation_reader: ConversationReader,
 ) -> None:
     """Send the visible failure notice for one scheduled workflow when possible."""
@@ -166,7 +166,7 @@ async def _notify_scheduled_workflow_failure(
         conversation_reader,
     )
     try:
-        await send_matrix_message(client, workflow.room_id, error_content)
+        await client_delivery.send_message_outcome(client, workflow.room_id, error_content)
     except Exception:
         logger.exception("Failed to send scheduled workflow failure message")
 
@@ -237,6 +237,49 @@ async def _prepare_scheduled_trigger(
     return content
 
 
+async def _deliver_scheduled_trigger(
+    client: nio.AsyncClient,
+    workflow: ScheduledWorkflow,
+    content: dict[str, typing.Any],
+    occurrence: RecurringOccurrence | None,
+) -> ScheduledWorkflowOutcome:
+    """Freeze recurring content before sending and classify the typed Matrix result."""
+    assert workflow.room_id is not None
+    if occurrence is not None and occurrence.checkpoint.prepared is None:
+        prepared = await client_delivery.prepare_message_content(client, workflow.room_id, content)
+        if isinstance(prepared, client_delivery.MatrixDeliveryFailure):
+            status = (
+                "failed" if prepared.kind is client_delivery.MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE else "retry"
+            )
+            return ScheduledWorkflowOutcome(status=status, failure_reason=prepared.detail)
+        occurrence = await prepare_recurring_delivery(occurrence, prepared, client.device_id)
+        assert occurrence.checkpoint.prepared is not None
+        content = occurrence.checkpoint.prepared.content
+
+    delivered = await client_delivery.send_message_outcome(
+        client,
+        workflow.room_id,
+        content,
+        message_type=SILENT_SCHEDULE_EVENT_TYPE if workflow.silent else "m.room.message",
+        transaction_id=occurrence.transaction_id if occurrence is not None else None,
+        content_is_prepared=occurrence is not None,
+    )
+    if isinstance(delivered, client_delivery.MatrixDeliveryFailure):
+        # Once frozen, keep the trigger even if a later send rejects its content.
+        return ScheduledWorkflowOutcome(
+            status="retry" if occurrence is not None else "failed",
+            failure_reason=delivered.detail,
+        )
+    logger.info(
+        "Executed scheduled workflow",
+        description=workflow.description,
+        thread_id=MessageTarget.for_scheduled_task(workflow).resolved_thread_id,
+        new_thread=workflow.new_thread,
+        event_id=delivered.event_id,
+    )
+    return ScheduledWorkflowOutcome(status="delivered")
+
+
 async def execute_scheduled_workflow(
     client: nio.AsyncClient,
     workflow: ScheduledWorkflow,
@@ -251,14 +294,13 @@ async def execute_scheduled_workflow(
     """Execute a scheduled workflow by posting its message to the thread."""
     if not workflow.room_id:
         logger.error("Cannot execute workflow without room_id")
-        return ScheduledWorkflowOutcome(delivered=False, failure_reason="missing room_id")
+        return ScheduledWorkflowOutcome(status="failed", failure_reason="missing room_id")
 
     target = MessageTarget.for_scheduled_task(
         workflow,
     )
 
     with bound_log_context(**target.log_context):
-        delivery_prepared = occurrence is not None and occurrence.checkpoint.prepared is not None
         try:
             content = recurring_delivery_content(occurrence, client.device_id) if occurrence is not None else None
             if content is None:
@@ -274,43 +316,32 @@ async def execute_scheduled_workflow(
                     f"{EVENT_SCHEDULE_FIRED}:{occurrence.transaction_id if occurrence is not None else task_id}",
                 )
                 if content is None:
-                    return ScheduledWorkflowOutcome(delivered=False, failure_reason="suppressed by hook")
-                if occurrence is not None:
-                    content = await prepare_matrix_message(client, workflow.room_id, content)
-                    await prepare_recurring_delivery(occurrence, content, client.device_id)
-                    delivery_prepared = True
-            delivery_kwargs: dict[str, typing.Any] = {
-                "message_type": SILENT_SCHEDULE_EVENT_TYPE if workflow.silent else "m.room.message",
-            }
-            if occurrence is not None:
-                delivery_kwargs["transaction_id"] = occurrence.transaction_id
-                delivery_kwargs["content_is_prepared"] = True
-            delivered = await send_matrix_message(
-                client,
-                workflow.room_id,
-                content,
-                **delivery_kwargs,
-            )
-            if delivered is None:
-                _raise_scheduled_workflow_send_error()
-            logger.info(
-                "Executed scheduled workflow",
-                description=workflow.description,
-                thread_id=target.resolved_thread_id,
-                new_thread=workflow.new_thread,
-                event_id=delivered.event_id,
-            )
-        except Exception as e:
+                    return ScheduledWorkflowOutcome(status="suppressed", failure_reason="suppressed by hook")
+            outcome = await _deliver_scheduled_trigger(client, workflow, content, occurrence)
+        except _InvalidScheduledTriggerError as error:
+            outcome = ScheduledWorkflowOutcome(status="failed", failure_reason=str(error))
+        except RecurringDeliveryHeldError as error:
+            outcome = ScheduledWorkflowOutcome(status="held", failure_reason=str(error))
+        except Exception as error:
             logger.exception("Failed to execute scheduled workflow")
-            retryable = occurrence is not None and (delivery_prepared or not isinstance(e, ValueError))
-            if not retryable:
-                await _notify_scheduled_workflow_failure(
-                    client,
-                    workflow,
-                    target,
-                    e,
-                    conversation_reader,
-                )
-            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e), retryable=retryable)
-        else:
-            return ScheduledWorkflowOutcome(delivered=True)
+            outcome = ScheduledWorkflowOutcome(
+                status="retry" if occurrence is not None else "failed",
+                failure_reason=str(error),
+            )
+        if outcome.status in {"retry", "held"}:
+            logger.warning(
+                "Recurring delivery remains pending",
+                task_id=task_id,
+                status=outcome.status,
+                reason=outcome.failure_reason,
+            )
+        if outcome.status == "failed":
+            assert outcome.failure_reason is not None
+            await _notify_scheduled_workflow_failure(
+                client,
+                workflow,
+                target,
+                outcome.failure_reason,
+                conversation_reader,
+            )
+        return outcome

--- a/src/mindroom/scheduling_executor.py
+++ b/src/mindroom/scheduling_executor.py
@@ -180,8 +180,9 @@ async def _prepare_scheduled_trigger(
     task_id: str,
     matrix_admin: HookMatrixAdmin | None,
     target: MessageTarget,
+    correlation_id: str,
 ) -> dict[str, typing.Any] | None:
-    """Run hooks and build content once, before a recurring delivery is frozen."""
+    """Run hooks and build content before a recurring delivery is frozen."""
     assert workflow.room_id is not None
     message_text = workflow.message
     hook_registry = _SCHEDULING_HOOK_REGISTRY_STATE.registry
@@ -193,7 +194,7 @@ async def _prepare_scheduled_trigger(
             config=config,
             runtime_paths=runtime_paths,
             logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
-            correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
+            correlation_id=correlation_id,
             message_sender=build_hook_message_sender(
                 client,
                 config,
@@ -257,6 +258,7 @@ async def execute_scheduled_workflow(
     )
 
     with bound_log_context(**target.log_context):
+        delivery_prepared = occurrence is not None and occurrence.checkpoint.prepared is not None
         try:
             content = recurring_delivery_content(occurrence, client.device_id) if occurrence is not None else None
             if content is None:
@@ -269,12 +271,14 @@ async def execute_scheduled_workflow(
                     task_id,
                     matrix_admin,
                     target,
+                    f"{EVENT_SCHEDULE_FIRED}:{occurrence.transaction_id if occurrence is not None else task_id}",
                 )
                 if content is None:
                     return ScheduledWorkflowOutcome(delivered=False, failure_reason="suppressed by hook")
                 if occurrence is not None:
                     content = await prepare_matrix_message(client, workflow.room_id, content)
                     await prepare_recurring_delivery(occurrence, content, client.device_id)
+                    delivery_prepared = True
             delivery_kwargs: dict[str, typing.Any] = {
                 "message_type": SILENT_SCHEDULE_EVENT_TYPE if workflow.silent else "m.room.message",
             }
@@ -298,7 +302,8 @@ async def execute_scheduled_workflow(
             )
         except Exception as e:
             logger.exception("Failed to execute scheduled workflow")
-            if occurrence is None:
+            retryable = occurrence is not None and (delivery_prepared or not isinstance(e, ValueError))
+            if not retryable:
                 await _notify_scheduled_workflow_failure(
                     client,
                     workflow,
@@ -306,6 +311,6 @@ async def execute_scheduled_workflow(
                     e,
                     conversation_reader,
                 )
-            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e), retryable=occurrence is not None)
+            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e), retryable=retryable)
         else:
             return ScheduledWorkflowOutcome(delivered=True)

--- a/src/mindroom/scheduling_executor.py
+++ b/src/mindroom/scheduling_executor.py
@@ -23,12 +23,14 @@ from mindroom.hooks import (
     build_hook_room_state_putter,
     build_hook_room_state_querier,
     emit,
+    prepare_matrix_message,
     send_matrix_message,
 )
 from mindroom.logging_config import bound_log_context, get_logger
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.message_target import MessageTarget
+from mindroom.recurring_schedule import prepare_recurring_delivery, recurring_delivery_content
 
 if TYPE_CHECKING:
     import nio
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.hooks import HookMatrixAdmin
     from mindroom.matrix.conversation_reads import ConversationReader
+    from mindroom.recurring_schedule import RecurringOccurrence
     from mindroom.scheduling import ScheduledWorkflow
 
 logger = get_logger(__name__)
@@ -55,6 +58,7 @@ class ScheduledWorkflowOutcome:
 
     delivered: bool
     failure_reason: str | None = None
+    retryable: bool = False
 
 
 def _raise_scheduled_workflow_send_error() -> typing.NoReturn:
@@ -167,6 +171,71 @@ async def _notify_scheduled_workflow_failure(
         logger.exception("Failed to send scheduled workflow failure message")
 
 
+async def _prepare_scheduled_trigger(
+    client: nio.AsyncClient,
+    workflow: ScheduledWorkflow,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    conversation_reader: ConversationReader,
+    task_id: str,
+    matrix_admin: HookMatrixAdmin | None,
+    target: MessageTarget,
+) -> dict[str, typing.Any] | None:
+    """Run hooks and build content once, before a recurring delivery is frozen."""
+    assert workflow.room_id is not None
+    message_text = workflow.message
+    hook_registry = _SCHEDULING_HOOK_REGISTRY_STATE.registry
+    if hook_registry.has_hooks(EVENT_SCHEDULE_FIRED):
+        context = ScheduleFiredContext(
+            event_name=EVENT_SCHEDULE_FIRED,
+            plugin_name="",
+            settings={},
+            config=config,
+            runtime_paths=runtime_paths,
+            logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
+            correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
+            message_sender=build_hook_message_sender(
+                client,
+                config,
+                runtime_paths,
+                conversation_reader=conversation_reader,
+            ),
+            matrix_admin=matrix_admin,
+            room_state_querier=build_hook_room_state_querier(client),
+            room_state_putter=build_hook_room_state_putter(client),
+            task_id=task_id,
+            workflow=workflow,
+            room_id=workflow.room_id,
+            thread_id=target.resolved_thread_id,
+            created_by=workflow.created_by,
+            message_text=message_text,
+            _hook_registry_state=_SCHEDULING_HOOK_REGISTRY_STATE,
+        )
+        await emit(hook_registry, EVENT_SCHEDULE_FIRED, context)
+        if context.suppress:
+            logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
+            return None
+        message_text = context.message_text
+
+    _validate_scheduled_workflow_message(message_text)
+    content = await _build_workflow_message_content(
+        workflow,
+        target,
+        config,
+        runtime_paths,
+        message_text,
+        conversation_reader,
+    )
+    if workflow.created_by:
+        content[ORIGINAL_SENDER_KEY] = workflow.created_by
+    content[SOURCE_KIND_KEY] = SILENT_SCHEDULE_SOURCE_KIND if workflow.silent else SCHEDULED_SOURCE_KIND
+    if workflow.new_thread and not workflow.silent:
+        content[PER_FIRE_THREAD_ROOT_KEY] = True
+    if workflow.history_limit is not None:
+        content[SCHEDULED_HISTORY_LIMIT_KEY] = workflow.history_limit
+    return content
+
+
 async def execute_scheduled_workflow(
     client: nio.AsyncClient,
     workflow: ScheduledWorkflow,
@@ -175,6 +244,8 @@ async def execute_scheduled_workflow(
     conversation_reader: ConversationReader,
     task_id: str = "scheduled-task",
     matrix_admin: HookMatrixAdmin | None = None,
+    *,
+    occurrence: RecurringOccurrence | None = None,
 ) -> ScheduledWorkflowOutcome:
     """Execute a scheduled workflow by posting its message to the thread."""
     if not workflow.room_id:
@@ -187,61 +258,34 @@ async def execute_scheduled_workflow(
 
     with bound_log_context(**target.log_context):
         try:
-            message_text = workflow.message
-            hook_registry = _SCHEDULING_HOOK_REGISTRY_STATE.registry
-            if hook_registry.has_hooks(EVENT_SCHEDULE_FIRED):
-                context = ScheduleFiredContext(
-                    event_name=EVENT_SCHEDULE_FIRED,
-                    plugin_name="",
-                    settings={},
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    logger=logger.bind(event_name=EVENT_SCHEDULE_FIRED),
-                    correlation_id=f"{EVENT_SCHEDULE_FIRED}:{task_id}",
-                    message_sender=build_hook_message_sender(
-                        client,
-                        config,
-                        runtime_paths,
-                        conversation_reader=conversation_reader,
-                    ),
-                    matrix_admin=matrix_admin,
-                    room_state_querier=build_hook_room_state_querier(client),
-                    room_state_putter=build_hook_room_state_putter(client),
-                    task_id=task_id,
-                    workflow=workflow,
-                    room_id=workflow.room_id,
-                    thread_id=target.resolved_thread_id,
-                    created_by=workflow.created_by,
-                    message_text=message_text,
-                    _hook_registry_state=_SCHEDULING_HOOK_REGISTRY_STATE,
+            content = recurring_delivery_content(occurrence, client.device_id) if occurrence is not None else None
+            if content is None:
+                content = await _prepare_scheduled_trigger(
+                    client,
+                    workflow,
+                    config,
+                    runtime_paths,
+                    conversation_reader,
+                    task_id,
+                    matrix_admin,
+                    target,
                 )
-                await emit(hook_registry, EVENT_SCHEDULE_FIRED, context)
-                if context.suppress:
-                    logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
+                if content is None:
                     return ScheduledWorkflowOutcome(delivered=False, failure_reason="suppressed by hook")
-                message_text = context.message_text
-
-            _validate_scheduled_workflow_message(message_text)
-            content = await _build_workflow_message_content(
-                workflow,
-                target,
-                config,
-                runtime_paths,
-                message_text,
-                conversation_reader,
-            )
-            if workflow.created_by:
-                content[ORIGINAL_SENDER_KEY] = workflow.created_by
-            content[SOURCE_KIND_KEY] = SILENT_SCHEDULE_SOURCE_KIND if workflow.silent else SCHEDULED_SOURCE_KIND
-            if workflow.new_thread and not workflow.silent:
-                content[PER_FIRE_THREAD_ROOT_KEY] = True
-            if workflow.history_limit is not None:
-                content[SCHEDULED_HISTORY_LIMIT_KEY] = workflow.history_limit
+                if occurrence is not None:
+                    content = await prepare_matrix_message(client, workflow.room_id, content)
+                    await prepare_recurring_delivery(occurrence, content, client.device_id)
+            delivery_kwargs: dict[str, typing.Any] = {
+                "message_type": SILENT_SCHEDULE_EVENT_TYPE if workflow.silent else "m.room.message",
+            }
+            if occurrence is not None:
+                delivery_kwargs["transaction_id"] = occurrence.transaction_id
+                delivery_kwargs["content_is_prepared"] = True
             delivered = await send_matrix_message(
                 client,
                 workflow.room_id,
                 content,
-                message_type=SILENT_SCHEDULE_EVENT_TYPE if workflow.silent else "m.room.message",
+                **delivery_kwargs,
             )
             if delivered is None:
                 _raise_scheduled_workflow_send_error()
@@ -254,13 +298,14 @@ async def execute_scheduled_workflow(
             )
         except Exception as e:
             logger.exception("Failed to execute scheduled workflow")
-            await _notify_scheduled_workflow_failure(
-                client,
-                workflow,
-                target,
-                e,
-                conversation_reader,
-            )
-            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e))
+            if occurrence is None:
+                await _notify_scheduled_workflow_failure(
+                    client,
+                    workflow,
+                    target,
+                    e,
+                    conversation_reader,
+                )
+            return ScheduledWorkflowOutcome(delivered=False, failure_reason=str(e), retryable=occurrence is not None)
         else:
             return ScheduledWorkflowOutcome(delivered=True)

--- a/tach.toml
+++ b/tach.toml
@@ -3556,6 +3556,7 @@ depends_on = [
     "mindroom.matrix.conversation_reads",
     "mindroom.model_loading",
     "mindroom.scheduling_executor",
+    "mindroom.recurring_schedule",
 ]
 
 [[modules]]
@@ -3563,6 +3564,19 @@ path = "mindroom.scheduling_executor"
 depends_on = [
     "mindroom.constants",
     "mindroom.hooks",
+    "mindroom.recurring_schedule",
+]
+
+[[modules]]
+path = "mindroom.recurring_schedule"
+depends_on = [
+    "mindroom.background_tasks",
+    "mindroom.durable_write",
+    "mindroom.logging_config",
+]
+visibility = [
+    "mindroom.scheduling",
+    "mindroom.scheduling_executor",
 ]
 
 [[modules]]
@@ -4679,6 +4693,7 @@ expose = [
     "cached_room",
     "edit_message_outcome",
     "edit_message_result",
+    "prepare_message_content",
     "resolve_room_encryption_for_delivery",
     "resolve_room_encryption_outcome",
     "send_audio_message",
@@ -5096,6 +5111,7 @@ expose = [
     "is_automation_source_kind",
     "is_voice_event",
     "iter_module_hooks",
+    "prepare_matrix_message",
     "render_enrichment_block",
     "render_system_enrichment_block",
     "render_transient_context",

--- a/tach.toml
+++ b/tach.toml
@@ -2509,6 +2509,7 @@ visibility = [
     "mindroom.matrix_rtc.call_manager",
     "mindroom.matrix.stale_stream_cleanup",
     "mindroom.scheduling",
+    "mindroom.scheduling_executor",
     "mindroom.streaming",
     "mindroom.thread_summary",
 ]
@@ -3562,6 +3563,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.scheduling_executor"
 depends_on = [
+    "mindroom.matrix.client_delivery",
     "mindroom.constants",
     "mindroom.hooks",
     "mindroom.recurring_schedule",
@@ -5111,7 +5113,6 @@ expose = [
     "is_automation_source_kind",
     "is_voice_event",
     "iter_module_hooks",
-    "prepare_matrix_message",
     "render_enrichment_block",
     "render_system_enrichment_block",
     "render_transient_context",

--- a/tests/test_cancel_mid_wait.py
+++ b/tests/test_cancel_mid_wait.py
@@ -3,21 +3,27 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from mindroom.constants import resolve_runtime_paths
+from mindroom.config.main import Config
 from mindroom.scheduling import CronSchedule, ScheduledTaskRecord, ScheduledWorkflow, _run_cron_task
+from tests.conftest import test_runtime_paths as runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.asyncio
-async def test_cancel_mid_wait_cron_task() -> None:
+async def test_cancel_mid_wait_cron_task(tmp_path: Path) -> None:
     """Test that cancellation during wait periods propagates correctly."""
     client = AsyncMock()
-    config = AsyncMock()
-    runtime_paths = resolve_runtime_paths()
+    client.homeserver = "https://example.org"
+    client.user_id = "@router:example.org"
+    config = Config()
 
     workflow = ScheduledWorkflow(
         schedule_type="cron",
@@ -35,13 +41,14 @@ async def test_cancel_mid_wait_cron_task() -> None:
         workflow=workflow,
     )
 
-    # Patch croniter to return next run far in the future to guarantee sleep
-    class DummyCron:
-        def get_next(self, _) -> datetime:  # noqa: ANN001
-            return datetime.now(UTC) + timedelta(hours=1)
+    waiting = asyncio.Event()
+
+    async def wait_until_cancelled(_delay: float) -> None:
+        waiting.set()
+        await asyncio.Event().wait()
 
     with (
-        patch("mindroom.scheduling.croniter", return_value=DummyCron()),
+        patch("mindroom.scheduling.asyncio.sleep", new=wait_until_cancelled),
         patch("mindroom.scheduling.get_scheduled_task", new=AsyncMock(return_value=pending_record)),
     ):
         task = asyncio.create_task(
@@ -51,11 +58,11 @@ async def test_cancel_mid_wait_cron_task() -> None:
                 workflow,
                 {},
                 config,
-                runtime_paths,
+                runtime_paths(tmp_path),
                 MagicMock(),
             ),
         )
-        await asyncio.sleep(0)  # let it start and hit sleep
+        await waiting.wait()
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task

--- a/tests/test_hook_schedule.py
+++ b/tests/test_hook_schedule.py
@@ -93,7 +93,7 @@ async def test_schedule_hook_rewrites_message_text(tmp_path: Path) -> None:
     conversation_reader = _conversation_reader(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
         await execute_scheduled_workflow(
@@ -120,7 +120,7 @@ async def test_schedule_hook_can_suppress_synthetic_message(tmp_path: Path) -> N
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [suppress])]))
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ) as mock_send:
         await execute_scheduled_workflow(
@@ -153,7 +153,7 @@ async def test_schedule_hook_suppression_log_includes_workflow_thread_context(
     capsys.readouterr()
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$scheduled")),
     ):
         await execute_scheduled_workflow(

--- a/tests/test_recurring_schedule_recovery.py
+++ b/tests/test_recurring_schedule_recovery.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 from contextlib import suppress
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock
 
@@ -14,13 +15,33 @@ import pytest
 
 from mindroom import recurring_schedule, scheduling, scheduling_executor
 from mindroom.config.main import Config
+from mindroom.config.plugin import PluginEntryConfig
+from mindroom.hooks import EVENT_SCHEDULE_FIRED, HookRegistry, ScheduleFiredContext, hook
 from mindroom.matrix import client_delivery
+from mindroom.matrix.large_messages import MatrixEventTooLargeError
 from mindroom.scheduling import CronSchedule, ScheduledWorkflow
 from tests.conftest import delivered_matrix_event, delivered_matrix_side_effect
 from tests.conftest import test_runtime_paths as runtime_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mindroom.hooks import HookCallback
+
+
+def install_schedule_hook(monkeypatch: pytest.MonkeyPatch, callback: HookCallback) -> None:
+    """Install one real hook with test-scoped registry restoration."""
+    plugin = SimpleNamespace(
+        name="schedule-test",
+        discovered_hooks=(callback,),
+        entry_config=PluginEntryConfig(path="./schedule-test"),
+        plugin_order=0,
+    )
+    monkeypatch.setattr(
+        scheduling_executor._SCHEDULING_HOOK_REGISTRY_STATE,
+        "registry",
+        HookRegistry.from_plugins([plugin]),
+    )
 
 
 class Clock:
@@ -483,6 +504,211 @@ async def test_frozen_sidecar_survives_encryption_enabled_before_retry(
     assert frozen["file"]["key"]
     assert frozen["file"]["iv"]
     assert client.upload.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["plan", "prepare", "complete"])
+async def test_checkpoint_io_failure_keeps_runner_alive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+    stage: str,
+) -> None:
+    """A transient checkpoint failure must recover without another process restart."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    save = recurring_schedule._save
+    plan = recurring_schedule._plan
+    failed = False
+    pauses = 0
+
+    def flaky_plan(
+        path: Path,
+        workflow_key: str,
+        cron: str,
+        now: datetime,
+        grace_seconds: int,
+    ) -> recurring_schedule.RecurringOccurrence:
+        nonlocal failed
+        if stage == "plan" and not failed:
+            failed = True
+            msg = "temporary checkpoint read failure"
+            raise OSError(msg)
+        return plan(path, workflow_key, cron, now, grace_seconds)
+
+    def flaky_save(path: Path, checkpoint: recurring_schedule._RecurringCheckpoint) -> None:
+        nonlocal failed
+        target_stage = "prepare" if checkpoint.prepared is not None else "complete"
+        if stage == target_stage and not failed:
+            failed = True
+            msg = "temporary checkpoint write failure"
+            raise OSError(msg)
+        save(path, checkpoint)
+
+    async def retry_pause(_delay: float) -> None:
+        nonlocal pauses
+        pauses += 1
+        assert pauses == 1
+
+    monkeypatch.setattr(recurring_schedule, "_plan", flaky_plan)
+    monkeypatch.setattr(recurring_schedule, "_save", flaky_save)
+    monkeypatch.setattr(scheduling.asyncio, "sleep", retry_pause)
+    await run_until_wait(task, client, tmp_path)
+    assert failed
+    assert pauses == 1
+    assert sent.await_count == 1
+    checkpoint = json.loads(next((tmp_path / "mindroom_data/tracking/recurring_schedules").glob("*.json")).read_text())
+    assert checkpoint["next_run_at"] == "2026-01-16T07:00:00Z"
+    assert checkpoint["prepared"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["plan", "prepare"])
+@pytest.mark.parametrize("change", ["elapsed", "cancelled", "edited"])
+async def test_checkpoint_retry_rechecks_time_and_task_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+    stage: str,
+    change: str,
+) -> None:
+    """Recovery must not send an old occurrence after time or authoritative state changed."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    plan = recurring_schedule._plan
+    save = recurring_schedule._save
+    plans = 0
+    failed = False
+    pauses = 0
+
+    def fail_final_plan(
+        path: Path,
+        workflow_key: str,
+        cron: str,
+        now: datetime,
+        grace_seconds: int,
+    ) -> recurring_schedule.RecurringOccurrence:
+        nonlocal plans
+        plans += 1
+        if stage == "plan" and plans == 2:
+            msg = "temporary final planning failure"
+            raise OSError(msg)
+        return plan(path, workflow_key, cron, now, grace_seconds)
+
+    def fail_preparation(path: Path, checkpoint: recurring_schedule._RecurringCheckpoint) -> None:
+        nonlocal failed
+        if stage == "prepare" and checkpoint.prepared is not None and not failed:
+            failed = True
+            msg = "temporary preparation checkpoint failure"
+            raise OSError(msg)
+        save(path, checkpoint)
+
+    async def change_during_retry(_delay: float) -> None:
+        nonlocal pauses
+        pauses += 1
+        if pauses > 1:
+            raise asyncio.CancelledError
+        if change == "elapsed":
+            controlled_clock.now = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+        else:
+            if change == "edited":
+                task.message = "Revised summary"
+            client.room_get_state_event.return_value = nio.RoomGetStateEventResponse.from_dict(
+                {"workflow": task.model_dump_json(), "status": "cancelled" if change == "cancelled" else "pending"},
+                room_id="!room:example.org",
+                event_type="com.mindroom.scheduled.task",
+                state_key="daily",
+            )
+
+    monkeypatch.setattr(recurring_schedule, "_plan", fail_final_plan)
+    monkeypatch.setattr(recurring_schedule, "_save", fail_preparation)
+    monkeypatch.setattr(scheduling.asyncio, "sleep", change_during_retry)
+    await run_until_wait(task, client, tmp_path)
+    assert pauses >= 1
+    assert sent.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_hook_retry_identity_is_specific_to_the_occurrence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Hooks can deduplicate replay before freezing without suppressing tomorrow's run."""
+    identities: list[str] = []
+
+    @hook(EVENT_SCHEDULE_FIRED)
+    async def record_identity(ctx: ScheduleFiredContext) -> None:
+        identities.append(ctx.correlation_id)
+
+    install_schedule_hook(monkeypatch, record_identity)
+    task = workflow()
+    client = client_for(task)
+    content = {"body": "summary", "msgtype": "m.text"}
+    monkeypatch.setattr(
+        scheduling_executor,
+        "prepare_matrix_message",
+        AsyncMock(side_effect=[RuntimeError("temporary preparation failure"), content, content]),
+    )
+    sent = AsyncMock(
+        side_effect=[asyncio.CancelledError, delivered_matrix_event("$first"), delivered_matrix_event("$next")],
+    )
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    assert len(identities) == 2  # Frozen delivery retries no longer invoke hooks.
+    controlled_clock.now = datetime(2026, 1, 16, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert len(identities) == 3
+    assert identities[0] == identities[1]
+    assert identities[1] != identities[2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["empty", "too_large"])
+async def test_permanent_preparation_failure_advances_occurrence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+    failure: str,
+) -> None:
+    """Invalid content fails visibly once rather than being retried every thirty seconds."""
+    if failure == "empty":
+
+        @hook(EVENT_SCHEDULE_FIRED)
+        async def empty_body(ctx: ScheduleFiredContext) -> None:
+            ctx.message_text = ""
+
+        install_schedule_hook(monkeypatch, empty_body)
+    else:
+        monkeypatch.setattr(
+            client_delivery,
+            "prepare_large_message",
+            AsyncMock(side_effect=MatrixEventTooLargeError("unrepresentable payload")),
+        )
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$failure"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+    assert "Scheduled task failed" in sent.await_args.args[2]["body"]
+    checkpoint = json.loads(next((tmp_path / "mindroom_data/tracking/recurring_schedules").glob("*.json")).read_text())
+    assert checkpoint["next_run_at"] == "2026-01-16T07:00:00Z"
+    assert checkpoint["prepared"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_recurring_schedule_recovery.py
+++ b/tests/test_recurring_schedule_recovery.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.hooks import HookCallback
+    from mindroom.recurring_schedule import RecurringOccurrence
 
 
 def install_schedule_hook(monkeypatch: pytest.MonkeyPatch, callback: HookCallback) -> None:
@@ -87,6 +88,27 @@ def client_for(task: ScheduledWorkflow) -> AsyncMock:
     return client
 
 
+async def plan_at(
+    tmp_path: Path,
+    task: ScheduledWorkflow,
+    now: datetime,
+    grace: int = 3600,
+) -> RecurringOccurrence:
+    """Exercise checkpoint planning at an explicit time without starting a timer."""
+    assert task.cron_schedule is not None
+    return await recurring_schedule.plan_recurring_occurrence(
+        runtime_paths(tmp_path),
+        homeserver="https://example.org",
+        sender="@router:example.org",
+        room_id="!room:example.org",
+        task_id="daily",
+        workflow_json=task.model_dump_json(),
+        cron=task.cron_schedule.to_cron_string(),
+        now=now,
+        grace_seconds=grace,
+    )
+
+
 async def run_until_wait(
     task: ScheduledWorkflow,
     client: AsyncMock,
@@ -113,7 +135,7 @@ async def test_restart_catches_recent_daily_run_once(tmp_path: Path, monkeypatch
     monkeypatch.setattr(scheduling, "datetime", type("Time", (datetime,), {"now": staticmethod(clock.utcnow)}))
     monkeypatch.setattr(scheduling.asyncio, "sleep", clock.sleep)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     task = workflow()
     client = client_for(task)
 
@@ -127,20 +149,13 @@ async def test_restart_catches_recent_daily_run_once(tmp_path: Path, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_future_schedule_does_not_fire_during_recovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_future_schedule_does_not_fire_during_recovery(tmp_path: Path) -> None:
     """Catch-up must leave a later daily occurrence waiting."""
-    clock = Clock()
-    monkeypatch.setattr(scheduling, "datetime", type("Time", (datetime,), {"now": staticmethod(clock.utcnow)}))
-    monkeypatch.setattr(scheduling.asyncio, "sleep", clock.sleep)
-    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
     task = workflow("8")
-    client = client_for(task)
-
-    await run_until_wait(task, client, tmp_path)
-    clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
-    await run_until_wait(task, client, tmp_path)
-    assert sent.await_count == 0
+    before = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    recovered = await plan_at(tmp_path, task, datetime(2026, 1, 15, 7, 1, tzinfo=UTC))
+    assert recovered == before
+    assert recovered.checkpoint.next_run_at == datetime(2026, 1, 15, 8, 0, tzinfo=UTC)
 
 
 @pytest.fixture
@@ -165,61 +180,45 @@ def controlled_clock(monkeypatch: pytest.MonkeyPatch) -> Clock:
 )
 async def test_catch_up_grace(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    controlled_clock: Clock,
     restart: datetime,
     grace: int,
     fires: int,
 ) -> None:
-    """Boundary and custom grace values determine whether overdue work still fires."""
-    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    """Boundary and custom grace values determine whether overdue work remains due."""
     task = workflow()
-    client = client_for(task)
-    config = Config(scheduler_catch_up_grace_seconds=grace)
-    await run_until_wait(task, client, tmp_path, config)
-    controlled_clock.now = restart
-    await run_until_wait(task, client, tmp_path, config)
-    assert sent.await_count == fires
-    await run_until_wait(task, client, tmp_path, config)
-    assert sent.await_count == fires
+    await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC), grace)
+    occurrence = await plan_at(tmp_path, task, restart, grace)
+    expected = datetime(2026, 1, 15 if fires else 16, 7, 0, tzinfo=UTC)
+    assert occurrence.checkpoint.next_run_at == expected
+    assert (occurrence.checkpoint.next_run_at <= restart) == bool(fires)
+    assert await plan_at(tmp_path, task, restart, grace) == occurrence
 
 
 @pytest.mark.asyncio
-async def test_first_adoption_does_not_replay_unknown_history(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    controlled_clock: Clock,
-) -> None:
+async def test_first_adoption_does_not_replay_unknown_history(tmp_path: Path) -> None:
     """An old schedule without a checkpoint may already have fired before upgrade."""
-    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
-    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
-    task = workflow()
-    await run_until_wait(task, client_for(task), tmp_path)
-    assert sent.await_count == 0
+    occurrence = await plan_at(tmp_path, workflow(), datetime(2026, 1, 15, 7, 1, tzinfo=UTC))
+    assert occurrence.checkpoint.next_run_at == datetime(2026, 1, 16, 7, 0, tzinfo=UTC)
 
 
 @pytest.mark.asyncio
-async def test_multiple_missed_occurrences_coalesce(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    controlled_clock: Clock,
-) -> None:
+async def test_multiple_missed_occurrences_coalesce(tmp_path: Path) -> None:
     """A frequent schedule resumes once at the latest missed slot and keeps its cadence."""
     task = workflow()
     task.cron_schedule = CronSchedule(minute="*/10")
-    client = client_for(task)
-    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
-    await run_until_wait(task, client, tmp_path)
-    controlled_clock.now = datetime(2026, 1, 15, 7, 37, tzinfo=UTC)
-    await run_until_wait(task, client, tmp_path)
-    assert sent.await_count == 1
-    checkpoint = json.loads(next((tmp_path / "mindroom_data/tracking/recurring_schedules").glob("*.json")).read_text())
-    assert checkpoint["next_run_at"] == "2026-01-15T07:40:00Z"
-    assert checkpoint["last_skipped_at"] == "2026-01-15T07:20:00Z"
-    assert checkpoint["skip_reason"]
+    await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 7, 37, tzinfo=UTC))
+    assert occurrence.checkpoint.next_run_at == datetime(2026, 1, 15, 7, 30, tzinfo=UTC)
+    assert occurrence.checkpoint.last_skipped_at == datetime(2026, 1, 15, 7, 20, tzinfo=UTC)
+    assert occurrence.checkpoint.skip_reason
+    await recurring_schedule.complete_recurring_occurrence(
+        occurrence,
+        "*/10 * * * *",
+        datetime(2026, 1, 15, 7, 37, tzinfo=UTC),
+    )
+    following = await plan_at(tmp_path, task, datetime(2026, 1, 15, 7, 37, tzinfo=UTC))
+    assert following.checkpoint.next_run_at == datetime(2026, 1, 15, 7, 40, tzinfo=UTC)
+    assert following.checkpoint.last_skipped_at == datetime(2026, 1, 15, 7, 20, tzinfo=UTC)
 
 
 @pytest.mark.asyncio
@@ -258,7 +257,7 @@ async def test_crash_retry_reuses_frozen_trigger(
             raise asyncio.CancelledError
         return await delivered_matrix_side_effect("$trigger")(_client, _room, content)
 
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", send)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", send)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -280,7 +279,7 @@ async def test_crash_after_send_before_checkpoint_does_not_duplicate(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     complete = scheduling.complete_recurring_occurrence
@@ -304,7 +303,7 @@ async def test_device_change_holds_ambiguous_delivery(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=asyncio.CancelledError)
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -324,7 +323,7 @@ async def test_edit_during_downtime_does_not_replay_previous_definition(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     task.message = "Summarize a different topic"
@@ -342,7 +341,7 @@ async def test_cancelled_task_never_replays_pending_trigger(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=asyncio.CancelledError)
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -369,7 +368,7 @@ async def test_live_timer_fires_with_catch_up_disabled(
 
     monkeypatch.setattr(scheduling.asyncio, "sleep", reach_due_time)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     task = workflow()
     await run_until_wait(task, client_for(task), tmp_path, Config(scheduler_catch_up_grace_seconds=0))
     assert sent.await_count == 1
@@ -408,7 +407,7 @@ async def test_failed_checkpoint_write_prevents_network_send(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     with monkeypatch.context() as failure:
@@ -443,7 +442,7 @@ async def test_live_stall_rechecks_grace_before_send(
 
     monkeypatch.setattr(scheduling.asyncio, "sleep", stalled_sleep)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     task = workflow()
     await run_until_wait(task, client_for(task), tmp_path)
     assert sent.await_count == 0
@@ -518,7 +517,7 @@ async def test_checkpoint_io_failure_keeps_runner_alive(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     save = recurring_schedule._save
@@ -580,7 +579,7 @@ async def test_checkpoint_retry_rechecks_time_and_task_state(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     plan = recurring_schedule._plan
@@ -654,14 +653,14 @@ async def test_hook_retry_identity_is_specific_to_the_occurrence(
     client = client_for(task)
     content = {"body": "summary", "msgtype": "m.text"}
     monkeypatch.setattr(
-        scheduling_executor,
-        "prepare_matrix_message",
+        client_delivery,
+        "prepare_message_content",
         AsyncMock(side_effect=[RuntimeError("temporary preparation failure"), content, content]),
     )
     sent = AsyncMock(
         side_effect=[asyncio.CancelledError, delivered_matrix_event("$first"), delivered_matrix_event("$next")],
     )
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -700,7 +699,7 @@ async def test_permanent_preparation_failure_advances_occurrence(
     task = workflow()
     client = client_for(task)
     sent = AsyncMock(side_effect=delivered_matrix_side_effect("$failure"))
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -722,7 +721,7 @@ async def test_delayed_ack_records_intervening_skipped_slots(
     task.cron_schedule = CronSchedule(minute="*/10")
     client = client_for(task)
     sent = AsyncMock(side_effect=[asyncio.CancelledError, delivered_matrix_event("$trigger")])
-    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    monkeypatch.setattr(client_delivery, "send_message_outcome", sent)
     await run_until_wait(task, client, tmp_path)
     controlled_clock.now = datetime(2026, 1, 15, 7, 0, tzinfo=UTC)
     await run_until_wait(task, client, tmp_path)
@@ -732,3 +731,145 @@ async def test_delayed_ack_records_intervening_skipped_slots(
     assert checkpoint["last_skipped_at"] == "2026-01-15T07:30:00Z"
     assert checkpoint["skip_reason"]
     assert checkpoint["next_run_at"] == "2026-01-15T07:40:00Z"
+
+
+@pytest.mark.asyncio
+async def test_preparation_returns_resumable_occurrence(tmp_path: Path) -> None:
+    """The saved state must be immediately usable without reloading or a separate flag."""
+    task = workflow()
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    content = {"body": "Frozen summary", "msgtype": "m.text"}
+    prepared = await recurring_schedule.prepare_recurring_delivery(occurrence, content, "TEST_DEVICE")
+    assert prepared is not None
+    assert recurring_schedule.recurring_delivery_content(prepared, "TEST_DEVICE") == content
+    assert recurring_schedule.recurring_delivery_content(occurrence, "TEST_DEVICE") is None
+    resumed = await plan_at(tmp_path, task, datetime(2026, 1, 16, 8, 1, tzinfo=UTC))
+    assert resumed == prepared
+    assert resumed.transaction_id == occurrence.transaction_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "expected_status"),
+    [
+        (client_delivery.MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, "failed"),
+        (client_delivery.MatrixDeliveryFailureKind.UNKNOWN_ENCRYPTION_STATE, "retry"),
+        (client_delivery.MatrixDeliveryFailureKind.ENCRYPTION_GUARD, "retry"),
+    ],
+)
+async def test_preparation_failure_uses_matrix_classification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: client_delivery.MatrixDeliveryFailureKind,
+    expected_status: str,
+) -> None:
+    """Only an unrepresentable payload is terminal before the trigger is frozen."""
+    task = workflow()
+    client = client_for(task)
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    failure = client_delivery.MatrixDeliveryFailure(kind, "Preparation failed")
+    monkeypatch.setattr(client_delivery, "prepare_message_content", AsyncMock(return_value=failure))
+    client.room_send.return_value = nio.RoomSendResponse.from_dict({"event_id": "$notice"}, "!room:example.org")
+    outcome = await scheduling_executor.execute_scheduled_workflow(
+        client,
+        task,
+        Config(),
+        runtime_paths(tmp_path),
+        AsyncMock(),
+        occurrence=occurrence,
+    )
+    assert outcome.status == expected_status
+    assert outcome.failure_reason == "Preparation failed"
+    assert client.room_send.await_count == (1 if expected_status == "failed" else 0)
+    assert json.loads(occurrence.path.read_text())["prepared"] is None
+
+
+@pytest.mark.asyncio
+async def test_unexpected_preparation_value_error_retries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception's Python base class must not silently discard a valid occurrence."""
+    task = workflow()
+    client = client_for(task)
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    monkeypatch.setattr(
+        client_delivery,
+        "prepare_message_content",
+        AsyncMock(side_effect=ValueError("temporary failure")),
+    )
+    outcome = await scheduling_executor.execute_scheduled_workflow(
+        client,
+        task,
+        Config(),
+        runtime_paths(tmp_path),
+        AsyncMock(),
+        occurrence=occurrence,
+    )
+    assert outcome.status == "retry"
+    assert client.room_send.await_count == 0
+    assert json.loads(occurrence.path.read_text())["next_run_at"] == "2026-01-15T07:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_device_mismatch_is_held(tmp_path: Path) -> None:
+    """A changed transaction namespace must hold the frozen trigger without sending it."""
+    task = workflow()
+    client = client_for(task)
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    content = {"body": "Frozen summary", "msgtype": "m.text"}
+    await recurring_schedule.prepare_recurring_delivery(occurrence, content, "PREVIOUS_DEVICE")
+    resumed = await plan_at(tmp_path, task, datetime(2026, 1, 15, 7, 1, tzinfo=UTC))
+    outcome = await scheduling_executor.execute_scheduled_workflow(
+        client,
+        task,
+        Config(),
+        runtime_paths(tmp_path),
+        AsyncMock(),
+        occurrence=resumed,
+    )
+    assert outcome.status == "held"
+    assert client.room_send.await_count == 0
+    assert recurring_schedule.recurring_delivery_content(resumed, "PREVIOUS_DEVICE") == content
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", list(client_delivery.MatrixDeliveryFailureKind))
+async def test_frozen_delivery_failure_preserves_retry_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: client_delivery.MatrixDeliveryFailureKind,
+) -> None:
+    """Even a terminal-looking transport failure cannot discard an already frozen trigger."""
+    task = workflow()
+    client = client_for(task)
+    occurrence = await plan_at(tmp_path, task, datetime(2026, 1, 15, 6, 58, tzinfo=UTC))
+    send = AsyncMock(return_value=client_delivery.MatrixDeliveryFailure(kind, "Send failed"))
+    monkeypatch.setattr(client_delivery, "send_message_outcome", send)
+    outcome = await scheduling_executor.execute_scheduled_workflow(
+        client,
+        task,
+        Config(),
+        runtime_paths(tmp_path),
+        AsyncMock(),
+        occurrence=occurrence,
+    )
+    assert outcome.status == "retry"
+    assert outcome.failure_reason == "Send failed"
+    first_attempt = send.await_args
+    assert send.await_count == 1
+    resumed = await plan_at(tmp_path, task, datetime(2026, 1, 16, 8, 1, tzinfo=UTC))
+    assert recurring_schedule.recurring_delivery_content(resumed, "TEST_DEVICE") == first_attempt.args[2]
+    assert resumed.transaction_id == occurrence.transaction_id
+    send.return_value = delivered_matrix_event("$retry")
+    outcome = await scheduling_executor.execute_scheduled_workflow(
+        client,
+        task,
+        Config(),
+        runtime_paths(tmp_path),
+        AsyncMock(),
+        occurrence=resumed,
+    )
+    assert outcome.status == "delivered"
+    assert send.await_count == 2
+    assert send.await_args == first_attempt

--- a/tests/test_recurring_schedule_recovery.py
+++ b/tests/test_recurring_schedule_recovery.py
@@ -1,0 +1,508 @@
+"""Recurring schedules preserve due work across process restarts."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock
+
+import nio
+import pytest
+
+from mindroom import recurring_schedule, scheduling, scheduling_executor
+from mindroom.config.main import Config
+from mindroom.matrix import client_delivery
+from mindroom.scheduling import CronSchedule, ScheduledWorkflow
+from tests.conftest import delivered_matrix_event, delivered_matrix_side_effect
+from tests.conftest import test_runtime_paths as runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Clock:
+    """Control wall time and stop a runner when it reaches its next wait."""
+
+    now = datetime(2026, 1, 15, 6, 58, tzinfo=UTC)
+
+    def utcnow(self, _tz: object = None) -> datetime:
+        """Return the controlled aware time."""
+        return self.now
+
+    async def sleep(self, _delay: float) -> None:
+        """Stop at the next timer boundary without advancing wall time."""
+        raise asyncio.CancelledError
+
+
+def workflow(hour: str = "7") -> ScheduledWorkflow:
+    """Make a daily task with synthetic room and requester identities."""
+    return ScheduledWorkflow(
+        schedule_type="cron",
+        cron_schedule=CronSchedule(minute="0", hour=hour),
+        message="Summarize the latest updates",
+        description="Daily summary",
+        room_id="!room:example.org",
+        created_by="@user:example.org",
+        new_thread=True,
+    )
+
+
+def client_for(task: ScheduledWorkflow) -> AsyncMock:
+    """Fake only Matrix IO; keep task parsing and runner behavior real."""
+    client = AsyncMock()
+    client.user_id = "@router:example.org"
+    client.device_id = "TEST_DEVICE"
+    client.homeserver = "https://example.org"
+    client.rooms = {"!room:example.org": nio.MatrixRoom("!room:example.org", client.user_id)}
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse.from_dict(
+        {"workflow": task.model_dump_json(), "status": "pending"},
+        room_id="!room:example.org",
+        event_type="com.mindroom.scheduled.task",
+        state_key="daily",
+    )
+    return client
+
+
+async def run_until_wait(
+    task: ScheduledWorkflow,
+    client: AsyncMock,
+    tmp_path: Path,
+    config: Config | None = None,
+) -> None:
+    """Run the production scheduler until it sleeps or finishes a delivery."""
+    with suppress(asyncio.CancelledError):
+        await scheduling._run_cron_task(
+            client,
+            "daily",
+            task,
+            {},
+            config or Config(),
+            runtime_paths(tmp_path),
+            AsyncMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_restart_catches_recent_daily_run_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recomputing from restart time would lose the due run; losing its ACK would duplicate it."""
+    clock = Clock()
+    monkeypatch.setattr(scheduling, "datetime", type("Time", (datetime,), {"now": staticmethod(clock.utcnow)}))
+    monkeypatch.setattr(scheduling.asyncio, "sleep", clock.sleep)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow()
+    client = client_for(task)
+
+    await run_until_wait(task, client, tmp_path)
+    clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_future_schedule_does_not_fire_during_recovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Catch-up must leave a later daily occurrence waiting."""
+    clock = Clock()
+    monkeypatch.setattr(scheduling, "datetime", type("Time", (datetime,), {"now": staticmethod(clock.utcnow)}))
+    monkeypatch.setattr(scheduling.asyncio, "sleep", clock.sleep)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow("8")
+    client = client_for(task)
+
+    await run_until_wait(task, client, tmp_path)
+    clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 0
+
+
+@pytest.fixture
+def controlled_clock(monkeypatch: pytest.MonkeyPatch) -> Clock:
+    """Control scheduler time while leaving its persistence and delivery real."""
+    clock = Clock()
+    monkeypatch.setattr(scheduling, "datetime", type("Time", (datetime,), {"now": staticmethod(clock.utcnow)}))
+    monkeypatch.setattr(scheduling.asyncio, "sleep", clock.sleep)
+    return clock
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("restart", "grace", "fires"),
+    [
+        (datetime(2026, 1, 15, 7, 59, 59, tzinfo=UTC), 3600, 1),
+        (datetime(2026, 1, 15, 8, 0, tzinfo=UTC), 3600, 1),
+        (datetime(2026, 1, 15, 8, 0, 1, tzinfo=UTC), 3600, 0),
+        (datetime(2026, 1, 15, 7, 1, tzinfo=UTC), 0, 0),
+        (datetime(2026, 1, 15, 9, 0, tzinfo=UTC), 7200, 1),
+    ],
+)
+async def test_catch_up_grace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+    restart: datetime,
+    grace: int,
+    fires: int,
+) -> None:
+    """Boundary and custom grace values determine whether overdue work still fires."""
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow()
+    client = client_for(task)
+    config = Config(scheduler_catch_up_grace_seconds=grace)
+    await run_until_wait(task, client, tmp_path, config)
+    controlled_clock.now = restart
+    await run_until_wait(task, client, tmp_path, config)
+    assert sent.await_count == fires
+    await run_until_wait(task, client, tmp_path, config)
+    assert sent.await_count == fires
+
+
+@pytest.mark.asyncio
+async def test_first_adoption_does_not_replay_unknown_history(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """An old schedule without a checkpoint may already have fired before upgrade."""
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow()
+    await run_until_wait(task, client_for(task), tmp_path)
+    assert sent.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_missed_occurrences_coalesce(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """A frequent schedule resumes once at the latest missed slot and keeps its cadence."""
+    task = workflow()
+    task.cron_schedule = CronSchedule(minute="*/10")
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 37, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+    checkpoint = json.loads(next((tmp_path / "mindroom_data/tracking/recurring_schedules").glob("*.json")).read_text())
+    assert checkpoint["next_run_at"] == "2026-01-15T07:40:00Z"
+    assert checkpoint["last_skipped_at"] == "2026-01-15T07:20:00Z"
+    assert checkpoint["skip_reason"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("silent", [False, True])
+@pytest.mark.parametrize("crash_after_accept", [False, True])
+async def test_crash_retry_reuses_frozen_trigger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+    silent: bool,
+    crash_after_accept: bool,
+) -> None:
+    """A crash on either side of Matrix acceptance must retain one trigger identity and payload."""
+    task = workflow()
+    task.silent = silent
+    client = client_for(task)
+    accepted: dict[str, dict[str, object]] = {}
+    attempts: list[str] = []
+    fail = True
+
+    async def send(
+        _client: object,
+        _room: str,
+        content: dict[str, object],
+        **kwargs: object,
+    ) -> object:
+        nonlocal fail
+        transaction_id = str(kwargs["transaction_id"])
+        attempts.append(transaction_id)
+        if not fail or crash_after_accept:
+            if transaction_id in accepted:
+                assert accepted[transaction_id] == content
+            accepted.setdefault(transaction_id, content.copy())
+        if fail:
+            fail = False
+            raise asyncio.CancelledError
+        return await delivered_matrix_side_effect("$trigger")(_client, _room, content)
+
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", send)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 2, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    assert len(accepted) == 1
+    assert len(attempts) == 2
+    assert attempts[0] == attempts[1]
+
+
+@pytest.mark.asyncio
+async def test_crash_after_send_before_checkpoint_does_not_duplicate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Losing the local delivery acknowledgement must resend only the same transaction."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    complete = scheduling.complete_recurring_occurrence
+    monkeypatch.setattr(scheduling, "complete_recurring_occurrence", AsyncMock(side_effect=asyncio.CancelledError))
+    await run_until_wait(task, client, tmp_path)
+    monkeypatch.setattr(scheduling, "complete_recurring_occurrence", complete)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 2
+    assert sent.await_args_list[0].kwargs["transaction_id"] == sent.await_args_list[1].kwargs["transaction_id"]
+    assert sent.await_args_list[0].args[2] == sent.await_args_list[1].args[2]
+
+
+@pytest.mark.asyncio
+async def test_device_change_holds_ambiguous_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """A new Matrix device cannot safely reuse the old device's transaction namespace."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+    client.device_id = "REPLACEMENT_DEVICE"
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_edit_during_downtime_does_not_replay_previous_definition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Editing an overdue task establishes a new cursor instead of firing stale work."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    task.message = "Summarize a different topic"
+    await run_until_wait(task, client_for(task), tmp_path)
+    assert sent.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_never_replays_pending_trigger(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Cancellation in authoritative room state fences a previously attempted send."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse.from_dict(
+        {"workflow": task.model_dump_json(), "status": "cancelled"},
+        room_id="!room:example.org",
+        event_type="com.mindroom.scheduled.task",
+        state_key="daily",
+    )
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_live_timer_fires_with_catch_up_disabled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Disabling restart catch-up must not disable ordinary timer execution."""
+
+    async def reach_due_time(_delay: float) -> None:
+        controlled_clock.now = datetime(2026, 1, 15, 7, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(scheduling.asyncio, "sleep", reach_due_time)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow()
+    await run_until_wait(task, client_for(task), tmp_path, Config(scheduler_catch_up_grace_seconds=0))
+    assert sent.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_transaction_identity_reaches_matrix_transport(
+    tmp_path: Path,
+    controlled_clock: Clock,
+) -> None:
+    """The real hook sender and delivery stack must carry stable IDs through to nio."""
+    task = workflow()
+    client = client_for(task)
+    client.rooms = {"!room:example.org": nio.MatrixRoom("!room:example.org", client.user_id)}
+    client.room_send = AsyncMock(
+        side_effect=[asyncio.CancelledError, nio.RoomSendResponse("$trigger", "!room:example.org")],
+    )
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    assert client.room_send.await_count == 2
+    first, retry = client.room_send.await_args_list
+    assert first.kwargs["tx_id"].startswith("schedule_")
+    assert first.kwargs["tx_id"] == retry.kwargs["tx_id"]
+    assert first.kwargs["content"] == retry.kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_failed_checkpoint_write_prevents_network_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """A trigger cannot escape before its retry identity and content are durable."""
+    task = workflow()
+    client = client_for(task)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    with monkeypatch.context() as failure:
+        failure.setattr(recurring_schedule, "write_json_file_durable", Mock(side_effect=OSError("disk full")))
+        await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 0
+    await run_until_wait(task, client, tmp_path)
+    assert sent.await_count == 1
+
+
+def test_negative_catch_up_grace_is_rejected() -> None:
+    """Invalid recovery windows must fail configuration validation."""
+    with pytest.raises(ValueError, match="greater than or equal"):
+        Config(scheduler_catch_up_grace_seconds=-1)
+
+
+@pytest.mark.asyncio
+async def test_live_stall_rechecks_grace_before_send(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """A late wake-up is a missed occurrence even if the process never restarted."""
+    waits = 0
+
+    async def stalled_sleep(_delay: float) -> None:
+        nonlocal waits
+        waits += 1
+        if waits > 1:
+            raise asyncio.CancelledError
+        controlled_clock.now = datetime(2026, 1, 15, 9, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(scheduling.asyncio, "sleep", stalled_sleep)
+    sent = AsyncMock(side_effect=delivered_matrix_side_effect("$trigger"))
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    task = workflow()
+    await run_until_wait(task, client_for(task), tmp_path)
+    assert sent.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_keeps_prepared_transport_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Sidecar preparation must happen before freezing, never again on a resend."""
+    preparations = 0
+
+    async def prepare(_client: object, _room: str, content: dict[str, object], **_kwargs: object) -> dict[str, object]:
+        nonlocal preparations
+        preparations += 1
+        return {**content, "attachment": f"mxc://example.org/upload-{preparations}"}
+
+    monkeypatch.setattr(client_delivery, "prepare_large_message", prepare)
+    task = workflow()
+    client = client_for(task)
+    client.rooms = {"!room:example.org": nio.MatrixRoom("!room:example.org", client.user_id)}
+    client.room_send = AsyncMock(
+        side_effect=[asyncio.CancelledError, nio.RoomSendResponse("$trigger", "!room:example.org")],
+    )
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    await run_until_wait(task, client, tmp_path)
+    first, retry = client.room_send.await_args_list
+    assert first.kwargs["content"] == retry.kwargs["content"]
+    assert preparations == 1
+
+
+@pytest.mark.asyncio
+async def test_frozen_sidecar_survives_encryption_enabled_before_retry(
+    tmp_path: Path,
+    controlled_clock: Clock,
+) -> None:
+    """A durable trigger prepared in plaintext must support a later encrypted send."""
+    task = workflow()
+    task.message = "x" * 100_000
+    client = client_for(task)
+    client.upload.return_value = (nio.UploadResponse("mxc://example.org/sidecar"), None)
+    client.room_send = AsyncMock(
+        side_effect=[asyncio.CancelledError, nio.RoomSendResponse("$trigger", "!room:example.org")],
+    )
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 1, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    client.rooms["!room:example.org"].encrypted = True
+    await run_until_wait(task, client, tmp_path)
+    first, retry = client.room_send.await_args_list
+    assert first.kwargs["content"] == retry.kwargs["content"]
+    frozen = first.kwargs["content"]
+    assert "url" not in frozen
+    assert frozen["file"]["key"]
+    assert frozen["file"]["iv"]
+    assert client.upload.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_delayed_ack_records_intervening_skipped_slots(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: Clock,
+) -> None:
+    """Completing an old in-flight trigger must explain the slots it coalesces."""
+    task = workflow()
+    task.cron_schedule = CronSchedule(minute="*/10")
+    client = client_for(task)
+    sent = AsyncMock(side_effect=[asyncio.CancelledError, delivered_matrix_event("$trigger")])
+    monkeypatch.setattr(scheduling_executor, "send_matrix_message", sent)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 0, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    controlled_clock.now = datetime(2026, 1, 15, 7, 37, tzinfo=UTC)
+    await run_until_wait(task, client, tmp_path)
+    checkpoint = json.loads(next((tmp_path / "mindroom_data/tracking/recurring_schedules").glob("*.json")).read_text())
+    assert checkpoint["last_skipped_at"] == "2026-01-15T07:30:00Z"
+    assert checkpoint["skip_reason"]
+    assert checkpoint["next_run_at"] == "2026-01-15T07:40:00Z"

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1026,7 +1026,7 @@ async def test_run_once_task_stops_when_cancelled_via_matrix_state() -> None:
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
         patch("mindroom.scheduling.asyncio.sleep", new=AsyncMock()),
     ):
@@ -1071,7 +1071,7 @@ async def test_run_once_task_executes_latest_state_workflow() -> None:
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
     ):
         await _run_once_task(
@@ -1126,7 +1126,7 @@ async def test_run_once_task_retries_transient_state_read_failure() -> None:
         patch("mindroom.scheduling.asyncio.sleep", new=AsyncMock()) as sleep,
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute,
         patch(
             "mindroom.scheduling_executor.send_scheduled_failure_notice",
@@ -1171,7 +1171,7 @@ async def test_run_once_task_marks_completed_after_success() -> None:
         ),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
     ):
         await _run_once_task(
@@ -1217,7 +1217,7 @@ async def test_run_once_task_marks_failed_after_execution_failure() -> None:
         ),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=False, failure_reason="send failed")),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="failed", failure_reason="send failed")),
         ) as execute_mock,
     ):
         await _run_once_task(
@@ -1274,7 +1274,7 @@ async def test_run_cron_task_executes_latest_state_workflow(tmp_path: Path) -> N
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
         patch("mindroom.scheduling.plan_recurring_occurrence", return_value=occurrence),
     ):
@@ -1325,7 +1325,7 @@ async def test_run_cron_task_keeps_pending_state_after_success(tmp_path: Path) -
         ),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
         patch("mindroom.scheduling.plan_recurring_occurrence", return_value=occurrence),
     ):
@@ -1364,7 +1364,7 @@ async def test_run_cron_task_stops_when_cancelled_via_matrix_state() -> None:
         patch("mindroom.scheduling.get_scheduled_task", side_effect=_fetch_task),
         patch(
             "mindroom.scheduling_executor.execute_scheduled_workflow",
-            new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
+            new=AsyncMock(return_value=ScheduledWorkflowOutcome(status="delivered")),
         ) as execute_mock,
     ):
         await _run_cron_task(

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -16,6 +16,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import resolve_runtime_paths
+from mindroom.recurring_schedule import RecurringOccurrence, _RecurringCheckpoint
 from mindroom.scheduling import (
     _SCHEDULED_TASK_EVENT_TYPE,
     CronSchedule,
@@ -542,8 +543,8 @@ async def test_drain_deferred_overdue_tasks_continues_after_one_start_failure() 
 
 
 @pytest.mark.asyncio
-async def test_restore_scheduled_tasks_keeps_cron_restoration_unchanged() -> None:
-    """Recurring cron tasks should still be restored immediately."""
+async def test_restore_scheduled_tasks_defers_cron_until_sync_ready() -> None:
+    """Recurring catch-up must wait for Matrix sync readiness."""
     client = AsyncMock()
     cron_workflow = ScheduledWorkflow(
         schedule_type="cron",
@@ -582,9 +583,8 @@ async def test_restore_scheduled_tasks_keeps_cron_restoration_unchanged() -> Non
         )
 
     assert restored == 1
-    mock_start.assert_called_once()
-    assert mock_start.call_args.kwargs["matrix_admin"] is not None
-    assert len(scheduling._deferred_overdue_tasks) == 0
+    mock_start.assert_not_called()
+    assert [task.task_id for task in scheduling._deferred_overdue_tasks] == ["task_cron"]
 
 
 @pytest.mark.asyncio
@@ -693,9 +693,8 @@ async def test_restore_scheduled_tasks_uses_canonical_state_parser_for_mixed_rec
         )
 
     assert restored == 1
-    mock_start.assert_called_once()
-    assert mock_start.call_args.args[1] == "task_cron"
-    assert len(scheduling._deferred_overdue_tasks) == 0
+    mock_start.assert_not_called()
+    assert [task.task_id for task in scheduling._deferred_overdue_tasks] == ["task_cron"]
 
 
 @pytest.mark.asyncio
@@ -1239,10 +1238,13 @@ async def test_run_once_task_marks_failed_after_execution_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_cron_task_executes_latest_state_workflow() -> None:
+async def test_run_cron_task_executes_latest_state_workflow(tmp_path: Path) -> None:
     """Recurring tasks should execute using the latest persisted workflow data."""
     client = AsyncMock()
-    config = AsyncMock()
+    config = Config()
+    client.homeserver = "https://example.org"
+    client.user_id = "@router:example.org"
+    client.device_id = "TEST_DEVICE"
     initial_workflow = ScheduledWorkflow(
         schedule_type="cron",
         cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
@@ -1260,9 +1262,10 @@ async def test_run_cron_task_executes_latest_state_workflow() -> None:
         thread_id="$thread123",
     )
 
-    class _ImmediateCron:
-        def get_next(self, _type: object) -> datetime:
-            return datetime.now(UTC) - timedelta(seconds=1)
+    occurrence = RecurringOccurrence(
+        tmp_path / "checkpoint.json",
+        _RecurringCheckpoint("workflow", datetime.now(UTC) - timedelta(seconds=1)),
+    )
 
     async def _fetch_task(*_args: object, **_kwargs: object) -> ScheduledTaskRecord:
         return _record("task_cron_updated", updated_workflow, status="pending")
@@ -1273,7 +1276,7 @@ async def test_run_cron_task_executes_latest_state_workflow() -> None:
             "mindroom.scheduling_executor.execute_scheduled_workflow",
             new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
         ) as execute_mock,
-        patch("mindroom.scheduling.croniter", return_value=_ImmediateCron()),
+        patch("mindroom.scheduling.plan_recurring_occurrence", return_value=occurrence),
     ):
         await _run_cron_task(
             client,
@@ -1281,7 +1284,7 @@ async def test_run_cron_task_executes_latest_state_workflow() -> None:
             initial_workflow,
             {},
             config,
-            _runtime_paths(),
+            _test_runtime_paths(tmp_path),
             _conversation_reader(),
         )
 
@@ -1292,11 +1295,14 @@ async def test_run_cron_task_executes_latest_state_workflow() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_cron_task_keeps_pending_state_after_success() -> None:
+async def test_run_cron_task_keeps_pending_state_after_success(tmp_path: Path) -> None:
     """Recurring tasks should keep their pending state after firing."""
     client = AsyncMock()
     client.room_put_state = AsyncMock()
-    config = AsyncMock()
+    config = Config()
+    client.homeserver = "https://example.org"
+    client.user_id = "@router:example.org"
+    client.device_id = "TEST_DEVICE"
     workflow = ScheduledWorkflow(
         schedule_type="cron",
         cron_schedule=CronSchedule(minute="0", hour="9", day="*", month="*", weekday="*"),
@@ -1307,9 +1313,10 @@ async def test_run_cron_task_keeps_pending_state_after_success() -> None:
     )
     pending_record = _record("task_cron_pending", workflow, status="pending")
 
-    class _ImmediateCron:
-        def get_next(self, _type: object) -> datetime:
-            return datetime.now(UTC) - timedelta(seconds=1)
+    occurrence = RecurringOccurrence(
+        tmp_path / "checkpoint.json",
+        _RecurringCheckpoint("workflow", datetime.now(UTC) - timedelta(seconds=1)),
+    )
 
     with (
         patch(
@@ -1320,7 +1327,7 @@ async def test_run_cron_task_keeps_pending_state_after_success() -> None:
             "mindroom.scheduling_executor.execute_scheduled_workflow",
             new=AsyncMock(return_value=ScheduledWorkflowOutcome(delivered=True)),
         ) as execute_mock,
-        patch("mindroom.scheduling.croniter", return_value=_ImmediateCron()),
+        patch("mindroom.scheduling.plan_recurring_occurrence", return_value=occurrence),
     ):
         await _run_cron_task(
             client,
@@ -1328,7 +1335,7 @@ async def test_run_cron_task_keeps_pending_state_after_success() -> None:
             workflow,
             {},
             config,
-            _runtime_paths(),
+            _test_runtime_paths(tmp_path),
             _conversation_reader(),
         )
 

--- a/tests/test_scheduling_executor.py
+++ b/tests/test_scheduling_executor.py
@@ -22,6 +22,7 @@ from mindroom.constants import (
 from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND, SILENT_SCHEDULE_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import EVENT_SCHEDULE_FIRED, HookRegistry, ScheduleFiredContext, hook
+from mindroom.matrix.client_delivery import MatrixDeliveryFailure, MatrixDeliveryFailureKind
 from mindroom.message_target import MessageTarget
 from mindroom.scheduling import ScheduledWorkflow
 from mindroom.scheduling_executor import (
@@ -120,7 +121,7 @@ async def test_fire_task_with_valid_agent_delivers_in_thread(tmp_path: Path) -> 
     conversation_reader = _conversation_reader(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -132,7 +133,7 @@ async def test_fire_task_with_valid_agent_delivers_in_thread(tmp_path: Path) -> 
             task_id="task-1",
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     assert outcome.failure_reason is None
     mock_send.assert_awaited_once()
     assert mock_send.await_args.args[1] == "!room:localhost"
@@ -165,7 +166,7 @@ async def test_schedule_transport_preserves_requester_and_history_metadata(
     workflow = _workflow("Reconcile the queue", history_limit=5, silent=silent)
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -176,7 +177,7 @@ async def test_schedule_transport_preserves_requester_and_history_metadata(
             _conversation_reader(latest_thread_event_id="$latest"),
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     content = mock_send.await_args.args[2]
     assert content[ORIGINAL_SENDER_KEY] == "@user:localhost"
     assert content[SCHEDULED_HISTORY_LIMIT_KEY] == 5
@@ -194,7 +195,7 @@ async def test_fire_task_with_history_limit_annotates_message_content(tmp_path: 
     conversation_reader = _conversation_reader(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -206,7 +207,7 @@ async def test_fire_task_with_history_limit_annotates_message_content(tmp_path: 
             task_id="task-1",
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     content = mock_send.await_args.args[2]
     assert content[SOURCE_KIND_KEY] == SCHEDULED_SOURCE_KIND
     assert content[SCHEDULED_HISTORY_LIMIT_KEY] == history_limit
@@ -221,7 +222,7 @@ async def test_fire_new_thread_task_posts_room_level_message(tmp_path: Path, sta
     conversation_reader = _conversation_reader()
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -232,7 +233,7 @@ async def test_fire_new_thread_task_posts_room_level_message(tmp_path: Path, sta
             conversation_reader,
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     conversation_reader.latest_thread_event_id.assert_not_awaited()
     content = mock_send.await_args.args[2]
     assert "⏰ [Automated Task]" not in content["body"]
@@ -247,7 +248,7 @@ async def test_silent_new_thread_fire_does_not_claim_a_visible_per_fire_root(tmp
     workflow = _workflow("Reconcile the queue", thread_id=None, new_thread=True, silent=True)
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -258,7 +259,7 @@ async def test_silent_new_thread_fire_does_not_claim_a_visible_per_fire_root(tmp
             _conversation_reader(),
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     content = mock_send.await_args.args[2]
     assert PER_FIRE_THREAD_ROOT_KEY not in content
     assert mock_send.await_args.kwargs["message_type"] == SILENT_SCHEDULE_EVENT_TYPE
@@ -271,7 +272,7 @@ async def test_fire_room_level_task_without_new_thread_keeps_room_scope(tmp_path
     workflow = _workflow("Check the shared queue", thread_id=None, new_thread=False)
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -282,7 +283,7 @@ async def test_fire_room_level_task_without_new_thread_keeps_room_scope(tmp_path
             _conversation_reader(),
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     content = mock_send.await_args.args[2]
     assert "m.relates_to" not in content
     assert PER_FIRE_THREAD_ROOT_KEY not in content
@@ -294,7 +295,7 @@ async def test_fire_task_without_room_id_is_typed_failure(tmp_path: Path) -> Non
     config = _config(tmp_path)
     workflow = _workflow("Orphaned task", room_id=None, thread_id=None)
 
-    with patch("mindroom.scheduling_executor.send_matrix_message", new=AsyncMock()) as mock_send:
+    with patch("mindroom.matrix.client_delivery.send_message_outcome", new=AsyncMock()) as mock_send:
         outcome = await execute_scheduled_workflow(
             AsyncMock(),
             workflow,
@@ -303,21 +304,23 @@ async def test_fire_task_without_room_id_is_typed_failure(tmp_path: Path) -> Non
             _conversation_reader(),
         )
 
-    assert outcome.delivered is False
+    assert outcome.status == "failed"
     assert outcome.failure_reason == "missing room_id"
     mock_send.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_delivery_returning_none_yields_failure_and_notice(tmp_path: Path) -> None:
-    """A send that returns no delivered event produces a failure outcome plus a visible notice."""
+async def test_typed_delivery_failure_yields_failure_and_notice(tmp_path: Path) -> None:
+    """A typed Matrix send failure produces a failure outcome plus a visible notice."""
     config = _config(tmp_path)
     workflow = _workflow("Check the queue depth")
     conversation_reader = _conversation_reader(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
-        new=AsyncMock(side_effect=[None, None]),
+        "mindroom.matrix.client_delivery.send_message_outcome",
+        new=AsyncMock(
+            return_value=MatrixDeliveryFailure(MatrixDeliveryFailureKind.SEND_EXCEPTION, "Matrix send failed"),
+        ),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
             AsyncMock(),
@@ -327,13 +330,11 @@ async def test_delivery_returning_none_yields_failure_and_notice(tmp_path: Path)
             conversation_reader,
         )
 
-    assert outcome.delivered is False
-    assert outcome.failure_reason == "Failed to send scheduled workflow message to Matrix"
+    assert outcome.status == "failed"
+    assert outcome.failure_reason == "Matrix send failed"
     assert mock_send.await_count == 2
     notice_content = mock_send.await_args_list[1].args[2]
-    assert notice_content["body"] == (
-        "❌ Scheduled task failed: executor test task\nError: Failed to send scheduled workflow message to Matrix"
-    )
+    assert notice_content["body"] == ("❌ Scheduled task failed: executor test task\nError: Matrix send failed")
     assert notice_content["m.relates_to"]["event_id"] == "$thread"
 
 
@@ -344,7 +345,7 @@ async def test_delivery_exception_yields_failure_without_raising(tmp_path: Path)
     workflow = _workflow("Check the queue depth")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=RuntimeError("boom")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -355,7 +356,7 @@ async def test_delivery_exception_yields_failure_without_raising(tmp_path: Path)
             _conversation_reader(latest_thread_event_id="$latest"),
         )
 
-    assert outcome.delivered is False
+    assert outcome.status == "failed"
     assert outcome.failure_reason == "boom"
     assert mock_send.await_count == 2  # original send plus the (also failing) notice
 
@@ -374,7 +375,7 @@ async def test_hook_emission_fires_with_task_context(tmp_path: Path) -> None:
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [rewrite])]))
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -386,7 +387,7 @@ async def test_hook_emission_fires_with_task_context(tmp_path: Path) -> None:
             task_id="task-hooked",
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     assert seen == [("task-hooked", "$thread")]
     assert "Prepare the agenda (hooked)" in mock_send.await_args.args[2]["body"]
 
@@ -409,7 +410,7 @@ async def test_running_schedule_hook_becomes_inactive_after_registry_replacement
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [observe_lifecycle])]))
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ):
         execution = asyncio.create_task(
@@ -426,7 +427,7 @@ async def test_running_schedule_hook_becomes_inactive_after_registry_replacement
         resume_hook.set()
         outcome = await execution
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     assert active_states == [True, False]
 
 
@@ -442,7 +443,7 @@ async def test_silent_hook_transform_is_sent_as_custom_event(tmp_path: Path) -> 
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [rewrite])]))
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -453,7 +454,7 @@ async def test_silent_hook_transform_is_sent_as_custom_event(tmp_path: Path) -> 
             _conversation_reader(latest_thread_event_id="$latest"),
         )
 
-    assert outcome.delivered is True
+    assert outcome.status == "delivered"
     assert "Transformed schedule" in mock_send.await_args.args[2]["body"]
     assert mock_send.await_args.kwargs["message_type"] == SILENT_SCHEDULE_EVENT_TYPE
 
@@ -470,7 +471,7 @@ async def test_empty_hook_transform_fails_before_silent_trigger_transport(tmp_pa
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [empty])]))
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$failure")),
     ) as mock_send:
         outcome = await execute_scheduled_workflow(
@@ -481,7 +482,7 @@ async def test_empty_hook_transform_fails_before_silent_trigger_transport(tmp_pa
             _conversation_reader(),
         )
 
-    assert outcome.delivered is False
+    assert outcome.status == "failed"
     assert outcome.failure_reason == "Scheduled workflow message is empty after hooks"
     mock_send.assert_awaited_once()
     assert "message_type" not in mock_send.await_args.kwargs
@@ -499,7 +500,7 @@ async def test_hook_suppression_is_undelivered_outcome(tmp_path: Path) -> None:
     config = _config(tmp_path)
     set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [suppress])]))
 
-    with patch("mindroom.scheduling_executor.send_matrix_message", new=AsyncMock()) as mock_send:
+    with patch("mindroom.matrix.client_delivery.send_message_outcome", new=AsyncMock()) as mock_send:
         outcome = await execute_scheduled_workflow(
             AsyncMock(),
             _workflow("Do not send", silent=True),
@@ -508,7 +509,7 @@ async def test_hook_suppression_is_undelivered_outcome(tmp_path: Path) -> None:
             _conversation_reader(),
         )
 
-    assert outcome.delivered is False
+    assert outcome.status == "suppressed"
     assert outcome.failure_reason == "suppressed by hook"
     mock_send.assert_not_called()
 
@@ -521,7 +522,7 @@ async def test_send_scheduled_failure_notice_follows_workflow_target() -> None:
     conversation_reader = _conversation_reader(latest_thread_event_id="$latest")
 
     with patch(
-        "mindroom.scheduling_executor.send_matrix_message",
+        "mindroom.matrix.client_delivery.send_message_outcome",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$notice")),
     ) as mock_send:
         await send_scheduled_failure_notice(

--- a/tests/test_workflow_scheduling.py
+++ b/tests/test_workflow_scheduling.py
@@ -17,7 +17,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.entity_resolution import entity_identity_registry
-from mindroom.matrix.client import DeliveredMatrixEvent
+from mindroom.matrix.client_delivery import DeliveredMatrixEvent, MatrixDeliveryFailure, MatrixDeliveryFailureKind
 from mindroom.matrix.identity import MatrixID
 from mindroom.message_target import MessageTarget
 from mindroom.scheduling import (
@@ -620,7 +620,7 @@ class TestExecuteScheduledWorkflow:
 
         conversation_reader = _conversation_reader(latest_thread_event_id="$latest456")
         with patch(
-            "mindroom.scheduling_executor.send_matrix_message",
+            "mindroom.matrix.client_delivery.send_message_outcome",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event123",
@@ -681,7 +681,7 @@ class TestExecuteScheduledWorkflow:
         )
 
         with patch(
-            "mindroom.scheduling_executor.send_matrix_message",
+            "mindroom.matrix.client_delivery.send_message_outcome",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event456",
@@ -723,7 +723,7 @@ class TestExecuteScheduledWorkflow:
         conversation_reader = _conversation_reader(latest_thread_event_id="$latest456")
 
         with patch(
-            "mindroom.scheduling_executor.send_matrix_message",
+            "mindroom.matrix.client_delivery.send_message_outcome",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$notice123",
@@ -762,7 +762,7 @@ class TestExecuteScheduledWorkflow:
         )
 
         with patch(
-            "mindroom.scheduling_executor.send_matrix_message",
+            "mindroom.matrix.client_delivery.send_message_outcome",
             new=AsyncMock(
                 return_value=DeliveredMatrixEvent(
                     event_id="$event789",
@@ -807,7 +807,7 @@ class TestExecuteScheduledWorkflow:
             ],
         )
 
-        with patch("mindroom.scheduling_executor.send_matrix_message", new=mock_send):
+        with patch("mindroom.matrix.client_delivery.send_message_outcome", new=mock_send):
             # Should not raise, but log error
             await execute_scheduled_workflow(
                 client,
@@ -825,8 +825,8 @@ class TestExecuteScheduledWorkflow:
             error_content = error_call[0][2]
             assert "failed" in error_content["body"].lower()
 
-    async def test_execute_workflow_send_message_returning_none_is_failure(self) -> None:
-        """send_message returning None should trigger failure handling instead of success logging."""
+    async def test_execute_workflow_typed_send_failure_is_reported(self) -> None:
+        """A typed send failure should trigger failure handling instead of success logging."""
         client = AsyncMock()
         config = _runtime_bound_config(Config())
         workflow = ScheduledWorkflow(
@@ -840,10 +840,10 @@ class TestExecuteScheduledWorkflow:
 
         with (
             patch(
-                "mindroom.scheduling_executor.send_matrix_message",
+                "mindroom.matrix.client_delivery.send_message_outcome",
                 new=AsyncMock(
                     side_effect=[
-                        None,
+                        MatrixDeliveryFailure(MatrixDeliveryFailureKind.SEND_EXCEPTION, "Send failed"),
                         DeliveredMatrixEvent(
                             event_id="$error456",
                             content_sent={"body": "error"},
@@ -879,7 +879,7 @@ class TestExecuteScheduledWorkflow:
             room_id=None,  # No room ID
         )
 
-        with patch("mindroom.scheduling_executor.send_matrix_message", new=AsyncMock()) as mock_send:
+        with patch("mindroom.matrix.client_delivery.send_message_outcome", new=AsyncMock()) as mock_send:
             await execute_scheduled_workflow(
                 client,
                 workflow,


### PR DESCRIPTION
Recurring timers previously restarted from the current time, so downtime across a scheduled occurrence silently skipped that run. Persist the next due time and recover the latest missed occurrence within a configurable grace period, defaulting to one hour. Restored timers wait for Matrix sync readiness, and delayed live timers apply the same catch-up policy.

Freeze the prepared trigger before sending and reuse its schedule/time transaction ID on retry. This prevents duplicate triggers after an ambiguous acknowledgement on the same Matrix device, including silent tasks and large encrypted attachments. Skipped backlog is recorded and logged. Unresolved delivery on a changed device is held for reconciliation.

Checkpoint failures retry without stopping the schedule. Preparation retries reload current time and authoritative task state; acknowledgement writes retry in place without resending. Invalid trigger content and unrepresentable payloads before freezing fail visibly and advance the timer. Unexpected preparation errors retry.

Ownership stays explicit: checkpoint preparation returns its saved immutable occurrence, and the executor consumes Matrix's typed preparation and delivery results directly. Scheduler outcomes distinguish delivered, suppressed, failed, retry, and held. Hooks remain responsible for plugin execution. Planning tests use explicit times, while runner tests cover crash recovery and lifecycle behavior.

The checkpoint directory must persist across restarts. First adoption without a checkpoint and workflow edits establish a future cursor without replaying unknown history. `scheduler_catch_up_grace_seconds: 0` disables catch-up for unattempted occurrences. Cancellation stops execution while retaining history and checkpoints. Hook side effects require idempotency; recurring hooks receive a stable occurrence-specific correlation ID for preparation retries.

Validation:

- `uv run pytest -n 8 --no-cov`: 18,507 passed, 22 skipped
- `uv run pytest tests/test_recurring_schedule_recovery.py -n 0 --no-cov`: 48 passed
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`
- Independent architecture review: no blockers

Regression coverage includes restart catch-up, grace boundaries, coalescing, cancellation, workflow edits, crashes before and after acceptance, checkpoint failures, state changes during retries, delayed acknowledgements, hook retry identity, typed preparation and delivery failures, device holds, and encryption changes between retries.

## Summary by Sourcery

Make recurring schedules recover missed work safely while preserving trigger identity and delivery state across restarts and retries.

New Features:
- Recover missed recurring schedule occurrences after restarts and delayed timer wakes within a configurable grace period, with coalescing and skip tracking.
- Persist recurring schedule checkpoints and pending trigger state across restarts, including safe handling of adoption, edits, cancellation, and device changes.
- Add stable occurrence correlation IDs for recurring schedule hooks and durable Matrix transaction identities for trigger retries.

Bug Fixes:
- Prevent duplicate recurring triggers after ambiguous Matrix delivery acknowledgements, including silent tasks and encrypted or large messages.
- Keep schedules running through transient checkpoint failures while avoiding resends of already acknowledged deliveries.
- Advance recurring schedules and report visible failures for permanently invalid trigger content instead of retrying indefinitely.

Enhancements:
- Freeze prepared Matrix trigger content and sending-device ownership before delivery, and classify scheduled execution outcomes for retry, hold, suppression, and failure handling.
- Apply the same catch-up policy to live timers and defer restored recurring schedules until Matrix sync readiness.

Documentation:
- Document recurring schedule recovery, catch-up configuration, durable delivery behavior, and hook idempotency requirements.

Tests:
- Add comprehensive regression coverage for recurring schedule recovery, delivery retries, checkpoint failures, state changes, hook identity, encryption changes, cancellation, and permanent preparation failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recurring scheduled tasks now recover after restarts with a configurable catch-up window (default: 1 hour).
  - Missed occurrences are coalesced while preserving future scheduling cadence.
  - Delivery retries use stable identifiers and preserved content to help prevent duplicates.
  - Pending deliveries remain recoverable across sync delays, device changes, and interruptions.
  - Cancelling a recurring schedule prevents pending timers from firing.
  - Recurring hook executions provide a stable correlation ID for idempotent side effects.

- **Documentation**
  - Added guidance for configuration, recovery, retries, skipped occurrences, hooks, and cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

