### PR TITLE
Timestamp event-loop delays and bound stack captures

### DIFF
--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -8,6 +8,10 @@ heartbeat goes stale the thread captures the loop thread's current stack via
 ``sys._current_frames()`` and logs it. That identifies the blocking code
 without ptrace capabilities, so it works in hardened non-root containers
 where external profilers such as py-spy cannot attach.
+
+Minute summaries retain the scheduled and observed UTC times of the worst
+heartbeat delay. Stack captures share a cooldown across separate stalls;
+suppressed captures still emit brief detection and recovery records.
 """
 
 from __future__ import annotations
@@ -20,6 +24,7 @@ import time
 import traceback
 from collections import deque
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
@@ -112,7 +117,7 @@ class EventLoopStallDetector:
         self._heartbeat = _Heartbeat(monotonic_seconds=0.0, process_cpu_seconds=0.0)
         self._stalled_beat: float | None = None
         self._next_repeat_log: float = 0.0
-        self._scheduler_lag_samples: deque[float] = deque(
+        self._scheduler_lag_samples: deque[tuple[float, float]] = deque(
             maxlen=max(1, math.ceil(_SCHEDULER_LAG_WINDOW_SECONDS / heartbeat_interval_seconds)),
         )
         self._scheduler_lag_window_started_at: float = 0.0
@@ -161,12 +166,13 @@ class EventLoopStallDetector:
         """Refresh heartbeat, sample callback lag, and re-arm from actual loop time."""
         assert self._loop is not None
         actual_loop_time = self._loop.time()
+        observed_at = time.time()
         self._heartbeat = _Heartbeat(
             monotonic_seconds=time.monotonic(),
             process_cpu_seconds=time.process_time(),
         )
         with self._scheduler_lag_lock:
-            self._scheduler_lag_samples.append(max(0.0, actual_loop_time - scheduled_loop_time))
+            self._scheduler_lag_samples.append((max(0.0, actual_loop_time - scheduled_loop_time), observed_at))
         if not self._stop_event.is_set():
             self._schedule_heartbeat(actual_loop_time + self.heartbeat_interval_seconds)
 
@@ -180,7 +186,8 @@ class EventLoopStallDetector:
             self._scheduler_lag_window_started_at = now
         if not samples:
             return
-        milliseconds = sorted(elapsed_ms_between(0.0, sample, ndigits=3) for sample in samples)
+        milliseconds = sorted(elapsed_ms_between(0.0, lag, ndigits=3) for lag, _ in samples)
+        max_lag, max_observed_at = max(samples, key=lambda sample: sample[0])
         logger.info(
             "event_loop_scheduler_lag_summary",
             sample_count=len(milliseconds),
@@ -188,6 +195,11 @@ class EventLoopStallDetector:
             p95_ms=_nearest_rank_percentile(milliseconds, 95),
             p99_ms=_nearest_rank_percentile(milliseconds, 99),
             max_ms=milliseconds[-1],
+            # This brackets callback lateness, not necessarily one blocking operation.
+            max_lag_scheduled_at=datetime.fromtimestamp(max_observed_at - max_lag, UTC).isoformat(
+                timespec="milliseconds",
+            ),
+            max_lag_observed_at=datetime.fromtimestamp(max_observed_at, UTC).isoformat(timespec="milliseconds"),
         )
 
     def _loop_thread_stack(self, frames: dict[int, FrameType]) -> str | None:
@@ -258,32 +270,31 @@ class EventLoopStallDetector:
         self._stalled_beat = None
 
     def _note_stalled(self, now: float, heartbeat: _Heartbeat) -> None:
-        """Log one stalled heartbeat, rate-limited to once per repeat interval."""
+        """Log each stall while sharing one stack-capture budget across incidents."""
         last_beat = heartbeat.monotonic_seconds
         stalled_for_seconds = round(now - last_beat, 3)
-        if self._stalled_beat is None:
+        new_stall = self._stalled_beat is None
+        if new_stall:
             self._stalled_beat = last_beat
+        elif now < self._next_repeat_log:
+            return
+        stack_capture_suppressed = now < self._next_repeat_log
+        diagnostics: dict[str, object] = {}
+        if not stack_capture_suppressed:
             self._next_repeat_log = now + self.repeat_log_interval_seconds
             current_process_cpu = time.process_time()
             frames = sys._current_frames()
-            logger.error(
-                "event_loop_stall_detected",
-                stalled_for_seconds=stalled_for_seconds,
-                threshold_seconds=self.threshold_seconds,
-                stack=self._loop_thread_stack(frames),
+            diagnostics = {
+                "stack": self._loop_thread_stack(frames),
                 **self._stall_diagnostics(heartbeat, frames=frames, current_process_cpu=current_process_cpu),
-            )
-        elif now >= self._next_repeat_log:
-            self._next_repeat_log = now + self.repeat_log_interval_seconds
-            current_process_cpu = time.process_time()
-            frames = sys._current_frames()
-            logger.error(
-                "event_loop_stall_ongoing",
-                stalled_for_seconds=stalled_for_seconds,
-                threshold_seconds=self.threshold_seconds,
-                stack=self._loop_thread_stack(frames),
-                **self._stall_diagnostics(heartbeat, frames=frames, current_process_cpu=current_process_cpu),
-            )
+            }
+        logger.error(
+            "event_loop_stall_detected" if new_stall else "event_loop_stall_ongoing",
+            stalled_for_seconds=stalled_for_seconds,
+            threshold_seconds=self.threshold_seconds,
+            stack_capture_suppressed=stack_capture_suppressed,
+            **diagnostics,
+        )
 
     def _watch(self) -> None:
         """Poll the heartbeat off-loop and log stalls with the blocking stack."""

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -117,7 +117,7 @@ class EventLoopStallDetector:
         self._heartbeat = _Heartbeat(monotonic_seconds=0.0, process_cpu_seconds=0.0)
         self._stalled_beat: float | None = None
         self._next_repeat_log: float = 0.0
-        self._scheduler_lag_samples: deque[tuple[float, float]] = deque(
+        self._scheduler_lag_samples: deque[tuple[float, float, float]] = deque(
             maxlen=max(1, math.ceil(_SCHEDULER_LAG_WINDOW_SECONDS / heartbeat_interval_seconds)),
         )
         self._scheduler_lag_window_started_at: float = 0.0
@@ -160,9 +160,10 @@ class EventLoopStallDetector:
     def _schedule_heartbeat(self, scheduled_loop_time: float) -> None:
         """Schedule one heartbeat while retaining its requested loop time."""
         assert self._loop is not None
-        self._heartbeat_handle = self._loop.call_at(scheduled_loop_time, self._beat, scheduled_loop_time)
+        scheduled_at = time.time() + (scheduled_loop_time - self._loop.time())
+        self._heartbeat_handle = self._loop.call_at(scheduled_loop_time, self._beat, scheduled_loop_time, scheduled_at)
 
-    def _beat(self, scheduled_loop_time: float) -> None:
+    def _beat(self, scheduled_loop_time: float, scheduled_at: float) -> None:
         """Refresh heartbeat, sample callback lag, and re-arm from actual loop time."""
         assert self._loop is not None
         actual_loop_time = self._loop.time()
@@ -172,7 +173,9 @@ class EventLoopStallDetector:
             process_cpu_seconds=time.process_time(),
         )
         with self._scheduler_lag_lock:
-            self._scheduler_lag_samples.append((max(0.0, actual_loop_time - scheduled_loop_time), observed_at))
+            self._scheduler_lag_samples.append(
+                (max(0.0, actual_loop_time - scheduled_loop_time), scheduled_at, observed_at),
+            )
         if not self._stop_event.is_set():
             self._schedule_heartbeat(actual_loop_time + self.heartbeat_interval_seconds)
 
@@ -186,8 +189,8 @@ class EventLoopStallDetector:
             self._scheduler_lag_window_started_at = now
         if not samples:
             return
-        milliseconds = sorted(elapsed_ms_between(0.0, lag, ndigits=3) for lag, _ in samples)
-        max_lag, max_observed_at = max(samples, key=lambda sample: sample[0])
+        milliseconds = sorted(elapsed_ms_between(0.0, lag, ndigits=3) for lag, _, _ in samples)
+        _, max_scheduled_at, max_observed_at = max(samples, key=lambda sample: sample[0])
         logger.info(
             "event_loop_scheduler_lag_summary",
             sample_count=len(milliseconds),
@@ -195,10 +198,8 @@ class EventLoopStallDetector:
             p95_ms=_nearest_rank_percentile(milliseconds, 95),
             p99_ms=_nearest_rank_percentile(milliseconds, 99),
             max_ms=milliseconds[-1],
-            # This brackets callback lateness, not necessarily one blocking operation.
-            max_lag_scheduled_at=datetime.fromtimestamp(max_observed_at - max_lag, UTC).isoformat(
-                timespec="milliseconds",
-            ),
+            # Wall-clock boundaries aid correlation; elapsed lag uses the monotonic clock.
+            max_lag_scheduled_at=datetime.fromtimestamp(max_scheduled_at, UTC).isoformat(timespec="milliseconds"),
             max_lag_observed_at=datetime.fromtimestamp(max_observed_at, UTC).isoformat(timespec="milliseconds"),
         )
 

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -34,21 +34,21 @@ class _LoopClock:
 
     def __init__(self) -> None:
         self.now = 0.0
-        self.scheduled: list[tuple[float, Callable[[float], None], float]] = []
+        self.scheduled: list[tuple[float, Callable[..., None], tuple[float, ...]]] = []
 
     def time(self) -> float:
         return self.now
 
-    def call_at(self, when: float, callback: Callable[[float], None], scheduled_loop_time: float) -> object:
-        self.scheduled.append((when, callback, scheduled_loop_time))
+    def call_at(self, when: float, callback: Callable[..., None], *args: float) -> object:
+        self.scheduled.append((when, callback, args))
         return object()
 
     def next_scheduled_time(self) -> float:
         return self.scheduled[0][0]
 
     def run_next(self) -> None:
-        _, callback, scheduled_loop_time = self.scheduled.pop(0)
-        callback(scheduled_loop_time)
+        _, callback, args = self.scheduled.pop(0)
+        callback(*args)
 
 
 class _FakeFrame:
@@ -176,9 +176,8 @@ def test_scheduler_lag_summary_timestamps_the_worst_sample_and_resets(monkeypatc
     loop = _LoopClock()
     detector._loop = loop
     detector._scheduler_lag_window_started_at = 0.0
+    monkeypatch.setattr(event_loop_stall.time, "time", lambda: 1_700_000_000.0 + loop.now)
     detector._schedule_heartbeat(1.0)
-    wall_times = iter((1_700_000_000.0, 1_700_000_002.0, 1_700_000_003.0, 1_700_000_065.0))
-    monkeypatch.setattr(event_loop_stall.time, "time", lambda: next(wall_times))
 
     with capture_logs() as logs:
         for lag_seconds in (0.25, 0.6, 0.01):
@@ -190,11 +189,31 @@ def test_scheduler_lag_summary_timestamps_the_worst_sample_and_resets(monkeypatc
         detector._report_scheduler_lag(120.0)
 
     assert logs[0]["max_ms"] == 600.0
-    assert logs[0]["max_lag_scheduled_at"] == "2023-11-14T22:13:21.400+00:00"
-    assert logs[0]["max_lag_observed_at"] == "2023-11-14T22:13:22.000+00:00"
+    assert logs[0]["max_lag_scheduled_at"] == "2023-11-14T22:13:21.270+00:00"
+    assert logs[0]["max_lag_observed_at"] == "2023-11-14T22:13:21.870+00:00"
     assert logs[1]["max_ms"] == 10.0
-    assert logs[1]["max_lag_scheduled_at"] == "2023-11-14T22:14:24.990+00:00"
-    assert logs[1]["max_lag_observed_at"] == "2023-11-14T22:14:25.000+00:00"
+    assert logs[1]["max_lag_scheduled_at"] == "2023-11-14T22:13:21.920+00:00"
+    assert logs[1]["max_lag_observed_at"] == "2023-11-14T22:13:21.930+00:00"
+
+
+def test_scheduler_lag_preserves_scheduled_time_across_clock_adjustment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wall-clock jump while overdue must not rewrite the original scheduled time."""
+    detector = _detector()
+    loop = _LoopClock()
+    detector._loop = loop
+    wall_clock = SimpleNamespace(now=1_700_000_000.0)
+    monkeypatch.setattr(event_loop_stall.time, "time", lambda: wall_clock.now)
+    detector._schedule_heartbeat(1.0)
+    loop.now = 1.4
+    wall_clock.now = 1_700_003_601.4
+
+    with capture_logs() as logs:
+        loop.run_next()
+        detector._report_scheduler_lag(60.0)
+
+    assert logs[0]["max_ms"] == 400.0
+    assert logs[0]["max_lag_scheduled_at"] == "2023-11-14T22:13:21.000+00:00"
+    assert logs[0]["max_lag_observed_at"] == "2023-11-14T23:13:21.400+00:00"
 
 
 def test_separate_stalls_share_a_stack_capture_budget(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -170,6 +170,76 @@ def test_scheduler_lag_heartbeat_rearms_from_actual_time_after_stall() -> None:
     assert loop.next_scheduled_time() == pytest.approx(1.41)
 
 
+def test_scheduler_lag_summary_timestamps_the_worst_sample_and_resets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The worst delay keeps its own overdue interval, even after smaller samples."""
+    detector = _detector()
+    loop = _LoopClock()
+    detector._loop = loop
+    detector._scheduler_lag_window_started_at = 0.0
+    detector._schedule_heartbeat(1.0)
+    wall_times = iter((1_700_000_000.0, 1_700_000_002.0, 1_700_000_003.0, 1_700_000_065.0))
+    monkeypatch.setattr(event_loop_stall.time, "time", lambda: next(wall_times))
+
+    with capture_logs() as logs:
+        for lag_seconds in (0.25, 0.6, 0.01):
+            loop.now = loop.next_scheduled_time() + lag_seconds
+            loop.run_next()
+        detector._report_scheduler_lag(60.0)
+        loop.now = loop.next_scheduled_time() + 0.01
+        loop.run_next()
+        detector._report_scheduler_lag(120.0)
+
+    assert logs[0]["max_ms"] == 600.0
+    assert logs[0]["max_lag_scheduled_at"] == "2023-11-14T22:13:21.400+00:00"
+    assert logs[0]["max_lag_observed_at"] == "2023-11-14T22:13:22.000+00:00"
+    assert logs[1]["max_ms"] == 10.0
+    assert logs[1]["max_lag_scheduled_at"] == "2023-11-14T22:14:24.990+00:00"
+    assert logs[1]["max_lag_observed_at"] == "2023-11-14T22:14:25.000+00:00"
+
+
+def test_separate_stalls_share_a_stack_capture_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated short stalls retain lifecycle logs without repeatedly sampling stacks."""
+    detector = _detector(repeat_log_interval_seconds=1.0)
+    captures: list[None] = []
+
+    def capture_frames() -> dict:
+        captures.append(None)
+        return {}
+
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", capture_frames)
+    with capture_logs() as logs:
+        for last_beat, detected_at, recovered_at in ((1.0, 1.2, 1.3), (1.3, 1.5, 1.6), (2.0, 2.2, 2.3)):
+            heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=last_beat, process_cpu_seconds=0.0)
+            detector._note_stalled(detected_at, heartbeat)
+            detector._note_stall_ended(recovered_at)
+
+    detected = [entry for entry in logs if entry["event"] == "event_loop_stall_detected"]
+    assert [entry["stack_capture_suppressed"] for entry in detected] == [False, True, False]
+    assert "stack" not in detected[1]
+    assert len(captures) == 2
+    ended = [entry for entry in logs if entry["event"] == "event_loop_stall_ended"]
+    assert [entry["stall_duration_seconds"] for entry in ended] == [0.3, 0.3, 0.3]
+
+
+def test_suppressed_stall_captures_a_stack_when_budget_recovers() -> None:
+    """A new long stall can get a stack after its initial capture was suppressed."""
+    detector = _detector(repeat_log_interval_seconds=1.0)
+    first = event_loop_stall._Heartbeat(monotonic_seconds=1.0, process_cpu_seconds=0.0)
+    second = event_loop_stall._Heartbeat(monotonic_seconds=1.3, process_cpu_seconds=0.0)
+    with capture_logs() as logs:
+        detector._note_stalled(1.2, first)
+        detector._note_stall_ended(1.3)
+        detector._note_stalled(1.5, second)
+        detector._note_stalled(2.0, second)
+        detector._note_stalled(2.2, second)
+
+    ongoing = [entry for entry in logs if entry["event"] == "event_loop_stall_ongoing"]
+    assert len(ongoing) == 1
+    assert ongoing[0]["stack_capture_suppressed"] is False
+    assert "stack" in ongoing[0]
+    assert ongoing[0]["stalled_for_seconds"] == 0.9
+
+
 @pytest.mark.asyncio
 async def test_detector_logs_blocking_stack_and_stall_duration() -> None:
     """Blocking the loop must produce one stall log naming the blocking frame."""


### PR DESCRIPTION
Event-loop lag summaries report the worst delay without saying when it happened. Lowering the stall threshold also causes every short incident to capture a full set of stacks.

Add scheduled and observed UTC timestamps for each window's maximum lag, preserving the scheduled time across wall-clock adjustments. Share the existing stack-capture cooldown across separate incidents, while retaining brief detection/recovery records and marking suppressed captures. A continuing stall can capture stacks when the cooldown expires.

Validation: 26 detector tests, all repository pre-commit hooks, and two independent reviews pass. The full suite passes with `-m "not requires_matrix"`, matching CI: 18,511 passed and 10 skipped. A local probe with a 500 ms threshold identified the function blocking the loop for 1.05 seconds.
