### PR TITLE
Reject incomplete OpenAI Responses streams

### DIFF
--- a/src/mindroom/error_handling.py
+++ b/src/mindroom/error_handling.py
@@ -31,6 +31,10 @@ class ModelSafeguardRefusalError(ModelProviderError):
     """Raised when a provider explicitly stops generation for safeguards."""
 
 
+class IncompleteResponsesStreamError(ModelProviderError):
+    """A Responses stream cannot safely reuse accumulated output in a retry."""
+
+
 def is_model_safeguard_refusal(error: Exception | str) -> bool:
     """Recognize typed refusals and the exact text Agno preserves in errored runs."""
     return isinstance(error, ModelSafeguardRefusalError) or str(error).strip() == MODEL_SAFEGUARD_REFUSAL_MESSAGE

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from agno.exceptions import ModelProviderError
 from agno.models.deepseek import DeepSeek
@@ -22,7 +22,7 @@ from mindroom.openai_tool_search import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterator
+    from collections.abc import AsyncGenerator, AsyncIterator, Generator, Iterator
 
     from agno.models.message import Message
     from agno.models.response import ModelResponse
@@ -156,7 +156,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
     ) -> Iterator[ModelResponse]:
         """Require a successful terminal event for each provider invocation."""
         completed = False
-        for chunk in super().invoke_stream(
+        stream = super().invoke_stream(
             messages,
             assistant_message,
             response_format,
@@ -164,10 +164,15 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             tool_choice,
             run_response,
             compress_tool_results,
-        ):
-            # The parser publishes response_id only on response.completed.
-            completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
-            yield chunk
+        )
+        try:
+            for chunk in stream:
+                # The parser publishes response_id only on response.completed.
+                completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
+                yield chunk
+        finally:
+            # Agno returns a generator, annotated only as Iterator.
+            cast("Generator[ModelResponse, None, None]", stream).close()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
             raise ModelProviderError(
@@ -188,7 +193,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
     ) -> AsyncIterator[ModelResponse]:
         """Require a successful terminal event for each async provider invocation."""
         completed = False
-        async for chunk in super().ainvoke_stream(
+        stream = super().ainvoke_stream(
             messages,
             assistant_message,
             response_format,
@@ -196,9 +201,14 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             tool_choice,
             run_response,
             compress_tool_results,
-        ):
-            completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
-            yield chunk
+        )
+        try:
+            async for chunk in stream:
+                completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
+                yield chunk
+        finally:
+            # Finalize Agno's async generator when the consumer stops at a yield.
+            await cast("AsyncGenerator[ModelResponse, None]", stream).aclose()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
             raise ModelProviderError(

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -85,7 +85,7 @@ class MindRoomLlamaCpp(ChatToolArgumentsCompat, LlamaCpp):
 
 
 class _IncompleteResponsesStreamError(ModelProviderError):
-    """A Responses stream ended before successful completion."""
+    """A Responses stream cannot safely reuse accumulated output in a retry."""
 
 
 @dataclass
@@ -164,6 +164,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
     ) -> Iterator[ModelResponse]:
         """Require a successful terminal event for each provider invocation."""
         completed = False
+        yielded = False
         stream = super().invoke_stream(
             messages,
             assistant_message,
@@ -175,9 +176,15 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         )
         try:
             for chunk in stream:
+                yielded = True
                 # The parser publishes response_id only on response.completed.
                 completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
                 yield chunk
+        except ModelProviderError as error:
+            if not yielded:
+                raise
+            msg = "OpenAI Responses stream failed after yielding output"
+            raise _IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
         finally:
             # Agno returns a generator, annotated only as Iterator.
             cast("Generator[ModelResponse, None, None]", stream).close()
@@ -201,6 +208,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
     ) -> AsyncIterator[ModelResponse]:
         """Require a successful terminal event for each async provider invocation."""
         completed = False
+        yielded = False
         stream = super().ainvoke_stream(
             messages,
             assistant_message,
@@ -212,8 +220,14 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         )
         try:
             async for chunk in stream:
+                yielded = True
                 completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
                 yield chunk
+        except ModelProviderError as error:
+            if not yielded:
+                raise
+            msg = "OpenAI Responses stream failed after yielding output"
+            raise _IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
         finally:
             # Finalize Agno's async generator when the consumer stops at a yield.
             await cast("AsyncGenerator[ModelResponse, None]", stream).aclose()

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -84,6 +84,10 @@ class MindRoomLlamaCpp(ChatToolArgumentsCompat, LlamaCpp):
     """llama.cpp server model that can replay tool calls from other providers."""
 
 
+class _IncompleteResponsesStreamError(ModelProviderError):
+    """A Responses stream ended before successful completion."""
+
+
 @dataclass
 class MindRoomOpenAIResponses(OpenAIResponses):
     """OpenAI Responses model that preserves completed response and tool-search state."""
@@ -144,6 +148,10 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         record_tool_search_items(model_response, response.output)
         return model_response
 
