### PR TITLE
Reduce local shell and Docker tool-call overhead

### DIFF
--- a/docs/dev/tool-call-overhead.md
+++ b/docs/dev/tool-call-overhead.md
@@ -1,0 +1,50 @@
+# Tool-call overhead
+
+The benchmark separates tool execution overhead from model latency and the surrounding conversation pipeline.
+It executes harmless commands directly; it does not send Matrix messages or call a model.
+
+## Reproduce
+
+Run from the checkout whose runtime you want to measure:
+
+```bash
+uv run scripts/testing/benchmark_tool_call_overhead.py --iterations 1000 --warmup 50
+uv run scripts/testing/benchmark_tool_call_overhead.py --shell --iterations 100 --warmup 5
+uv run scripts/testing/benchmark_tool_call_overhead.py --docker-image YOUR_LOCAL_IMAGE --iterations 30 --warmup 3
+```
+
+The default mode measures the hook bridge with trivial synchronous and asynchronous functions.
+The shell mode measures the real local shell toolkit with argv and command-string inputs.
+The Docker mode requires Docker daemon access and a locally available MindRoom image matching the checkout.
+It creates an isolated config, storage directory, token, and worker with no granted credentials, then removes its containers on exit.
+It includes worker readiness checks and authenticated HTTP execution, but excludes agent construction, plugin hooks, model calls, and conversation loading in the parent.
+The command is `printf benchmark-ok`; Docker uses argv input so login-shell startup does not distort the worker comparison.
+
+Docker results separate warm worker ensure, execution, and their combined latency.
+`docker_cold_ready` measures initial container readiness, not first-tool/template initialization; warmup calls exclude that initialization from warm results.
+For import-level profiling, run the script with `uv run python -m cProfile -o tool-call.prof` before the script path and arguments.
+Parent profiling does not capture code inside the Docker request child.
+Do not compare profiled timings directly with unprofiled timings.
+
+## Measured bottlenecks and changes
+
+Measurements on the development host in September 2026 identified three avoidable costs:
+
+- Implicit command strings started login Bash and repeatedly loaded host profiles; use non-login Bash with the prepared environment, retaining explicit `bash -lc` support.
+- A warm Docker ensure resolved the same image three times; pass one request-local image snapshot through validation, resolving again on the next call so retags still take effect.
+- Agno tool-schema construction imported `Agent` and `Team` afresh in each fork child; preload their class definitions in the single-threaded template, without constructing agents or sharing request state.
+
+An unprofiled paired comparison against `f1be0a562`, using the same host and Docker base image/dependencies, measured:
+
+| Warm Docker phase | Baseline median | Optimized median |
+| --- | ---: | ---: |
+| Ensure | 113.5 ms | 68.0 ms |
+| Execute | 228.6 ms | 76.5 ms |
+| Combined | 340.3 ms | 144.5 ms |
+
+Combined p95 fell from 407.7 ms to 166.0 ms across 30 measured calls per version, after three warmup calls.
+Local command strings fell from 268.6 ms to 3.2 ms median across 100 measured calls after five warmups; direct argv stayed around 1.3–1.4 ms.
+These are host-dependent measurements, not latency guarantees or CI thresholds.
+Earlier instrumented profiling runs were slower and are not used for this comparison.
+Authorization, credential preparation, worker isolation, and per-call image/config validation remain in place.
+Remaining Docker time includes daemon round trips, filesystem/config work, HTTP setup, and fresh request-child execution.

--- a/docs/tools/execution-and-coding.md
+++ b/docs/tools/execution-and-coding.md
@@ -149,7 +149,8 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 `shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`.
 `run_shell_command()` accepts either a natural shell command string or a list of argv strings.
