### PR TITLE
Show Matrix agent avatars in Connections

### DIFF
--- a/frontend/src/connections/AgentAvatar.tsx
+++ b/frontend/src/connections/AgentAvatar.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { Users, UserRound } from "lucide-react";
+import type { AgentConnections } from "./types";
+
+export function AgentAvatar({ agent }: { agent: AgentConnections }) {
+  const [failed, setFailed] = useState(false);
+  const Icon = agent.is_shared ? Users : UserRound;
+  return (
+    <span className="flex h-9 w-9 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-primary/5 text-primary">
+      {failed ? (
+        <Icon className="h-4 w-4" aria-hidden="true" />
+      ) : (
+        <img
+          src={`/api/connections/agents/${encodeURIComponent(agent.agent_name)}/avatar`}
+          alt=""
+          loading="lazy"
+          className="h-full w-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      )}
+    </span>
+  );
+}

--- a/frontend/src/connections/AgentTable.tsx
+++ b/frontend/src/connections/AgentTable.tsx
@@ -8,17 +8,12 @@ import {
   getFilteredRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import {
-  ChevronDown,
-  ChevronRight,
-  Search,
-  Users,
-  UserRound,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { AgentTools } from "./AgentTools";
+import { AgentAvatar } from "./AgentAvatar";
 import type { AgentConnections } from "./types";
 import type { McpSelectionState } from "./useMcpSelection";
 
@@ -31,7 +26,6 @@ const columns: ColumnDef<AgentTableRow>[] = [
     accessorFn: (agent) => agent.agent_display_name,
     cell: ({ row }) => {
       const agent = row.original;
-      const Icon = agent.is_shared ? Users : UserRound;
       return (
         <button
           type="button"
@@ -52,9 +46,7 @@ const columns: ColumnDef<AgentTableRow>[] = [
               aria-hidden="true"
             />
           )}
-          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-primary/5 text-primary">
-            <Icon className="h-4 w-4" aria-hidden="true" />
-          </span>
+          <AgentAvatar key={agent.agent_name} agent={agent} />
           <span id={`agent-${agent.agent_name}`} className="font-medium">
             {agent.agent_display_name}
           </span>

--- a/frontend/src/connections/Connections.test.tsx
+++ b/frontend/src/connections/Connections.test.tsx
@@ -52,6 +52,26 @@ const catalog = (services: (typeof service)[]) => ({
   ],
 });
 
+it("falls back cleanly when an agent's Matrix picture cannot load", async () => {
+  installApi({
+    "/api/connections": async () => json(catalog([])),
+    "/api/connections/mcp/selection": async () => json({ enabled: false }),
+  });
+  render(<Connections />);
+  const rowButton = await screen.findByRole("button", {
+    name: "Expand Personal assistant",
+  });
+  const image = rowButton.querySelector("img")!;
+  expect(image).toHaveAttribute(
+    "src",
+    "/api/connections/agents/personal/avatar",
+  );
+  fireEvent.error(image);
+  expect(rowButton.querySelector("img")).toBeNull();
+  fireEvent.click(rowButton);
+  expect(rowButton).toHaveAttribute("aria-expanded", "true");
+});
+
 it("shows shared connection availability without account controls for agent users", async () => {
   installApi({
     "/api/connections": async () =>

--- a/src/mindroom/api/connections.py
+++ b/src/mindroom/api/connections.py
@@ -255,6 +255,7 @@ async def avatar(agent_name: str, user: _ConnectionUserContext) -> Response:
             if (
                 not isinstance(thumbnail, nio.ThumbnailResponse)
                 or not isinstance(thumbnail.body, bytes)
+                or not 0 < len(thumbnail.body) <= 1024 * 1024
                 or thumbnail.content_type not in {"image/png", "image/jpeg", "image/gif", "image/webp"}
             ):
                 raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS)

--- a/src/mindroom/api/connections.py
+++ b/src/mindroom/api/connections.py
@@ -2,24 +2,32 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, cast
 from urllib.parse import urlsplit
 
+import nio
+from aiohttp import ClientError
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, ConfigDict
 
 from mindroom.api import config_lifecycle, oauth
 from mindroom.api.auth import require_connections_user
-from mindroom.api.connection_agents import CONNECTIONS_HEADERS, resolve_connection_agent, resolve_connection_user
+from mindroom.api.connection_agents import (
+    CONNECTIONS_HEADERS,
+    ConnectionUserContext,
+    resolve_connection_agent,
+    resolve_connection_user,
+)
 from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.matrix.users import create_agent_http_client
 from mindroom.oauth.credential_lifecycle import resolve_oauth_credential_context
 from mindroom.oauth.registry import load_oauth_providers_for_snapshot
 from mindroom.oauth.service import oauth_provider_service_account_configured
 from mindroom.tool_system.catalog import resolved_tool_metadata_for_runtime
 
 if TYPE_CHECKING:
-    from mindroom.api.connection_agents import ConnectionUserContext
     from mindroom.constants import RuntimePaths
     from mindroom.oauth import OAuthProvider
     from mindroom.tool_system.catalog import ToolMetadata
@@ -89,7 +97,7 @@ class _Connections:
     providers: dict[str, OAuthProvider]
 
 
-async def _connections(request: Request, response: Response) -> _Connections:
+async def _connection_user(request: Request, response: Response) -> ConnectionUserContext:
     response.headers.update(CONNECTIONS_HEADERS)
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     agent_name = (snapshot.runtime_paths.env_value("MINDROOM_CONNECTIONS_AGENT") or "").strip()
@@ -105,11 +113,18 @@ async def _connections(request: Request, response: Response) -> _Connections:
         requester_id,
         membership_index=config_lifecycle.app_state(request.app).agent_reply_memberships,
     )
-    config = user.config
     if not user.visible_agent_names:
         raise HTTPException(403, "No connections are available for this account", headers=CONNECTIONS_HEADERS)
+    return user
+
+
+_ConnectionUserContext = Annotated[ConnectionUserContext, Depends(_connection_user)]
+
+
+async def _connections(request: Request, user: _ConnectionUserContext) -> _Connections:
+    snapshot = config_lifecycle.bind_current_request_snapshot(request)
     providers = load_oauth_providers_for_snapshot(snapshot)
-    metadata = resolved_tool_metadata_for_runtime(snapshot.runtime_paths, config, tolerate_plugin_load_errors=True)
+    metadata = resolved_tool_metadata_for_runtime(snapshot.runtime_paths, user.config, tolerate_plugin_load_errors=True)
     agents = [_agent_connections(name, user, providers, metadata) for name in user.visible_agent_names]
     return _Connections(
         runtime_paths=snapshot.runtime_paths,
@@ -210,6 +225,50 @@ def _require_same_origin(request: Request, context: _Connections) -> None:
 async def catalog(context: _ConnectionsContext) -> ConnectionsCatalog:
     """List allowed services without waiting for any upstream account status."""
     return context.catalog
+
+
+@router.get("/agents/{agent_name}/avatar")
+async def avatar(agent_name: str, user: _ConnectionUserContext) -> Response:
+    """Serve a visible agent's current Matrix thumbnail without exposing its token."""
+    if agent_name not in user.visible_agent_names:
+        raise HTTPException(404, "Agent is not available", headers=CONNECTIONS_HEADERS)
+    try:
+        client = create_agent_http_client(agent_name, user.runtime_paths)
+    except ValueError as exc:
+        raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS) from exc
+    try:
+        async with asyncio.timeout(5):
+            profile = await client.get_profile(client.user_id)
+            if not isinstance(profile, nio.ProfileGetResponse) or not profile.avatar_url:
+                raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS)
+            uri = urlsplit(profile.avatar_url)
+            if (
+                uri.scheme != "mxc"
+                or not uri.netloc
+                or not uri.path.strip("/")
+                or uri.path.count("/") != 1
+                or uri.query
+                or uri.fragment
+            ):
+                raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS)
+            thumbnail = await client.thumbnail(uri.netloc, uri.path[1:], width=96, height=96)
+            if (
+                not isinstance(thumbnail, nio.ThumbnailResponse)
+                or not isinstance(thumbnail.body, bytes)
+                or thumbnail.content_type not in {"image/png", "image/jpeg", "image/gif", "image/webp"}
+            ):
+                raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS)
+            return Response(
+                thumbnail.body,
+                media_type=thumbnail.content_type,
+                headers={**CONNECTIONS_HEADERS, "X-Content-Type-Options": "nosniff"},
+            )
+    except (ClientError, TimeoutError) as exc:
+        raise HTTPException(502, "Avatar is temporarily unavailable", headers=CONNECTIONS_HEADERS) from exc
+    except ValueError as exc:
+        raise HTTPException(404, "Avatar is not available", headers=CONNECTIONS_HEADERS) from exc
+    finally:
+        await client.close()
 
 
 @router.get("/agents/{agent_name}/{provider_id}/status")

--- a/tach.toml
+++ b/tach.toml
@@ -1116,6 +1116,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.api.connections"
 depends_on = [
+    "mindroom.matrix.users",
     "mindroom.api.auth",
     "mindroom.api.config_lifecycle",
     "mindroom.api.oauth",

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
@@ -10,10 +11,12 @@ from urllib.parse import parse_qs, urlparse
 import jwt
 import pytest
 import yaml
+from aioresponses import aioresponses
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from mindroom.api import config_lifecycle, main, oauth
+from mindroom.matrix.state import MatrixState
 from mindroom.oauth import registry as oauth_registry
 from tests.api.test_api import (
     _trusted_upstream_jwks,
@@ -123,6 +126,83 @@ def test_catalog_lists_tools_without_browser_authentication(portal: dict[str, An
     assert tools["calculator"]["requires_room_context"] is False
     assert tools["google_drive"]["provider"] == "google_drive"
     assert tools["matrix_message"]["requires_room_context"] is True
+
+
+@pytest.mark.parametrize("agent_name", ["personal", "research"])
+@pytest.mark.parametrize(("content_type", "expected"), [("image/png", 200), ("image/svg+xml", 404)])
+def test_avatar_serves_current_matrix_thumbnail(
+    shared_portal: dict[str, Any],
+    agent_name: str,
+    content_type: str,
+    expected: int,
+) -> None:
+    """Visible private and management-only shared agents use their saved Matrix identity."""
+    state = MatrixState()
+    state.add_account(f"agent_{agent_name}", "custom_bot", None, domain="example.org", access_token="avatar-token")  # noqa: S106
+    state.save(runtime_paths=shared_portal["paths"])
+    with aioresponses() as matrix:
+        matrix.get(
+            "http://localhost:8008/_matrix/client/v3/profile/@custom_bot:example.org",
+            payload={"avatar_url": "mxc://example.org/current-avatar"},
+        )
+        matrix.get(
+            "http://localhost:8008/_matrix/client/v1/media/thumbnail/example.org/current-avatar"
+            "?width=96&height=96&method=scale&allow_remote=true",
+            body=b"thumbnail",
+            content_type=content_type,
+        )
+        response = shared_portal["client"].get(
+            f"/api/connections/agents/{agent_name}/avatar",
+            headers=shared_portal["headers"]["alice"],
+        )
+        assert response.status_code == expected, (response.text, list(matrix.requests))
+        assert all(
+            call.kwargs["headers"]["Authorization"] == "Bearer avatar-token"
+            for calls in matrix.requests.values()
+            for call in calls
+        )
+    if expected != 200:
+        return
+    assert response.content == b"thumbnail"
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert "no-store" in response.headers["cache-control"]
+    assert "avatar-token" not in str(response.headers)
+
+
+@pytest.mark.parametrize("avatar_url", [None, "https://example.org/picture.png", "mxc://example.org/"])
+def test_avatar_unavailable_for_missing_or_invalid_profile(portal: dict[str, Any], avatar_url: str | None) -> None:
+    """An absent or non-Matrix picture cannot turn the endpoint into an arbitrary URL proxy."""
+    state = MatrixState()
+    state.add_account("agent_personal", "personal", None, domain="example.org", access_token="avatar-token")  # noqa: S106
+    state.save(runtime_paths=portal["paths"])
+    with aioresponses() as matrix:
+        matrix.get(
+            re.compile(r"http://localhost:8008/_matrix/client/v3/profile/.*"),
+            payload={"avatar_url": avatar_url},
+        )
+        response = portal["client"].get("/api/connections/agents/personal/avatar", headers=portal["headers"]["alice"])
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    ("user", "agent_name", "expected"),
+    [("alice", "support", 404), ("admin", "other_private", 404), (None, "personal", 401)],
+)
+def test_avatar_requires_visible_agent(
+    shared_portal: dict[str, Any],
+    user: str | None,
+    agent_name: str,
+    expected: int,
+) -> None:
+    """Signed-in access alone cannot reveal hidden agents, including to administrators."""
+    with aioresponses() as matrix:
+        response = shared_portal["client"].get(
+            f"/api/connections/agents/{agent_name}/avatar",
+            headers=shared_portal["headers"][user] if user else {},
+        )
+        assert not matrix.requests
+    assert response.status_code == expected
 
 
 @pytest.mark.parametrize("query", ["agent_name=other", "worker_key=other", "user_id=bob", "execution_scope=user"])

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -129,11 +129,21 @@ def test_catalog_lists_tools_without_browser_authentication(portal: dict[str, An
 
 
 @pytest.mark.parametrize("agent_name", ["personal", "research"])
-@pytest.mark.parametrize(("content_type", "expected"), [("image/png", 200), ("image/svg+xml", 404)])
+@pytest.mark.parametrize(
+    ("content_type", "body", "expected"),
+    [
+        ("image/png", b"thumbnail", 200),
+        ("image/svg+xml", b"thumbnail", 404),
+        ("image/png", b"", 404),
+        ("image/png", b"x" * (1024 * 1024 + 1), 404),
+    ],
+    ids=["raster", "svg", "empty", "oversized"],
+)
 def test_avatar_serves_current_matrix_thumbnail(
     shared_portal: dict[str, Any],
     agent_name: str,
     content_type: str,
+    body: bytes,
     expected: int,
 ) -> None:
     """Visible private and management-only shared agents use their saved Matrix identity."""
@@ -148,7 +158,7 @@ def test_avatar_serves_current_matrix_thumbnail(
         matrix.get(
             "http://localhost:8008/_matrix/client/v1/media/thumbnail/example.org/current-avatar"
             "?width=96&height=96&method=scale&allow_remote=true",
-            body=b"thumbnail",
+            body=body,
             content_type=content_type,
         )
         response = shared_portal["client"].get(

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -5,6 +5,7 @@
 dashboard_credentials_supported  # unused variable (src/mindroom/agent_policy.py)
 is_shared  # JSON response field consumed by connections portal (src/mindroom/api/connections.py)
 can_use  # JSON response field consumed by connections portal (src/mindroom/api/connections.py)
+avatar  # FastAPI route (src/mindroom/api/connections.py)
 can_connect  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 account_label  # JSON response field consumed by personal portal (src/mindroom/api/connections.py)
 connection_url  # TypedDict field consumed by gateway clients (src/mindroom/mcp_gateway/types.py)


### PR DESCRIPTION
Connections now shows each agent's current Matrix profile picture beside its name, with the existing personal/shared icon when the picture is missing or unavailable.

Reuse the existing authenticated Matrix client to serve small thumbnails through the Connections API, restricted to agents the signed-in user can see. Pictures load lazily and separately from the tool catalog. Empty and over-1 MiB thumbnails fall back to the icon. No new dependencies or stored state.

Application code: 91 lines added, 16 removed. Tests: 110 lines added.

Validation: 157 initial backend, authorization, and import checks; 128 Connections/authorization/import checks after the size-limit follow-up; 596 frontend tests passed (one skipped); frontend lint, type checking, production build, and pre-commit hooks passed. Browser checks covered loaded and missing pictures on desktop, mobile, and dark mode using fixture responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Agent avatars now appear in the connections table.
  - Avatars load from Matrix thumbnails, with shared or individual user icons shown when images cannot be loaded.
  - Avatar access is limited to visible agents, and invalid, unavailable, or oversized images are handled safely.

- **Bug Fixes**
  - Agent rows remain expandable when an avatar fails to load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->