+    def _is_retryable_error(self, error: ModelProviderError) -> bool:
+        """Do not retry incomplete streams with Agno's retained partial text and tool calls."""
+        return not isinstance(error, _IncompleteResponsesStreamError) and super()._is_retryable_error(error)
+
     def invoke_stream(
         self,
         messages: list[Message],
@@ -175,7 +183,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             cast("Generator[ModelResponse, None, None]", stream).close()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
-            raise ModelProviderError(
+            raise _IncompleteResponsesStreamError(
                 msg,
                 model_name=self.name,
                 model_id=self.id,
@@ -211,7 +219,7 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             await cast("AsyncGenerator[ModelResponse, None]", stream).aclose()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
-            raise ModelProviderError(
+            raise _IncompleteResponsesStreamError(
                 msg,
                 model_name=self.name,
                 model_id=self.id,

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from agno.exceptions import ModelProviderError
 from agno.models.deepseek import DeepSeek
 from agno.models.llama_cpp import LlamaCpp
 from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
-from openai.types.responses import ResponseOutputItemDoneEvent
+from openai.types.responses import ResponseCompletedEvent, ResponseCreatedEvent, ResponseOutputItemDoneEvent
 
 from mindroom.legacy_openai_tool_replay import repair_legacy_openai_tool_replay
 from mindroom.openai_tool_search import (
@@ -21,6 +22,8 @@ from mindroom.openai_tool_search import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
     from agno.models.message import Message
     from agno.models.response import ModelResponse
     from agno.run.agent import RunOutput
@@ -83,7 +86,7 @@ class MindRoomLlamaCpp(ChatToolArgumentsCompat, LlamaCpp):
 
 @dataclass
 class MindRoomOpenAIResponses(OpenAIResponses):
-    """OpenAI Responses model that preserves native tool-search state."""
+    """OpenAI Responses model that preserves completed response and tool-search state."""
 
     approval_receipt_after_response_id: ClassVar[bool] = True
 
@@ -141,14 +144,86 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         record_tool_search_items(model_response, response.output)
         return model_response
 
+    def invoke_stream(
+        self,
+        messages: list[Message],
+        assistant_message: Message,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | None = None,
+        compress_tool_results: bool = False,
+    ) -> Iterator[ModelResponse]:
+        """Require a successful terminal event for each provider invocation."""
+        completed = False
+        for chunk in super().invoke_stream(
+            messages,
+            assistant_message,
+            response_format,
+            tools,
+            tool_choice,
+            run_response,
+            compress_tool_results,
+        ):
+            # The parser publishes response_id only on response.completed.
+            completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
+            yield chunk
+        if not completed:
+            msg = "OpenAI Responses stream ended without response.completed"
+            raise ModelProviderError(
+                msg,
+                model_name=self.name,
+                model_id=self.id,
+            )
+
+    async def ainvoke_stream(
+        self,
+        messages: list[Message],
+        assistant_message: Message,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | None = None,
+        compress_tool_results: bool = False,
+    ) -> AsyncIterator[ModelResponse]:
+        """Require a successful terminal event for each async provider invocation."""
+        completed = False
+        async for chunk in super().ainvoke_stream(
+            messages,
+            assistant_message,
+            response_format,
+            tools,
+            tool_choice,
+            run_response,
+            compress_tool_results,
+        ):
+            completed = completed or bool(chunk.provider_data and chunk.provider_data.get("response_id"))
+            yield chunk
+        if not completed:
+            msg = "OpenAI Responses stream ended without response.completed"
+            raise ModelProviderError(
+                msg,
+                model_name=self.name,
+                model_id=self.id,
+            )
+
     def _parse_provider_response_delta(
         self,
         stream_event: ResponseStreamEvent,
         assistant_message: Message,
         tool_use: dict[str, Any],
     ) -> tuple[ModelResponse, dict[str, Any]]:
-        """Capture streamed tool-search output items that Agno drops."""
+        """Publish only completed response IDs and capture native tool-search items."""
         model_response, tool_use = super()._parse_provider_response_delta(stream_event, assistant_message, tool_use)
+        if isinstance(stream_event, ResponseCreatedEvent) and model_response.provider_data is not None:
+            # An unfinished response may contain tool calls we never received.
+            # Chaining to it would require outputs that we cannot supply.
+            model_response.provider_data.pop("response_id", None)
+        elif isinstance(stream_event, ResponseCompletedEvent):
+            model_response.provider_data = {
+                **(model_response.provider_data or {}),
+                "response_id": stream_event.response.id,
+            }
         if isinstance(stream_event, ResponseOutputItemDoneEvent):
             record_tool_search_items(model_response, [stream_event.item])
         return model_response, tool_use

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -13,6 +13,7 @@ from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
 from openai.types.responses import ResponseCompletedEvent, ResponseCreatedEvent, ResponseOutputItemDoneEvent
 
+from mindroom.error_handling import IncompleteResponsesStreamError
 from mindroom.legacy_openai_tool_replay import repair_legacy_openai_tool_replay
 from mindroom.openai_tool_search import (
     formatted_input_with_tool_search_items,
@@ -84,10 +85,6 @@ class MindRoomLlamaCpp(ChatToolArgumentsCompat, LlamaCpp):
     """llama.cpp server model that can replay tool calls from other providers."""
 
 
-class _IncompleteResponsesStreamError(ModelProviderError):
-    """A Responses stream cannot safely reuse accumulated output in a retry."""
-
-
 @dataclass
 class MindRoomOpenAIResponses(OpenAIResponses):
     """OpenAI Responses model that preserves completed response and tool-search state."""
@@ -148,9 +145,13 @@ class MindRoomOpenAIResponses(OpenAIResponses):
         record_tool_search_items(model_response, response.output)
         return model_response
 
+    # Agno 3.0.9 workaround; upstream completion/response-ID fix:
+    # https://github.com/agno-agi/agno/pull/10135
+    # Remove duplicate completion/ID checks after pinning a release with that fix.
+    # Keep retry protection until Agno also avoids reusing partial stream output.
     def _is_retryable_error(self, error: ModelProviderError) -> bool:
         """Do not retry incomplete streams with Agno's retained partial text and tool calls."""
-        return not isinstance(error, _IncompleteResponsesStreamError) and super()._is_retryable_error(error)
+        return not isinstance(error, IncompleteResponsesStreamError) and super()._is_retryable_error(error)
 
     def invoke_stream(
         self,
@@ -184,13 +185,13 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             if not yielded:
                 raise
             msg = "OpenAI Responses stream failed after yielding output"
-            raise _IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
+            raise IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
         finally:
             # Agno returns a generator, annotated only as Iterator.
             cast("Generator[ModelResponse, None, None]", stream).close()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
-            raise _IncompleteResponsesStreamError(
+            raise IncompleteResponsesStreamError(
                 msg,
                 model_name=self.name,
                 model_id=self.id,
@@ -227,13 +228,13 @@ class MindRoomOpenAIResponses(OpenAIResponses):
             if not yielded:
                 raise
             msg = "OpenAI Responses stream failed after yielding output"
-            raise _IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
+            raise IncompleteResponsesStreamError(msg, model_name=self.name, model_id=self.id) from error
         finally:
             # Finalize Agno's async generator when the consumer stops at a yield.
             await cast("AsyncGenerator[ModelResponse, None]", stream).aclose()
         if not completed:
             msg = "OpenAI Responses stream ended without response.completed"
-            raise _IncompleteResponsesStreamError(
+            raise IncompleteResponsesStreamError(
                 msg,
                 model_name=self.name,
                 model_id=self.id,

--- a/src/mindroom/provider_media_fallback.py
+++ b/src/mindroom/provider_media_fallback.py
@@ -12,7 +12,11 @@ from typing import TYPE_CHECKING, Never, Protocol, cast, runtime_checkable
 from agno.exceptions import ContextWindowExceededError, ModelProviderError, RetryableModelProviderError
 from agno.models.message import Message
 
-from mindroom.error_handling import TRANSIENT_PROVIDER_STATUS_CODES, is_model_safeguard_refusal
+from mindroom.error_handling import (
+    TRANSIENT_PROVIDER_STATUS_CODES,
+    IncompleteResponsesStreamError,
+    is_model_safeguard_refusal,
+)
 from mindroom.logging_config import get_logger
 from mindroom.redaction import redact_sensitive_text
 
@@ -482,7 +486,9 @@ def _route_text(value: str | None) -> str | None:
 
 
 def _should_retry(error: Exception) -> bool:
-    return not isinstance(error, RetryableModelProviderError) and not is_model_safeguard_refusal(error)
+    return not isinstance(error, (RetryableModelProviderError, IncompleteResponsesStreamError)) and not (
+        is_model_safeguard_refusal(error)
+    )
 
 
 def _should_learn(error: Exception, media_kinds: frozenset[MediaKind]) -> bool:

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -470,7 +470,7 @@ def _response_completed_event(response_id: str) -> ResponseCompletedEvent:
             "response": {
                 "id": response_id,
                 "created_at": 1,
-                "model": "gpt-5.6",
+                "model": "gpt-6-astra",
                 "object": "response",
                 "status": "completed",
                 "output": [],
@@ -609,7 +609,7 @@ def test_codex_tool_search_items_round_trip_through_streaming_history() -> None:
         _response_completed_event("resp_1"),
     ]
     client = _FakeCodexClient([first_batch, [_response_completed_event("resp_2")]])
-    model = CodexResponses(id="gpt-5.6")
+    model = CodexResponses(id="gpt-6-astra")
     vars(model)["get_client"] = lambda: client
 
     messages = [Message(role="user", content="What is the weather?")]

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -19,7 +19,7 @@ from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 from agno.models.response import ModelResponse
 from agno.utils.models.claude import format_messages as claude_format_messages
-from openai.types.responses import Response, ResponseOutputItemDoneEvent, ResponseTextDeltaEvent
+from openai.types.responses import Response, ResponseCompletedEvent, ResponseOutputItemDoneEvent, ResponseTextDeltaEvent
 
 from mindroom import codex_model
 from mindroom.codex_model import (
@@ -462,6 +462,26 @@ def _output_item_done_event(item: dict[str, object], index: int) -> ResponseOutp
     )
 
 
+def _response_completed_event(response_id: str) -> ResponseCompletedEvent:
+    return ResponseCompletedEvent.model_validate(
+        {
+            "type": "response.completed",
+            "sequence_number": 3,
+            "response": {
+                "id": response_id,
+                "created_at": 1,
+                "model": "gpt-5.6",
+                "object": "response",
+                "status": "completed",
+                "output": [],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+        },
+    )
+
+
 class _FakeResponsesAPI:
     def __init__(self, event_batches: list[list[object]]) -> None:
         self._event_batches = iter(event_batches)
@@ -586,8 +606,9 @@ def test_codex_tool_search_items_round_trip_through_streaming_history() -> None:
         _output_item_done_event(_TOOL_SEARCH_CALL_ITEM, 0),
         _output_item_done_event(_TOOL_SEARCH_OUTPUT_ITEM, 1),
         text_event,
+        _response_completed_event("resp_1"),
     ]
-    client = _FakeCodexClient([first_batch, []])
+    client = _FakeCodexClient([first_batch, [_response_completed_event("resp_2")]])
     model = CodexResponses(id="gpt-5.6")
     vars(model)["get_client"] = lambda: client
 
@@ -599,7 +620,7 @@ def test_codex_tool_search_items_round_trip_through_streaming_history() -> None:
         _output_item_done_event(_TOOL_SEARCH_CALL_ITEM, 0).item.model_dump(exclude_none=True),
         _output_item_done_event(_TOOL_SEARCH_OUTPUT_ITEM, 1).item.model_dump(exclude_none=True),
     ]
-    assert messages[1].provider_data == {"tool_search_items": expected_items}
+    assert messages[1].provider_data == {"tool_search_items": expected_items, "response_id": "resp_1"}
     assert client.responses.captured_kwargs[1]["input"] == [
         {"role": "user", "content": "What is the weather?"},
         *expected_items,

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,7 @@ from agno.db.base import SessionType
 from agno.db.sqlite import SqliteDb
 from agno.exceptions import ModelProviderError
 from agno.models.message import Message
+from agno.models.openai import OpenAIResponses
 from agno.run.agent import RunCompletedEvent, RunErrorEvent
 from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
@@ -199,6 +201,41 @@ async def test_cancelled_request_remains_cancelled() -> None:
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
+
+
+async def test_closing_sync_stream_closes_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closing the wrapper must close the actual parent even when another reference keeps it alive."""
+    async with _model(_created() + _text()) as model:
+        messages = [Message(role="user", content="Check")]
+        assistant = Message(role="assistant")
+        parent = OpenAIResponses.invoke_stream(model, messages, assistant)
+        monkeypatch.setattr(OpenAIResponses, "invoke_stream", lambda *_args: parent)
+        stream = model.invoke_stream(messages, assistant)
+        assert isinstance(stream, Generator)
+        next(stream)
+        stream.close()
+        with pytest.raises(StopIteration):
+            next(parent)
+
+
+@pytest.mark.parametrize("cancel", [False, True], ids=["close", "cancel"])
+async def test_closing_async_stream_closes_parent(monkeypatch: pytest.MonkeyPatch, *, cancel: bool) -> None:
+    """Early close or cancellation after a chunk must finalize the actual superclass stream."""
+    async with _model(_created() + _text()) as model:
+        messages = [Message(role="user", content="Check")]
+        assistant = Message(role="assistant")
+        parent = OpenAIResponses.ainvoke_stream(model, messages, assistant)
+        monkeypatch.setattr(OpenAIResponses, "ainvoke_stream", lambda *_args: parent)
+        stream = model.ainvoke_stream(messages, assistant)
+        assert isinstance(stream, AsyncGenerator)
+        await anext(stream)
+        if cancel:
+            with pytest.raises(asyncio.CancelledError):
+                await stream.athrow(asyncio.CancelledError())
+        else:
+            await stream.aclose()
+        with pytest.raises(StopAsyncIteration):
+            await anext(parent)
 
 
 async def test_agent_records_truncated_followup_as_error_after_completed_tool(tmp_path: Path) -> None:

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -24,7 +24,7 @@ from openai import AsyncOpenAI, OpenAI
 from mindroom.openai_models import MindRoomOpenAIResponses
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
     from pathlib import Path
 
     from agno.models.response import ModelResponse
@@ -80,6 +80,20 @@ def _tool_stream() -> str:
         + _event("response.output_item.done", output_index=0, item=call)
         + _event("response.completed", response=_response("resp_tools", "completed", [call]))
     )
+
+
+class _InterruptedStream(httpx.SyncByteStream, httpx.AsyncByteStream):
+    def __init__(self, data: str) -> None:
+        self.data = data.encode()
+
+    def __iter__(self) -> Iterator[bytes]:
+        yield self.data
+        msg = "Connection dropped"
+        raise httpx.ReadError(msg)
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self:
+            yield chunk
 
 
 @asynccontextmanager
@@ -274,11 +288,34 @@ async def test_agent_records_truncated_followup_as_error_after_completed_tool(tm
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 @pytest.mark.parametrize(
-    "stream",
-    [_created() + _text(), _tool_stream().split("event: response.completed")[0]],
-    ids=["partial-text", "partial-tool"],
+    ("stream", "disconnect"),
+    [
+        (_created() + _text(), False),
+        (_created() + _text(), True),
+        (_tool_stream().split("event: response.completed")[0], False),
+        (_tool_stream().split("event: response.completed")[0], True),
+        (
+            _created("resp_answer")
+            + _text()
+            + _event("response.completed", response=_response("resp_answer", "completed")),
+            True,
+        ),
+    ],
+    ids=[
+        "partial-text-eof",
+        "partial-text-transport-error",
+        "partial-tool-eof",
+        "partial-tool-transport-error",
+        "completed-transport-error",
+    ],
 )
-async def test_agent_does_not_retry_incomplete_stream(tmp_path: Path, stream: str, *, sync: bool) -> None:
+async def test_agent_does_not_retry_incomplete_stream(
+    tmp_path: Path,
+    stream: str,
+    *,
+    sync: bool,
+    disconnect: bool,
+) -> None:
     """Retries must not combine partial output with a successful response or execute its tools."""
     executed_tools: list[str] = []
 
@@ -293,7 +330,12 @@ async def test_agent_does_not_retry_incomplete_stream(tmp_path: Path, stream: st
         + _event("response.completed", response=_response("resp_no_tools", "completed"))
     )
     db = SqliteDb(db_file=str(tmp_path / "sessions.db"))
-    async with _model(stream, completed, completed) as model:
+    first_response = (
+        httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=_InterruptedStream(stream))
+        if disconnect
+        else stream
+    )
+    async with _model(first_response, completed, completed) as model:
         model.retries = 1
         model.delay_between_retries = 0
         agent = Agent(id="status_agent", model=model, db=db, tools=[get_status], add_history_to_context=True)
@@ -321,10 +363,14 @@ async def test_agent_does_not_retry_incomplete_stream(tmp_path: Path, stream: st
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
-@pytest.mark.parametrize("status_code", [429, 503])
-async def test_agent_still_retries_transient_provider_errors(status_code: int, *, sync: bool) -> None:
+@pytest.mark.parametrize("status_code", [429, 503, None], ids=["429", "503", "transport-error"])
+async def test_agent_still_retries_transient_provider_errors(status_code: int | None, *, sync: bool) -> None:
     """The incomplete-stream guard must preserve ordinary provider retries before any output."""
-    failed = httpx.Response(status_code, json={"error": {"message": "Temporarily unavailable", "type": "server_error"}})
+    failed = (
+        httpx.Response(status_code, json={"error": {"message": "Temporarily unavailable", "type": "server_error"}})
+        if status_code is not None
+        else httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=_InterruptedStream(""))
+    )
     completed = (
         _created("resp_answer") + _text() + _event("response.completed", response=_response("resp_answer", "completed"))
     )

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -1,0 +1,228 @@
+"""Exercise Responses stream completion through the real SDK and agent runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+from agno.agent import Agent
+from agno.db.base import SessionType
+from agno.db.sqlite import SqliteDb
+from agno.exceptions import ModelProviderError
+from agno.models.message import Message
+from agno.run.agent import RunCompletedEvent, RunErrorEvent
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+from openai import AsyncOpenAI, OpenAI
+
+from mindroom.openai_models import MindRoomOpenAIResponses
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from agno.models.response import ModelResponse
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _event(kind: str, **fields: object) -> str:
+    return f"event: {kind}\ndata: {json.dumps({'type': kind, 'sequence_number': 0, **fields})}\n\n"
+
+
+def _response(response_id: str, status: str, output: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": 1,
+        "model": "gpt-6-astra",
+        "status": status,
+        "output": output or [],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "temperature": 1,
+        "top_p": 1,
+        "usage": None,
+        "error": None,
+        "incomplete_details": None,
+    }
+
+
+def _created(response_id: str = "resp_unfinished") -> str:
+    return _event("response.created", response=_response(response_id, "in_progress"))
+
+
+def _text() -> str:
+    return _event("response.output_text.delta", item_id="msg_answer", output_index=0, content_index=0, delta="Ready")
+
+
+def _tool_stream() -> str:
+    call = {
+        "type": "function_call",
+        "id": "fc_status",
+        "call_id": "call_status",
+        "name": "get_status",
+        "arguments": "{}",
+        "status": "completed",
+    }
+    return (
+        _created("resp_tools")
+        + _event("response.output_item.added", output_index=0, item={**call, "arguments": "", "status": "in_progress"})
+        + _event("response.function_call_arguments.delta", output_index=0, item_id="fc_status", delta="{}")
+        + _event("response.output_item.done", output_index=0, item=call)
+        + _event("response.completed", response=_response("resp_tools", "completed", [call]))
+    )
+
+
+@asynccontextmanager
+async def _model(*streams: str, store: bool = True) -> AsyncIterator[MindRoomOpenAIResponses]:
+    remaining = iter(streams)
+
+    def respond(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=next(remaining))
+
+    transport = httpx.MockTransport(respond)
+    with OpenAI(api_key="test-key", http_client=httpx.Client(transport=transport)) as client:
+        async with AsyncOpenAI(api_key="test-key", http_client=httpx.AsyncClient(transport=transport)) as async_client:
+            yield MindRoomOpenAIResponses(id="gpt-6-astra", client=client, async_client=async_client, store=store)
+
+
+async def _invoke(model: MindRoomOpenAIResponses, *, sync: bool) -> AsyncIterator[ModelResponse]:
+    messages = [Message(role="user", content="Check status")]
+    assistant = Message(role="assistant")
+    if sync:
+        for chunk in model.invoke_stream(messages, assistant):
+            yield chunk
+    else:
+        async for chunk in model.ainvoke_stream(messages, assistant):
+            yield chunk
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "stream",
+    [
+        "",
+        _created(),
+        _created() + _text(),
+        _created()
+        + _event(
+            "response.failed",
+            response={
+                **_response("resp_unfinished", "failed"),
+                "error": {"code": "server_error", "message": "Generation failed"},
+            },
+        ),
+        _created()
+        + _event(
+            "response.incomplete",
+            response={
+                **_response("resp_unfinished", "incomplete"),
+                "incomplete_details": {"reason": "max_output_tokens"},
+            },
+        ),
+    ],
+    ids=["empty", "created-only", "partial-text", "failed", "incomplete"],
+)
+async def test_unsuccessful_stream_raises_without_publishing_response_id(stream: str, *, sync: bool) -> None:
+    """EOF, failed, and incomplete responses must not become replay anchors."""
+    async with _model(stream) as model:
+        with pytest.raises(ModelProviderError):  # noqa: PT012 - inspect each chunk before failure
+            async for chunk in _invoke(model, sync=sync):
+                assert not chunk.provider_data or "response_id" not in chunk.provider_data
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize("store", [True, False], ids=["stored", "stateless"])
+async def test_completed_text_publishes_response_id_only_at_completion(*, sync: bool, store: bool) -> None:
+    """Successful completion is independent of usage metrics and storage mode."""
+    stream = (
+        _created("resp_answer") + _text() + _event("response.completed", response=_response("resp_answer", "completed"))
+    )
+    async with _model(stream, store=store) as model:
+        chunks = [chunk async for chunk in _invoke(model, sync=sync)]
+
+    assert "".join(chunk.content or "" for chunk in chunks) == "Ready"
+    assert all(not chunk.provider_data or "response_id" not in chunk.provider_data for chunk in chunks[:-1])
+    assert chunks[-1].provider_data == {"response_id": "resp_answer"}
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_completed_tool_stream_does_not_complete_the_next_invocation(*, sync: bool) -> None:
+    """A valid tools-only response cannot hide a later truncated response."""
+    async with _model(_tool_stream(), _created()) as model:
+        chunks = [chunk async for chunk in _invoke(model, sync=sync)]
+        assert [call["function"]["name"] for chunk in chunks for call in chunk.tool_calls] == ["get_status"]
+        assert chunks[-1].provider_data == {"response_id": "resp_tools"}
+
+        with pytest.raises(ModelProviderError, match=r"response\.completed"):
+            _ = [chunk async for chunk in _invoke(model, sync=sync)]
+
+
+async def test_concurrent_invocations_do_not_share_completion_state() -> None:
+    """Completion of one request cannot validate another active request on the same model."""
+    completed = _created("resp_answer") + _event("response.completed", response=_response("resp_answer", "completed"))
+    async with _model(completed, _created()) as model:
+        first = model.ainvoke_stream([Message(role="user", content="First")], Message(role="assistant"))
+        second = model.ainvoke_stream([Message(role="user", content="Second")], Message(role="assistant"))
+        await anext(first)
+        await anext(second)
+        _ = [chunk async for chunk in first]
+        with pytest.raises(ModelProviderError, match=r"response\.completed"):
+            _ = [chunk async for chunk in second]
+
+
+async def test_cancelled_request_remains_cancelled() -> None:
+    """Cancellation while waiting for the provider must not become a completion error."""
+    entered = asyncio.Event()
+
+    async def respond(_request: httpx.Request) -> httpx.Response:
+        entered.set()
+        await asyncio.Future()
+        raise AssertionError
+
+    async with AsyncOpenAI(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(respond)),
+    ) as client:
+        model = MindRoomOpenAIResponses(id="gpt-6-astra", async_client=client)
+        task = asyncio.create_task(
+            anext(model.ainvoke_stream([Message(role="user", content="Check")], Message(role="assistant"))),
+        )
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_agent_records_truncated_followup_as_error_after_completed_tool(tmp_path: Path) -> None:
+    """An earlier successful tool must not allow a truncated final response into history."""
+
+    def get_status() -> str:
+        """Return the local status."""
+        return "ready"
+
+    db = SqliteDb(db_file=str(tmp_path / "sessions.db"))
+    async with _model(_tool_stream(), _created()) as model:
+        agent = Agent(id="status_agent", model=model, db=db, tools=[get_status], add_history_to_context=True)
+        events = [
+            event
+            async for event in agent.arun("Check status", session_id="status_session", stream=True, stream_events=True)
+        ]
+        assert not any(isinstance(event, RunCompletedEvent) for event in events)
+        assert any(isinstance(event, RunErrorEvent) for event in events)
+
+        session = db.get_session("status_session", SessionType.AGENT)
+        assert isinstance(session, AgentSession)
+        run = session.runs[-1]
+        assert RunStatus(run.status) is RunStatus.error
+        assert run.tools is not None
+        assert [(tool.tool_name, tool.result) for tool in run.tools] == [("get_status", "ready")]
+        history = [*session.get_messages(agent_id="status_agent"), Message(role="user", content="Follow up")]
+        assert "previous_response_id" not in model.get_request_params(messages=history)

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -14,6 +14,7 @@ from agno.agent import Agent
 from agno.db.base import SessionType
 from agno.db.sqlite import SqliteDb
 from agno.exceptions import ModelProviderError
+from agno.media import Image
 from agno.models.message import Message
 from agno.models.openai import OpenAIResponses
 from agno.run.agent import RunCompletedEvent, RunErrorEvent
@@ -21,7 +22,10 @@ from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
 from openai import AsyncOpenAI, OpenAI
 
+from mindroom.codex_model import CodexResponses
 from mindroom.openai_models import MindRoomOpenAIResponses
+from mindroom.prompts import INLINE_MEDIA_FALLBACK_PROMPT
+from mindroom.provider_media_fallback import install_provider_media_fallback
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -360,6 +364,52 @@ async def test_agent_does_not_retry_incomplete_stream(
         assert RunStatus(session.runs[-1].status) is RunStatus.error
         history = [*session.get_messages(agent_id="status_agent"), Message(role="user", content="Follow up")]
         assert "previous_response_id" not in model.get_request_params(messages=history)
+
+
+@pytest.mark.parametrize("disconnect", [False, True], ids=["eof", "transport-error"])
+async def test_codex_media_fallback_does_not_retry_incomplete_tool_stream(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    disconnect: bool,
+) -> None:
+    """A blocking Codex call must not execute failed-stream tools through media fallback."""
+    executed_tools: list[str] = []
+
+    def get_status() -> str:
+        """Return the local status."""
+        executed_tools.append("get_status")
+        return "ready"
+
+    partial = _tool_stream().split("event: response.completed")[0]
+    first_response = (
+        httpx.Response(200, headers={"content-type": "text/event-stream"}, stream=_InterruptedStream(partial))
+        if disconnect
+        else partial
+    )
+    completed = (
+        _created("resp_no_tools")
+        + _text()
+        + _event("response.completed", response=_response("resp_no_tools", "completed"))
+    )
+    db = SqliteDb(db_file=str(tmp_path / "sessions.db"))
+    async with _model(first_response, completed, completed) as sdk_model:
+        model = CodexResponses(id="gpt-6-astra")
+        monkeypatch.setattr(model, "get_async_client", lambda: sdk_model.async_client)
+        install_provider_media_fallback(model, fallback_prompt=INLINE_MEDIA_FALLBACK_PROMPT)
+        agent = Agent(id="status_agent", model=model, db=db, tools=[get_status])
+        result = await agent.arun(
+            "Check status",
+            session_id="status_session",
+            images=[Image(url="https://example.com/image.png")],
+        )
+
+    assert executed_tools == []
+    assert result.status is RunStatus.error
+    session = db.get_session("status_session", SessionType.AGENT)
+    assert isinstance(session, AgentSession)
+    assert RunStatus(session.runs[-1].status) is RunStatus.error
+    assert session.get_messages(agent_id="status_agent") == []
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])

--- a/tests/test_openai_responses_stream.py
+++ b/tests/test_openai_responses_stream.py
@@ -83,15 +83,22 @@ def _tool_stream() -> str:
 
 
 @asynccontextmanager
-async def _model(*streams: str, store: bool = True) -> AsyncIterator[MindRoomOpenAIResponses]:
+async def _model(*streams: str | httpx.Response, store: bool = True) -> AsyncIterator[MindRoomOpenAIResponses]:
     remaining = iter(streams)
 
     def respond(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=next(remaining))
+        response = next(remaining)
+        if isinstance(response, httpx.Response):
+            return response
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=response)
 
     transport = httpx.MockTransport(respond)
-    with OpenAI(api_key="test-key", http_client=httpx.Client(transport=transport)) as client:
-        async with AsyncOpenAI(api_key="test-key", http_client=httpx.AsyncClient(transport=transport)) as async_client:
+    with OpenAI(api_key="test-key", max_retries=0, http_client=httpx.Client(transport=transport)) as client:
+        async with AsyncOpenAI(
+            api_key="test-key",
+            max_retries=0,
+            http_client=httpx.AsyncClient(transport=transport),
+        ) as async_client:
             yield MindRoomOpenAIResponses(id="gpt-6-astra", client=client, async_client=async_client, store=store)
 
 
@@ -263,3 +270,72 @@ async def test_agent_records_truncated_followup_as_error_after_completed_tool(tm
         assert [(tool.tool_name, tool.result) for tool in run.tools] == [("get_status", "ready")]
         history = [*session.get_messages(agent_id="status_agent"), Message(role="user", content="Follow up")]
         assert "previous_response_id" not in model.get_request_params(messages=history)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "stream",
+    [_created() + _text(), _tool_stream().split("event: response.completed")[0]],
+    ids=["partial-text", "partial-tool"],
+)
+async def test_agent_does_not_retry_incomplete_stream(tmp_path: Path, stream: str, *, sync: bool) -> None:
+    """Retries must not combine partial output with a successful response or execute its tools."""
+    executed_tools: list[str] = []
+
+    def get_status() -> str:
+        """Return the local status."""
+        executed_tools.append("get_status")
+        return "ready"
+
+    completed = (
+        _created("resp_no_tools")
+        + _text()
+        + _event("response.completed", response=_response("resp_no_tools", "completed"))
+    )
+    db = SqliteDb(db_file=str(tmp_path / "sessions.db"))
+    async with _model(stream, completed, completed) as model:
+        model.retries = 1
+        model.delay_between_retries = 0
+        agent = Agent(id="status_agent", model=model, db=db, tools=[get_status], add_history_to_context=True)
+        if sync:
+            events = list(agent.run("Check status", session_id="status_session", stream=True, stream_events=True))
+        else:
+            events = [
+                event
+                async for event in agent.arun(
+                    "Check status",
+                    session_id="status_session",
+                    stream=True,
+                    stream_events=True,
+                )
+            ]
+
+        assert executed_tools == []
+        assert not any(isinstance(event, RunCompletedEvent) for event in events)
+        assert any(isinstance(event, RunErrorEvent) for event in events)
+        session = db.get_session("status_session", SessionType.AGENT)
+        assert isinstance(session, AgentSession)
+        assert RunStatus(session.runs[-1].status) is RunStatus.error
+        history = [*session.get_messages(agent_id="status_agent"), Message(role="user", content="Follow up")]
+        assert "previous_response_id" not in model.get_request_params(messages=history)
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize("status_code", [429, 503])
+async def test_agent_still_retries_transient_provider_errors(status_code: int, *, sync: bool) -> None:
+    """The incomplete-stream guard must preserve ordinary provider retries before any output."""
+    failed = httpx.Response(status_code, json={"error": {"message": "Temporarily unavailable", "type": "server_error"}})
+    completed = (
+        _created("resp_answer") + _text() + _event("response.completed", response=_response("resp_answer", "completed"))
+    )
+    async with _model(failed, completed) as model:
+        model.retries = 1
+        model.delay_between_retries = 0
+        agent = Agent(model=model)
+        if sync:
+            events = list(agent.run("Check status", stream=True, stream_events=True))
+        else:
+            events = [event async for event in agent.arun("Check status", stream=True, stream_events=True)]
+
+    assert not any(isinstance(event, RunErrorEvent) for event in events)
+    assert [event.content for event in events if isinstance(event, RunCompletedEvent)] == ["Ready"]


### PR DESCRIPTION
An unfinished OpenAI Responses stream could be saved as a successful assistant turn.
Reusing its response ID could then fail with missing tool outputs; retries could also combine partial text or execute stale tool calls.

Require `response.completed` for each sync or async provider invocation and publish response IDs only at completion.
The wrappers preserve Agno's request construction and parsing, including native tool-search metadata, tools-only responses, cancellation, and concurrent calls.
A code comment links the upstream completion fix and explains when the local checks can be removed.

Stop retries after streamed output begins because Agno retains partial text and tool calls across attempts.
The same terminal error also stops Codex's non-streaming media fallback, which otherwise bypasses the ordinary stream retry guard.
Errors before output preserve ordinary provider retries and media fallback.
Trailing provider failures after completion retain the existing run-error behavior, preventing duplicate output from a retry.

Validation:
- 40 regression cases exercise the real SDK, Agent/SQLite persistence, sync/async completion, cancellation, retries, and transport failures.
- New Codex/image regressions reproduced stale tool execution before the fix, then passed with no tool execution or successful replay history.
- Focused model, media-fallback, approval-receipt, and import tests: 189 passed.
- Full suite: `uv run --no-sync pytest -n 4 --no-cov -o addopts='' -q` — 18,499 passed, 22 skipped, 21 warnings.
- All repository hooks passed with `uv run pre-commit run --all-files`.
- Independent critical review approved the final change and found no useful simplification.
