### PR TITLE
Clarify connections and external MCP access

### DIFF
--- a/docs/deployment/mcp-gateway.md
+++ b/docs/deployment/mcp-gateway.md
@@ -53,7 +53,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
 The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
-Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Under **MCP gateway**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.

--- a/frontend/src/connections/AgentTable.tsx
+++ b/frontend/src/connections/AgentTable.tsx
@@ -84,7 +84,7 @@ const columns: ColumnDef<AgentTableRow>[] = [
   },
   {
     id: "mcp",
-    header: "MCP access",
+    header: "MCP gateway",
     cell: ({ row }) => {
       const mcp = row.original.mcp;
       if (!row.original.can_use)
@@ -211,7 +211,7 @@ export function AgentTable({
             <option value="personal">Personal</option>
             <option value="shared">Shared</option>
             {mcp.selection?.enabled && (
-              <option value="exposed">MCP enabled</option>
+              <option value="exposed">On MCP gateway</option>
             )}
           </select>
         </div>

--- a/frontend/src/connections/AgentTools.tsx
+++ b/frontend/src/connections/AgentTools.tsx
@@ -39,7 +39,7 @@ export function AgentTools({
               Connection
             </th>
             <th scope="col" className="w-[15%] px-4 py-3 font-medium">
-              MCP access
+              MCP gateway
             </th>
             <th scope="col" className="px-5 py-3 text-right font-medium">
               Actions

--- a/frontend/src/connections/ConnectedClients.test.tsx
+++ b/frontend/src/connections/ConnectedClients.test.tsx
@@ -145,7 +145,7 @@ describe("connected clients", () => {
 
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: "Connected clients" }),
+        screen.queryByRole("heading", { name: "Connected MCP clients" }),
       ).not.toBeInTheDocument(),
     );
   });

--- a/frontend/src/connections/ConnectedClients.tsx
+++ b/frontend/src/connections/ConnectedClients.tsx
@@ -167,12 +167,13 @@ export function ConnectedClients() {
         <div className="space-y-1">
           <h2
             id="connected-clients-heading"
-            className="text-2xl font-semibold tracking-tight"
+            className="text-lg font-semibold tracking-tight"
           >
-            Connected clients
+            Connected MCP clients
           </h2>
           <p className="text-sm text-muted-foreground">
-            Manage apps that can use tools from your selected agents.
+            Apps authorized to use your selected tools through the MindRoom MCP
+            gateway.
           </p>
         </div>
         {clients.length > 0 && (
@@ -267,9 +268,7 @@ export function ConnectedClients() {
                   className="shrink-0 self-start sm:self-center"
                   variant="outline"
                   disabled={busy !== null}
-                  aria-label={`Disconnect ${client.client_name}${
-                    host ? ` from ${host}` : ""
-                  }`}
+                  aria-label={`Disconnect ${client.client_name}${host ? ` from ${host}` : ""}`}
                   onClick={() => void disconnect(client)}
                 >
                   {busy === client.id ? "Disconnecting…" : "Disconnect"}

--- a/frontend/src/connections/Connections.tsx
+++ b/frontend/src/connections/Connections.tsx
@@ -9,6 +9,8 @@ import { useMcpSelection } from "./useMcpSelection";
 import type { ConnectionList } from "./types";
 
 export function Connections() {
+  const gatewayUrl =
+    "'" + window.location.origin.replace(/'/g, "'\\''") + "/mcp'";
   const mcp = useMcpSelection();
   const [connections, setConnections] = useState<ConnectionList | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -46,15 +48,14 @@ export function Connections() {
               Your connections
             </h1>
             <p className="max-w-2xl text-sm text-muted-foreground">
-              Manage accounts and choose which tools your MCP clients can use.
+              See each agent’s tools and connect the accounts they need.
             </p>
           </div>
         </header>
         {mcp.selection?.enabled && (
           <p className="text-sm text-muted-foreground">
-            MCP access applies to every connected MCP client for your account.
-            Select all compatible tools for an agent, or expand it to choose
-            individual tools.
+            The MCP gateway column controls access from external apps. It does
+            not change which tools your agents can use in MindRoom.
           </p>
         )}
         {mcp.loading && (
@@ -93,6 +94,42 @@ export function Connections() {
           />
         )}
         <ConnectedClients />
+        {mcp.selection?.enabled && (
+          <footer className="space-y-3 border-t pt-5 text-xs text-muted-foreground">
+            <div className="space-y-1">
+              <h2 className="text-sm font-medium text-foreground">
+                MindRoom MCP gateway
+              </h2>
+              <p>
+                Use your selected agent tools outside MindRoom, in Claude Code,
+                Codex, or another MCP client. Your selection applies to every
+                connected MCP client for your account.
+              </p>
+            </div>
+            {[
+              [
+                "Claude Code",
+                `claude mcp add --transport http --scope user mindroom ${gatewayUrl}`,
+              ],
+              ["Codex", `codex mcp add mindroom --url ${gatewayUrl}`],
+            ].map(([name, command]) => (
+              <div
+                key={name}
+                className="grid gap-1.5 sm:grid-cols-[6rem_minmax(0,1fr)] sm:items-center sm:gap-3"
+              >
+                <span className="font-medium">{name}</span>
+                <code className="block overflow-x-auto whitespace-nowrap rounded-md bg-muted/60 px-3 py-2 text-foreground">
+                  {command}
+                </code>
+              </div>
+            ))}
+            <p>
+              Run a command in your terminal, then sign in using{" "}
+              <code>/mcp</code> in Claude Code or{" "}
+              <code>codex mcp login mindroom</code> in Codex.
+            </p>
+          </footer>
+        )}
       </div>
     </main>
   );

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -19118,7 +19118,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
 The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
-Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Under **MCP gateway**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.

--- a/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
+++ b/skills/mindroom-docs/references/page__deployment__mcp-gateway__index.md
@@ -49,7 +49,7 @@ The feature is disabled by default and requires both `MINDROOM_TRUSTED_UPSTREAM_
 Connections lists agents in a searchable table, with filters for personal, shared, and MCP-enabled agents.
 The table includes agents you can use or manage credentials for; agents you can only manage have no MCP selection controls.
 Expand an agent to see each tool with a connection, and expand **Other tools** for tools that need no additional setup.
-Under **MCP access**, select all compatible tools for an agent or choose tools individually.
+Under **MCP gateway**, select all compatible tools for an agent or choose tools individually.
 Each tool selection applies only to that agent, even when another agent has the same tool.
 An individual selection covers the configured toolkit or MCP server, rather than individual functions inside it.
 Selecting **All tools** includes future compatible tools assigned to that agent; a custom selection includes only the tools you checked.


### PR DESCRIPTION
The Connections page led with MCP client access, making its main purpose unclear.
Lead with each agent's tools and account connections, label the gateway controls and connected MCP clients explicitly, and explain that gateway selections affect external access.

Add a compact footer with Claude Code and Codex setup commands using the current site's `/mcp` URL, plus sign-in guidance.
The footer appears only when the gateway is enabled.

Validation:

- Frontend tests: 595 passed, 1 skipped, including all 68 Connections tests.
- Type checking, lint, production build, and repository hooks pass.
- Browser checks with fixture data: desktop, mobile, dark mode, correct command URLs, and gateway-disabled state; no browser errors.
- Independent review approved after checking quoted command URLs and documentation consistency.

Command syntax checked against the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp) and [Codex MCP documentation](https://developers.openai.com/codex/mcp).

## Summary by Sourcery

Clarify Connections terminology and explain how to configure external MCP clients through the enabled gateway.

New Features:
- Add setup commands and sign-in guidance for connecting Claude Code and Codex to the MindRoom MCP gateway.

Enhancements:
- Clarify that Connections focuses on agent tools and account connections, while gateway selections control external MCP access.
- Explicitly label the MCP gateway and connected MCP clients throughout the Connections interface.
- Show the external MCP setup footer only when the gateway is enabled.

Documentation:
- Update MCP gateway documentation and generated references to use the clarified MCP gateway terminology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP gateway setup guidance, including connection instructions and CLI commands for Claude Code and Codex.
  * Added authentication guidance and a generated gateway URL to the connections page.
  * Clarified how MCP gateway access relates to agents and their available tools.

* **Updates**
  * Renamed “MCP access” labels to “MCP gateway” throughout the interface and documentation.
  * Updated connected-client wording to identify apps authorized through the MindRoom MCP gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->