-Plain command strings and single-item argv lists that look shell-like run through `bash -lc`.
+Plain command strings and single-item argv lists that look shell-like run through `bash -c`, using the prepared execution environment without sourcing login profiles on every call.
+Pass `["bash", "-lc", "command"]` explicitly when login-shell initialization is needed.
 Explicit multi-item argv lists run directly without shell parsing.
 If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit.
 Shell output is also capped to the most recent 51200 bytes, with a truncation notice when older output is dropped.

--- a/scripts/testing/benchmark_tool_call_overhead.py
+++ b/scripts/testing/benchmark_tool_call_overhead.py
@@ -1,4 +1,4 @@
-"""Synthetic benchmark for MindRoom tool-call bridge and sandbox dispatch overhead."""
+"""Benchmark MindRoom hooks, local shell calls, and sandbox dispatch overhead."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import math
+import secrets
 import tempfile
 import time
 from pathlib import Path
@@ -39,14 +40,16 @@ def _noop_sync(value: int) -> int:
 
 
 @hook(EVENT_TOOL_BEFORE_CALL)
-async def _benchmark_before_hook(ctx: ToolBeforeCallContext) -> None:
+async def _benchmark_before_hook(ctx: object) -> None:
+    assert isinstance(ctx, ToolBeforeCallContext)
     if ctx.tool_name != "noop":
         msg = f"unexpected benchmark tool: {ctx.tool_name}"
         raise AssertionError(msg)
 
 
 @hook(EVENT_TOOL_AFTER_CALL)
-async def _benchmark_after_hook(ctx: ToolAfterCallContext) -> None:
+async def _benchmark_after_hook(ctx: object) -> None:
+    assert isinstance(ctx, ToolAfterCallContext)
     if ctx.tool_name != "noop":
         msg = f"unexpected benchmark tool: {ctx.tool_name}"
         raise AssertionError(msg)
@@ -139,6 +142,125 @@ async def _run_benchmark(iterations: int, warmup: int) -> list[dict[str, object]
     ]
 
 
+def _write_shell_benchmark_config(root: Path) -> Path:
+    """Create an isolated config that cannot call a provider or access real agent state."""
+    path = root / "config.yaml"
+    path.write_text(
+        "models:\n  default:\n    provider: openai\n    id: unused-benchmark-model\n"
+        "agents:\n  benchmark:\n    display_name: Benchmark\n    model: default\n    tools: [shell]\n"
+        "router:\n  model: default\nmemory:\n  backend: file\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+async def _run_shell_benchmark(iterations: int, warmup: int) -> list[dict[str, object]]:
+    """Measure the real local shell toolkit with argv and command-string inputs."""
+    from mindroom.constants import resolve_runtime_paths  # noqa: PLC0415
+    from mindroom.tools.shell import shell_tools  # noqa: PLC0415
+
+    results: list[dict[str, object]] = []
+    with tempfile.TemporaryDirectory(prefix="mindroom-shell-benchmark-") as tmp:
+        root = Path(tmp)
+        runtime = resolve_runtime_paths(
+            config_path=_write_shell_benchmark_config(root),
+            storage_path=root / "storage",
+            process_env={},
+        )
+        toolkit = shell_tools()(runtime_paths=runtime)
+        for label, command in (("shell_argv", ["printf", "benchmark-ok"]), ("shell_string", "printf benchmark-ok")):
+            samples: list[float] = []
+            for index in range(warmup + iterations):
+                started = time.perf_counter()
+                result = await toolkit.run_shell_command(command)
+                elapsed = (time.perf_counter() - started) * 1000
+                if result != "benchmark-ok":
+                    msg = f"Shell benchmark returned unexpected output: {result}"
+                    raise RuntimeError(msg)
+                if index >= warmup:
+                    samples.append(elapsed)
+            results.append({"case": label, **summarize_samples(samples)})
+    return results
+
+
+def _run_docker_shell_benchmark(image: str, iterations: int, warmup: int) -> list[dict[str, object]]:
+    """Measure a disposable Docker worker with empty credentials and isolated storage."""
+    from mindroom.constants import resolve_runtime_paths  # noqa: PLC0415
+    from mindroom.tool_system.worker_proxy_client import (  # noqa: PLC0415
+        WorkerProxyClientConfig,
+        execute_worker_proxy_request,
+    )
+    from mindroom.workers.backends.docker import DockerWorkerBackend  # noqa: PLC0415
+    from mindroom.workers.models import WorkerSpec  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="mindroom-docker-benchmark-") as tmp:
+        root = Path(tmp)
+        runtime = resolve_runtime_paths(
+            config_path=_write_shell_benchmark_config(root),
+            storage_path=root / "storage",
+            process_env={
+                "MINDROOM_WORKER_BACKEND": "docker",
+                "MINDROOM_DOCKER_WORKER_IMAGE": image,
+                "MINDROOM_DOCKER_WORKER_NAME_PREFIX": "mindroom-tool-benchmark",
+                "MINDROOM_SANDBOX_RUNNER_EXECUTION_MODE": "forkserver",
+            },
+        )
+        manager = DockerWorkerBackend.from_runtime(
+            runtime,
+            auth_token=secrets.token_urlsafe(32),
+            worker_grantable_credentials=frozenset(),
+        )
+        spec = WorkerSpec("v1:default:unscoped:benchmark", mirrored_credential_services=frozenset())
+        proxy = WorkerProxyClientConfig(
+            proxy_url=None,
+            proxy_token=None,
+            proxy_timeout_seconds=120,
+            credential_lease_ttl_seconds=60,
+            credential_policy={},
+        )
+        samples: dict[str, list[float]] = {"docker_ensure": [], "docker_execute": [], "docker_total": []}
+        try:
+            started = time.perf_counter()
+            manager.ensure_worker(spec)
+            cold_ready_ms = (time.perf_counter() - started) * 1000
+            for index in range(warmup + iterations):
+                started = time.perf_counter()
+                handle = manager.ensure_worker(spec)
+                ready = time.perf_counter()
+                result = execute_worker_proxy_request(
+                    config=proxy,
+                    payload={
+                        "tool_name": "shell",
+                        "function_name": "run_shell_command",
+                        "kwargs": {"args": ["printf", "benchmark-ok"]},
+                        "worker_key": spec.worker_key,
+                        "routing_agent_name": "benchmark",
+                    },
+                    credentials_manager=None,
+                    tool_name="shell",
+                    function_name="run_shell_command",
+                    worker_target=None,
+                    worker_handle=handle,
+                    worker_manager=manager,
+                )
+                finished = time.perf_counter()
+                if not isinstance(result, str) or result.splitlines()[-1:] != ["benchmark-ok"]:
+                    msg = f"Docker shell benchmark returned unexpected output: {result}"
+                    raise RuntimeError(msg)
+                if index >= warmup:
+                    samples["docker_ensure"].append((ready - started) * 1000)
+                    samples["docker_execute"].append((finished - ready) * 1000)
+                    samples["docker_total"].append((finished - started) * 1000)
+            results: list[dict[str, object]] = [
+                {"case": "docker_cold_ready", "elapsed_ms": round(cold_ready_ms, 3)},
+            ]
+            for name, values in samples.items():
+                results.append({"case": name, **summarize_samples(values)})
+            return results
+        finally:
+            manager.shutdown()
+
+
 def _run_sandbox_dispatch_case(mode: str, iterations: int, warmup: int) -> dict[str, object]:
     """Benchmark one worker-routed sandbox dispatch mode with a trivial tool call."""
     # Imported here so the lightweight hook benchmark does not pay the full
@@ -194,7 +316,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Benchmark MindRoom tool-call bridge and sandbox dispatch overhead.")
     parser.add_argument("--iterations", type=int, default=1000)
     parser.add_argument("--warmup", type=int, default=50)
-    parser.add_argument(
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument(
+        "--shell",
+        action="store_true",
+        help="Benchmark real local shell calls (argv and command strings).",
+    )
+    modes.add_argument(
+        "--docker-image",
+        help="Benchmark shell calls in an isolated Docker worker using this local image.",
+    )
+    modes.add_argument(
         "--sandbox-dispatch",
         nargs="+",
         choices=["forkserver", "subprocess"],
@@ -218,7 +350,11 @@ def main() -> None:
         wrapper_class=structlog.make_filtering_bound_logger(logging.WARNING),
         cache_logger_on_first_use=False,
     )
-    if args.sandbox_dispatch:
+    if args.docker_image:
+        results = _run_docker_shell_benchmark(args.docker_image, args.iterations, args.warmup)
+    elif args.shell:
+        results = asyncio.run(_run_shell_benchmark(args.iterations, args.warmup))
+    elif args.sandbox_dispatch:
         results = [_run_sandbox_dispatch_case(mode, args.iterations, args.warmup) for mode in args.sandbox_dispatch]
     else:
         results = asyncio.run(_run_benchmark(iterations=args.iterations, warmup=args.warmup))

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3743,7 +3743,8 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 `shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`.
 `run_shell_command()` accepts either a natural shell command string or a list of argv strings.
-Plain command strings and single-item argv lists that look shell-like run through `bash -lc`.
+Plain command strings and single-item argv lists that look shell-like run through `bash -c`, using the prepared execution environment without sourcing login profiles on every call.
+Pass `["bash", "-lc", "command"]` explicitly when login-shell initialization is needed.
 Explicit multi-item argv lists run directly without shell parsing.
 If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit.
 Shell output is also capped to the most recent 51200 bytes, with a truncation notice when older output is dropped.

--- a/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
+++ b/skills/mindroom-docs/references/page__tools__execution-and-coding__index.md
@@ -145,7 +145,8 @@ save_file("temporary notes\n", "scratch/notes.txt")
 
 `shell` exposes `run_shell_command()`, `check_shell_command()`, and `kill_shell_command()`.
 `run_shell_command()` accepts either a natural shell command string or a list of argv strings.
-Plain command strings and single-item argv lists that look shell-like run through `bash -lc`.
+Plain command strings and single-item argv lists that look shell-like run through `bash -c`, using the prepared execution environment without sourcing login profiles on every call.
+Pass `["bash", "-lc", "command"]` explicitly when login-shell initialization is needed.
 Explicit multi-item argv lists run directly without shell parsing.
 If the command exits within `timeout`, the tool returns the last `tail` lines of stdout, or stderr on non-zero exit.
 Shell output is also capped to the most recent 51200 bytes, with a truncation notice when older output is dropped.

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -1417,6 +1417,11 @@ def _run_forkserver_template() -> int:
     socket_path = sys.argv[sys.argv.index(sandbox_forkserver.TEMPLATE_ARG) + 1]
     # Pre-warm the full tool import graph once so fork children skip it; this
     # belongs to template startup, not to importing this module.
+    # Agno resolves these types while building tool schemas. Import them in the
+    # single-threaded template, not afresh in every isolated request child.
+    from agno.agent import Agent  # noqa: F401, PLC0415
+    from agno.team import Team  # noqa: F401, PLC0415
+
     import mindroom.tools  # noqa: F401, PLC0415
 
     # `python -m` prepended the runner's cwd to sys.path at template startup;

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -98,7 +98,7 @@ def _normalize_shell_command_line(command: str) -> list[str]:
     stripped = command.strip()
     if not stripped:
         raise ValueError(_SHELL_ARGS_ERROR)
-    return ["bash", "-lc", command]
+    return ["bash", "-c", command]
 
 
 def _looks_like_shell_command_line(command: str) -> bool:
@@ -392,6 +392,9 @@ def shell_tools() -> type[Toolkit]:  # noqa: C901
             the timeout is exceeded the process keeps running in the background
             and a handle string is returned that can be polled with
             ``check_shell_command`` or stopped with ``kill_shell_command``.
+
+            Command strings use non-login Bash with the prepared execution environment.
+            Use explicit ``["bash", "-lc", command]`` only when login startup is needed.
 
             Args:
                 args: The command to run as a shell command string or a list of argv strings.

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -382,6 +382,7 @@ def check_docker_workers_absent_for_storage_upgrade(
 class _DockerLaunchConfig:
     image_reference: str
     launch_config_hash: str
+    image_resolved: bool
 
 
 class DockerWorkerBackend:
@@ -533,6 +534,7 @@ class DockerWorkerBackend:
                 paths,
                 private_agent_names=spec.private_agent_names,
                 state_scope_worker_key=spec.state_scope_worker_key,
+                launch_config=launch_config,
             )
             lifecycle_state = prepare_worker_ensure_lifecycle(
                 read_lifecycle_state(metadata),
@@ -833,6 +835,7 @@ class DockerWorkerBackend:
         *,
         private_agent_names: frozenset[str] | None,
         state_scope_worker_key: str | None,
+        launch_config: _DockerLaunchConfig,
     ) -> bool:
         container = self._read_container(metadata.container_name)
         if metadata.status == "failed":
@@ -845,6 +848,7 @@ class DockerWorkerBackend:
             paths,
             private_agent_names=private_agent_names,
             state_scope_worker_key=state_scope_worker_key,
+            launch_config=launch_config,
         ):
             return True
         return not self._container_is_running(container)
@@ -857,8 +861,9 @@ class DockerWorkerBackend:
         *,
         private_agent_names: frozenset[str] | None,
         state_scope_worker_key: str | None,
+        launch_config: _DockerLaunchConfig,
     ) -> bool:
-        compatible_launch_config_hashes = self._compatible_launch_config_hashes(container)
+        compatible_launch_config_hashes = self._compatible_launch_config_hashes(container, launch_config)
         if metadata.launch_config_hash not in compatible_launch_config_hashes:
             return False
         if self._container_launch_config_hash(container) not in compatible_launch_config_hashes:
@@ -908,6 +913,7 @@ class DockerWorkerBackend:
             paths,
             private_agent_names=private_agent_names,
             state_scope_worker_key=state_scope_worker_key,
+            launch_config=launch_config,
         ):
             self._remove_container(container)
             container = None
@@ -1295,6 +1301,7 @@ class DockerWorkerBackend:
         return _DockerLaunchConfig(
             image_reference=image_identity if image_resolved else self.config.image,
             launch_config_hash=self._compute_launch_config_hash(image_identity=image_identity),
+            image_resolved=image_resolved,
         )
 
     def _container_launch_config_hash(self, container: _DockerContainer | None) -> str | None:
@@ -1329,18 +1336,19 @@ class DockerWorkerBackend:
             return config_image
         return None
 
-    def _compatible_launch_config_hashes(self, container: _DockerContainer | None) -> set[str]:
-        current_image_identity, image_resolved = _docker_image_identity_state(
-            self.config.image,
-            client=self._client,
-            docker_errors=self._docker_errors,
-        )
-        compatible_hashes = {self._compute_launch_config_hash(image_identity=current_image_identity)}
+    def _compatible_launch_config_hashes(
+        self,
+        container: _DockerContainer | None,
+        launch_config: _DockerLaunchConfig,
+    ) -> set[str]:
+        # One ensure uses one image snapshot; the next call resolves the tag again.
+        current_image_identity = launch_config.image_reference
+        compatible_hashes = {launch_config.launch_config_hash}
         container_image_identity = self._container_image_identity(container)
         if container_image_identity is None:
             return compatible_hashes
 
-        if not image_resolved:
+        if not launch_config.image_resolved:
             compatible_hashes.add(self._compute_launch_config_hash(image_identity=container_image_identity))
             return compatible_hashes
 

--- a/tests/api/test_sandbox_forkserver.py
+++ b/tests/api/test_sandbox_forkserver.py
@@ -6,6 +6,7 @@ import json
 import os
 import signal
 import subprocess
+import sys
 import time
 from typing import TYPE_CHECKING
 
@@ -57,6 +58,39 @@ def _run_payload(payload: str) -> tuple[int, str, str]:
 
 sys.exit(serve_template(sys.argv[1], _run_payload))
 '''
+
+
+def test_runtime_template_preloads_schema_types_without_starting_threads() -> None:
+    """Fork children must inherit expensive schema imports, not live background threads."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import json
+import sys
+import threading
+from mindroom.api import sandbox_runner
+from agno.utils.schema import identity_injected_types
+
+def ready(socket_path, handler):
+    before = set(sys.modules)
+    identity_injected_types()
+    print(json.dumps({"new_modules": sorted(set(sys.modules) - before), "threads": threading.active_count()}))
+    return 0
+
+sandbox_runner.sandbox_forkserver.serve_template = ready
+sys.argv = ["runner", "--sandbox-forkserver-template", "unused-test-socket"]
+sandbox_runner._run_forkserver_template()
+""",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    result = json.loads(completed.stdout)
+    assert result == {"new_modules": [], "threads": 1}
 
 
 @pytest.fixture

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -236,8 +236,10 @@ class _FakeImagesApi:
         self.by_name: dict[str, _FakeImage] = {}
         self.pulls: list[str] = []
         self.pull_image_id: str | None = None
+        self.gets: list[str] = []
 
     def get(self, name: str) -> _FakeImage:
+        self.gets.append(name)
         image = self.by_name.get(name)
         if image is None:
             raise _FakeNotFoundError(name)
@@ -2591,6 +2593,27 @@ def test_docker_worker_ready_failure_surfaces_container_logs(
     assert "OPENAI_API_KEY=***redacted***" in message
     assert "... [truncated]" in message
     assert len(message) < 4300
+
+
+def test_warm_ensure_resolves_image_once_and_detects_next_call_tag_change(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Avoid repeated daemon lookups without caching image identity across calls."""
+    backend, client, _ = _backend(monkeypatch, tmp_path)
+    spec = WorkerSpec(_TEST_UNSCOPED_WORKER_KEY)
+    backend.ensure_worker(spec)
+    original = client.containers.created_containers[-1]
+    client.images.gets.clear()
+
+    backend.ensure_worker(spec)
+
+    assert client.containers.by_name[original.name] is original
+    assert client.images.gets == [backend.config.image]
+    client.images.by_name[backend.config.image] = _FakeImage("sha256:image-v2")
+    backend.ensure_worker(spec)
+    assert original.removed == 1
+    assert client.containers.created_containers[-1].attrs["Image"] == "sha256:image-v2"
 
 
 def test_docker_worker_health_accepts_matching_protocol() -> None:

--- a/tests/test_shell_async.py
+++ b/tests/test_shell_async.py
@@ -157,6 +157,31 @@ async def test_run_shell_command_accepts_shell_command_string(tmp_path: Path) ->
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "command",
+    [
+        "if shopt -q login_shell; then echo login; else echo plain; fi",
+        ["if shopt -q login_shell; then echo login; else echo plain; fi"],
+    ],
+)
+async def test_implicit_shell_does_not_run_login_startup(tmp_path: Path, command: str | list[str]) -> None:
+    """Ordinary commands must not pay for or acquire side effects from login profiles."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+    assert await entrypoint(command) == "plain"
+
+
+@pytest.mark.asyncio
+async def test_explicit_login_shell_remains_available(tmp_path: Path) -> None:
+    """Callers opting into login initialization still get it."""
+    tool = _get_toolkit(tmp_path)
+    entrypoint = tool.async_functions["run_shell_command"].entrypoint
+    assert entrypoint is not None
+    assert await entrypoint(["bash", "-lc", "shopt -q login_shell && echo login"]) == "login"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("command", "expected"),
     [
         ("[ 1 -eq 1 ] && echo ok", "ok"),

--- a/tests/test_tool_call_benchmark.py
+++ b/tests/test_tool_call_benchmark.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
+import pytest
+
+from scripts.testing import benchmark_tool_call_overhead
 from scripts.testing.benchmark_tool_call_overhead import summarize_samples
+
+
+@pytest.mark.asyncio
+async def test_shell_benchmark_measures_both_inputs_without_counting_warmup() -> None:
+    """Shell input modes must run real commands and report only measured iterations."""
+    results = await benchmark_tool_call_overhead._run_shell_benchmark(iterations=2, warmup=1)
+    assert {row["case"]: row["count"] for row in results} == {"shell_argv": 2, "shell_string": 2}
+    assert all(row["mean_ms"] > 0 for row in results)
 
 
 def test_summarize_samples_reports_zeroes_for_empty_samples() -> None:


### PR DESCRIPTION
## Summary

Profile and reduce avoidable tool-call overhead with three bounded runtime changes:

- Run implicit shell strings with non-login Bash; explicit login-shell argv still works.
- Resolve Docker image identity once per ensure call and pass the snapshot through validation. No cross-call cache; retags and config changes remain checked.
- Preload Agno schema identity classes in the single-threaded forkserver template instead of importing them in every isolated request child.

Add real local-shell and disposable Docker benchmark modes, regression tests, and reproduction notes in `docs/dev/tool-call-overhead.md`.

## Measurements

Unprofiled paired measurements on the same host, against `f1be0a562`, with matching Docker base image/dependencies:

| Path | Before median | After median |
| --- | ---: | ---: |
| Local shell string | 268.6 ms | 3.2 ms |
| Local argv | 1.3 ms | 1.4 ms |
| Warm Docker ensure | 113.5 ms | 68.0 ms |
| Warm Docker execute | 228.6 ms | 76.5 ms |
| Warm Docker combined | 340.3 ms | 144.5 ms |

Docker combined p95: 407.7 → 166.0 ms. Local: 100 calls / 5 warmups; Docker: 30 calls / 3 warmups. Host-dependent, not CI thresholds. Excludes model calls and the parent conversation/agent pipeline. Cold initialization is reported separately; warm samples exclude it.

## Verification

- 636 focused shell, Docker, sandbox, hook, benchmark, and import-graph tests passed.
- Full suite: 18,334 passed, 200 skipped; the existing 180-day OAuth refresh soak test timed out at 300 seconds on disk-backed temporary storage. The unchanged test passed in 41 seconds with memory-backed temporary storage.
- Repository pre-commit hooks passed, including typing, lint, import boundaries, privacy checks, and regenerated documentation references.
- Independent code review: no findings.
- Live tests used disposable workers with isolated state and no granted credentials; benchmark containers were removed. Production services were not changed.

## Summary by Sourcery

Reduce local shell and Docker worker tool-call latency while preserving per-call validation and isolated execution behavior.

New Features:
- Add local-shell and disposable Docker benchmark modes that measure real tool-call overhead separately from model and conversation latency.

Bug Fixes:
- Prevent implicit shell commands from sourcing login profiles while preserving explicit login-shell behavior.
- Avoid repeated Docker image identity resolution within a single worker ensure operation while continuing to detect image changes on subsequent calls.

Enhancements:
- Preload Agno schema identity classes in the forkserver template to reduce per-request child import overhead.

Documentation:
- Document tool-call overhead benchmarks, reproduction steps, measured bottlenecks, and runtime behavior changes.

Tests:
- Add regression coverage for non-login shell execution, explicit login shells, Docker image resolution behavior, forkserver schema preloading, and shell benchmark measurements.