### PR TITLE
Clarify Connections tool descriptions and MCP display metadata

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -104,6 +104,8 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `display_name` | string | `null` | Dashboard and catalog name; defaults to `auth.display_name`, then a name derived from the server ID |
+| `summary` | string | `null` | Short capability summary for the dashboard and tool catalog, with or without OAuth |
 | `icon` | string | `null` | Optional dashboard icon name, such as `SiConfluence` or `Calendar` |
 | `description` | string | `null` | What the server provides; appended to the OAuth bridge tool descriptions shown to the model; requires `auth` |
 | `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
@@ -126,6 +128,19 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 `tool_prefix` must use only letters, numbers, and underscores.
 `include_tools` and `exclude_tools` are matched against the remote MCP tool names, not the MindRoom-prefixed function names.
 `include_tools` and `exclude_tools` cannot overlap.
+
+Use `display_name` and `summary` to explain what people can do with a connection.
+Keep detailed model instructions in the OAuth-only `description` field; those instructions are not shown on the Connections page.
+Display metadata does not change tool IDs, function names, or permissions.
+
+```yaml
+mcp_servers:
+  team_wiki:
+    display_name: Team Wiki
+    summary: Search and edit team documentation
+    transport: streamable-http
+    url: https://wiki.example.com/mcp
+```
 
 Set `icon` to choose how an MCP server appears in the dashboard and on Connections, including OAuth connection cards:
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11531,6 +11531,8 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `display_name` | string | `null` | Dashboard and catalog name; defaults to `auth.display_name`, then a name derived from the server ID |
+| `summary` | string | `null` | Short capability summary for the dashboard and tool catalog, with or without OAuth |
 | `icon` | string | `null` | Optional dashboard icon name, such as `SiConfluence` or `Calendar` |
 | `description` | string | `null` | What the server provides; appended to the OAuth bridge tool descriptions shown to the model; requires `auth` |
 | `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
@@ -11553,6 +11555,19 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 `tool_prefix` must use only letters, numbers, and underscores.
 `include_tools` and `exclude_tools` are matched against the remote MCP tool names, not the MindRoom-prefixed function names.
 `include_tools` and `exclude_tools` cannot overlap.
+
+Use `display_name` and `summary` to explain what people can do with a connection.
+Keep detailed model instructions in the OAuth-only `description` field; those instructions are not shown on the Connections page.
+Display metadata does not change tool IDs, function names, or permissions.
+
+```yaml
+mcp_servers:
+  team_wiki:
+    display_name: Team Wiki
+    summary: Search and edit team documentation
+    transport: streamable-http
+    url: https://wiki.example.com/mcp
+```
 
 Set `icon` to choose how an MCP server appears in the dashboard and on Connections, including OAuth connection cards:
 

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -100,6 +100,8 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `enabled` | bool | `true` | Set to `false` to disable one server without removing its config |
+| `display_name` | string | `null` | Dashboard and catalog name; defaults to `auth.display_name`, then a name derived from the server ID |
+| `summary` | string | `null` | Short capability summary for the dashboard and tool catalog, with or without OAuth |
 | `icon` | string | `null` | Optional dashboard icon name, such as `SiConfluence` or `Calendar` |
 | `description` | string | `null` | What the server provides; appended to the OAuth bridge tool descriptions shown to the model; requires `auth` |
 | `required` | bool | `false` | Block dependent agent startup while this server is unavailable instead of degrading |
@@ -122,6 +124,19 @@ Use `worker_scope: shared` when one connected account belongs to the agent and e
 `tool_prefix` must use only letters, numbers, and underscores.
 `include_tools` and `exclude_tools` are matched against the remote MCP tool names, not the MindRoom-prefixed function names.
 `include_tools` and `exclude_tools` cannot overlap.
+
+Use `display_name` and `summary` to explain what people can do with a connection.
+Keep detailed model instructions in the OAuth-only `description` field; those instructions are not shown on the Connections page.
+Display metadata does not change tool IDs, function names, or permissions.
+
+```yaml
+mcp_servers:
+  team_wiki:
+    display_name: Team Wiki
+    summary: Search and edit team documentation
+    transport: streamable-http
+    url: https://wiki.example.com/mcp
+```
 
 Set `icon` to choose how an MCP server appears in the dashboard and on Connections, including OAuth connection cards:
 

--- a/src/mindroom/mcp/config.py
+++ b/src/mindroom/mcp/config.py
@@ -79,6 +79,12 @@ class MCPOAuthConfig(BaseModel):
     client_config_services: list[str] = Field(default_factory=list, description="Provider-specific client config")
     shared_client_config_services: list[str] = Field(default_factory=list, description="Shared client config services")
 
+    @field_validator("display_name")
+    @classmethod
+    def normalize_display_name(cls, value: str | None) -> str | None:
+        """Trim OAuth labels so blank names use the provider and catalog fallbacks."""
+        return (value.strip() or None) if value is not None else None
+
     @field_validator("provider_id")
     @classmethod
     def validate_provider_id(cls, value: str | None) -> str | None:

--- a/src/mindroom/mcp/config.py
+++ b/src/mindroom/mcp/config.py
@@ -110,6 +110,8 @@ class MCPServerConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     enabled: bool = Field(default=True, description="Whether the server is active")
+    display_name: str | None = Field(default=None, description="Human-readable tool name for the dashboard and catalog")
+    summary: str | None = Field(default=None, description="Short capability summary for the dashboard and tool catalog")
     icon: str | None = Field(default=None, description="Optional dashboard icon name, such as SiConfluence or Calendar")
     description: str | None = Field(
         default=None,
@@ -135,7 +137,7 @@ class MCPServerConfig(BaseModel):
     max_concurrent_calls: int = Field(default=1, ge=1, description="Maximum concurrent calls")
     auto_reconnect: bool = Field(default=True, description="Whether to reconnect automatically")
 
-    @field_validator("description", "icon")
+    @field_validator("display_name", "summary", "description", "icon")
     @classmethod
     def normalize_display_metadata(cls, value: str | None) -> str | None:
         """Trim optional display metadata and collapse blank values to None."""

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -125,7 +125,7 @@ def validate_mcp_agent_overrides(tool_name: str, overrides: dict[str, object]) -
 
 def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetadata:
     tool_name = mcp_tool_name(server_id)
-    transport_label = server_config.transport.replace("-", " ")
+    provider_name = (server_config.auth.display_name or "").strip() if server_config.auth is not None else None
     is_oauth = server_config.auth is not None
     manager = require_mcp_server_manager()
     catalog = None
@@ -143,8 +143,8 @@ def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetada
         function_names = tuple(tool.function_name for tool in catalog.tools) if catalog is not None else ()
     return ToolMetadata(
         name=tool_name,
-        display_name=f"MCP {server_id.replace('_', ' ').title()}",
-        description=f"MCP server '{server_id}' tools over {transport_label}.",
+        display_name=server_config.display_name or provider_name or f"MCP {server_id.replace('_', ' ').title()}",
+        description=server_config.summary or "Tools provided by this MCP server",
         icon=server_config.icon,
         category=ToolCategory.DEVELOPMENT,
         status=ToolStatus.REQUIRES_CONFIG if is_oauth else ToolStatus.AVAILABLE,

--- a/src/mindroom/mcp/registry.py
+++ b/src/mindroom/mcp/registry.py
@@ -125,7 +125,7 @@ def validate_mcp_agent_overrides(tool_name: str, overrides: dict[str, object]) -
 
 def _tool_metadata(server_id: str, server_config: MCPServerConfig) -> ToolMetadata:
     tool_name = mcp_tool_name(server_id)
-    provider_name = (server_config.auth.display_name or "").strip() if server_config.auth is not None else None
+    provider_name = server_config.auth.display_name if server_config.auth is not None else None
     is_oauth = server_config.auth is not None
     manager = require_mcp_server_manager()
     catalog = None

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -369,7 +369,7 @@ def _homeassistant_tools() -> type[Toolkit]:
 @register_tool_with_metadata(
     name="agent_vault_access",
     display_name="Agent Vault Access",
-    description="Grant yourself UI access to manage this agent's Agent Vault secrets",
+    description="Get a link to manage this agent's passwords and API keys in Agent Vault",
     category=ToolCategory.INTEGRATIONS,
     icon="Lock",
     icon_color="text-amber-600",

--- a/src/mindroom/tools/approved_egress.py
+++ b/src/mindroom/tools/approved_egress.py
@@ -353,8 +353,8 @@ class _ApprovedEgressTools(Toolkit):
 
 @register_tool_with_metadata(
     name="approved_egress",
-    display_name="Approved Worker Egress",
-    description="Request human-approved temporary worker access to blocked external hostnames",
+    display_name="Network Access Requests",
+    description="Request approval for temporary access to a blocked website or service",
     category=ToolCategory.INTEGRATIONS,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.SPECIAL,

--- a/src/mindroom/tools/attachments.py
+++ b/src/mindroom/tools/attachments.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="attachments",
     display_name="Attachments",
-    description="List and register context-scoped file attachments",
+    description="Find files attached to a conversation and make workspace files available as attachments",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -20,10 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="browser",
     display_name="Browser",
-    description=(
-        "OpenClaw-style browser control (status/start/stop/profiles/tabs/open/focus/close/"
-        "snapshot/screenshot/navigate/console/pdf/upload/dialog/act/help/actions)"
-    ),
+    description="Browse websites, fill in forms, and capture screenshots",
     category=ToolCategory.RESEARCH,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/coding.py
+++ b/src/mindroom/tools/coding.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="coding",
     display_name="Coding Tools",
-    description="Advanced code-oriented file operations (precise edits, grep, and discovery). Prefer this over file for coding agents; keep file for backward compatibility.",
+    description="Find code, search across files, and make precise edits",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/desktop.py
+++ b/src/mindroom/tools/desktop.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="desktop",
     display_name="Matrix Desktop",
-    description="Operate exact locally allowlisted applications through accessibility state over Matrix encryption",
+    description="Let the agent interact with desktop apps you explicitly allow",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.SPECIAL,

--- a/src/mindroom/tools/file.py
+++ b/src/mindroom/tools/file.py
@@ -248,7 +248,7 @@ class _MindRoomFileTools(AgnoFileTools):
 @register_tool_with_metadata(
     name="file",
     display_name="File Tools",
-    description="Local file operations including read, write, list, and search",
+    description="Read, write, list, and search files in the agent workspace",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/github.py
+++ b/src/mindroom/tools/github.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="github",
     display_name="GitHub",
-    description="Repository and issue management",
+    description="Browse code and manage GitHub repositories, issues, and pull requests",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/gmail.py
+++ b/src/mindroom/tools/gmail.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="gmail",
     display_name="Gmail",
-    description="Read, search, and manage Gmail emails",
+    description="Search, read, send, and organize email in Gmail",
     category=ToolCategory.EMAIL,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_calendar.py
+++ b/src/mindroom/tools/google_calendar.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_calendar",
     display_name="Google Calendar",
-    description="View and schedule meetings with Google Calendar",
+    description="View calendars and create or update events in Google Calendar",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_drive",
     display_name="Google Drive",
-    description="Search, read, upload, and organize files in the connected user's Google Drive",
+    description="Search, read, upload, and organize files in Google Drive",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_scholar.py
+++ b/src/mindroom/tools/google_scholar.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_scholar",
     display_name="Google Scholar",
-    description="Search academic publications on Google Scholar",
+    description="Find academic papers and publications on Google Scholar",
     category=ToolCategory.RESEARCH,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/matrix_message.py
+++ b/src/mindroom/tools/matrix_message.py
@@ -19,9 +19,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="matrix_message",
     display_name="Matrix Message",
-    description=(
-        "Send, reply, react, read, room-threads, thread-list, and edit Matrix messages with room/thread context defaults"
-    ),
+    description="Read, send, edit, and react to messages in Matrix rooms and threads",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/matrix_room.py
+++ b/src/mindroom/tools/matrix_room.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="matrix_room",
     display_name="Matrix Room",
-    description="Inspect Matrix room metadata, members, threads, and state",
+    description="View Matrix room details, members, and conversation threads",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/matrix_voice_message.py
+++ b/src/mindroom/tools/matrix_voice_message.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="matrix_voice_message",
     display_name="Matrix Voice Message",
-    description="Generate speech from text and send it as a Matrix voice message with room/thread context defaults",
+    description="Turn text into speech and send it as a Matrix voice message",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.API_KEY,

--- a/src/mindroom/tools/memory.py
+++ b/src/mindroom/tools/memory.py
@@ -18,7 +18,7 @@ register_builtin_tool_metadata(
     ToolMetadata(
         name="memory",
         display_name="Agent Memory",
-        description="Explicitly store and search agent memories on demand",
+        description="Save, find, and update information the agent remembers",
         category=ToolCategory.PRODUCTIVITY,
         status=ToolStatus.AVAILABLE,
         setup_type=SetupType.NONE,

--- a/src/mindroom/tools/oauth_connections.py
+++ b/src/mindroom/tools/oauth_connections.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="oauth_connections",
     display_name="OAuth Connections",
-    description="Reset the current requester's OAuth connections for the current agent",
+    description="Get a confirmation link to reset an account connection for this agent",
     category=ToolCategory.INTEGRATIONS,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/report_publishing.py
+++ b/src/mindroom/tools/report_publishing.py
@@ -12,7 +12,7 @@ register_builtin_tool_metadata(
     ToolMetadata(
         name="report_publishing",
         display_name="Report Publishing",
-        description="Publish authorized report artifacts through revocable public links",
+        description="Share reports through public links that you can revoke",
         category=ToolCategory.PRODUCTIVITY,
         status=ToolStatus.AVAILABLE,
         setup_type=SetupType.NONE,

--- a/src/mindroom/tools/scheduler.py
+++ b/src/mindroom/tools/scheduler.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="scheduler",
     display_name="Scheduler",
-    description="Schedule, edit, list, and cancel tasks and reminders",
+    description="Schedule tasks and reminders, and manage upcoming runs",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/script.py
+++ b/src/mindroom/tools/script.py
@@ -20,10 +20,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="script",
     display_name="Background Scripts",
-    description=(
-        "Run trusted arbitrary Python code with scoped worker filesystem and environment access plus "
-        "deployment-policy network access"
-    ),
+    description="Run Python scripts in the background, monitor them, or cancel them",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/shell.py
+++ b/src/mindroom/tools/shell.py
@@ -251,7 +251,7 @@ def _handle_namespace(*, runtime_paths: RuntimePaths, base_dir: Path | None) -> 
 @register_tool_with_metadata(
     name="shell",
     display_name="Shell Commands",
-    description="Execute shell commands and scripts",
+    description="Run terminal commands and scripts in the agent workspace",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/subagents.py
+++ b/src/mindroom/tools/subagents.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="subagents",
     display_name="Sub-Agents",
-    description="Discover, spawn, and communicate with sub-agent sessions. `agents_list` reports per-tool capability flags (delegate-aware).",
+    description="Delegate tasks to sub-agents and follow up on their work",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/thread_model.py
+++ b/src/mindroom/tools/thread_model.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_model",
     display_name="Thread Model",
-    description="List configured models or switch which model the current Matrix thread uses",
+    description="Choose which AI model responds in the current conversation thread",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/thread_resolution.py
+++ b/src/mindroom/tools/thread_resolution.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_resolution",
     display_name="Thread Resolution",
-    description="Explicitly resolve or reopen Matrix threads in the current room",
+    description="Mark conversation threads as resolved or reopen them",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/thread_summary.py
+++ b/src/mindroom/tools/thread_summary.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_summary",
     display_name="Thread Summary",
-    description="Set or update Matrix thread summaries with room/thread context defaults",
+    description="Write or update a summary of a conversation thread",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/thread_tags.py
+++ b/src/mindroom/tools/thread_tags.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_tags",
     display_name="Thread Tags",
-    description="Tag, untag, and inspect Matrix threads using shared room-state markers",
+    description="Add, remove, and view tags on conversation threads",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools/todo.py
+++ b/src/mindroom/tools/todo.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="todo",
     display_name="Todo",
-    description="Create and manage per-thread work plans with dependencies",
+    description="Track tasks, progress, and dependencies in a conversation thread",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -174,7 +174,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Send, reply, react, read, room-threads, thread-list, and edit Matrix messages with room/thread context defaults",
+      "description": "Read, send, edit, and react to messages in Matrix rooms and threads",
       "display_name": "Matrix Message",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -198,7 +198,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Inspect Matrix room metadata, members, threads, and state",
+      "description": "View Matrix room details, members, and conversation threads",
       "display_name": "Matrix Room",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -283,7 +283,7 @@
       "dependencies": [
         "openai"
       ],
-      "description": "Generate speech from text and send it as a Matrix voice message with room/thread context defaults",
+      "description": "Turn text into speech and send it as a Matrix voice message",
       "display_name": "Matrix Voice Message",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -836,7 +836,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Explicitly resolve or reopen Matrix threads in the current room",
+      "description": "Mark conversation threads as resolved or reopen them",
       "display_name": "Thread Resolution",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -861,7 +861,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Set or update Matrix thread summaries with room/thread context defaults",
+      "description": "Write or update a summary of a conversation thread",
       "display_name": "Thread Summary",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -885,7 +885,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Tag, untag, and inspect Matrix threads using shared room-state markers",
+      "description": "Add, remove, and view tags on conversation threads",
       "display_name": "Thread Tags",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -2191,7 +2191,7 @@
       "consumes_workspace_paths": true,
       "default_execution_target": "worker",
       "dependencies": [],
-      "description": "Advanced code-oriented file operations (precise edits, grep, and discovery). Prefer this over file for coding agents; keep file for backward compatibility.",
+      "description": "Find code, search across files, and make precise edits",
       "display_name": "Coding Tools",
       "docs_url": null,
       "function_names": [
@@ -3298,7 +3298,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Local file operations including read, write, list, and search",
+      "description": "Read, write, list, and search files in the agent workspace",
       "display_name": "File Tools",
       "docs_url": "https://docs.agno.com/tools/toolkits/local/file",
       "function_names": [
@@ -3775,7 +3775,7 @@
       "dependencies": [
         "PyGithub"
       ],
-      "description": "Repository and issue management",
+      "description": "Browse code and manage GitHub repositories, issues, and pull requests",
       "display_name": "GitHub",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/github",
       "function_names": [
@@ -5932,7 +5932,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Run trusted arbitrary Python code with scoped worker filesystem and environment access plus deployment-policy network access",
+      "description": "Run Python scripts in the background, monitor them, or cancel them",
       "display_name": "Background Scripts",
       "docs_url": null,
       "function_names": [
@@ -6067,7 +6067,7 @@
       "consumes_workspace_paths": true,
       "default_execution_target": "worker",
       "dependencies": [],
-      "description": "Execute shell commands and scripts",
+      "description": "Run terminal commands and scripts in the agent workspace",
       "display_name": "Shell Commands",
       "docs_url": "https://docs.agno.com/tools/toolkits/local/shell",
       "function_names": [
@@ -6142,7 +6142,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Discover, spawn, and communicate with sub-agent sessions. `agents_list` reports per-tool capability flags (delegate-aware).",
+      "description": "Delegate tasks to sub-agents and follow up on their work",
       "display_name": "Sub-Agents",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -6773,7 +6773,7 @@
         "google-auth-oauthlib",
         "google-auth-httplib2"
       ],
-      "description": "Read, search, and manage Gmail emails",
+      "description": "Search, read, send, and organize email in Gmail",
       "display_name": "Gmail",
       "docs_url": "https://docs.agno.com/tools/toolkits/social/gmail",
       "function_names": [
@@ -7227,7 +7227,7 @@
       "dependencies": [
         "httpx"
       ],
-      "description": "Grant yourself UI access to manage this agent's Agent Vault secrets",
+      "description": "Get a link to manage this agent's passwords and API keys in Agent Vault",
       "display_name": "Agent Vault Access",
       "docs_url": null,
       "function_names": [
@@ -7249,8 +7249,8 @@
       "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": null,
-      "description": "Request human-approved temporary worker access to blocked external hostnames",
-      "display_name": "Approved Worker Egress",
+      "description": "Request approval for temporary access to a blocked website or service",
+      "display_name": "Network Access Requests",
       "docs_url": null,
       "function_names": [
         "request_network_access"
@@ -7519,7 +7519,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Reset the current requester's OAuth connections for the current agent",
+      "description": "Get a confirmation link to reset an account connection for this agent",
       "display_name": "OAuth Connections",
       "docs_url": null,
       "function_names": [
@@ -7627,7 +7627,7 @@
       "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": [],
-      "description": "List and register context-scoped file attachments",
+      "description": "Find files attached to a conversation and make workspace files available as attachments",
       "display_name": "Attachments",
       "docs_url": null,
       "function_names": [
@@ -7935,7 +7935,7 @@
       "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": null,
-      "description": "Operate exact locally allowlisted applications through accessibility state over Matrix encryption",
+      "description": "Let the agent interact with desktop apps you explicitly allow",
       "display_name": "Matrix Desktop",
       "docs_url": "https://docs.mindroom.chat/tools/desktop/",
       "function_names": [
@@ -8154,7 +8154,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "View and schedule meetings with Google Calendar",
+      "description": "View calendars and create or update events in Google Calendar",
       "display_name": "Google Calendar",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/googlecalendar",
       "function_names": [
@@ -8334,7 +8334,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "Search, read, upload, and organize files in the connected user's Google Drive",
+      "description": "Search, read, upload, and organize files in Google Drive",
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [
@@ -8512,7 +8512,7 @@
       "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": [],
-      "description": "Explicitly store and search agent memories on demand",
+      "description": "Save, find, and update information the agent remembers",
       "display_name": "Agent Memory",
       "docs_url": null,
       "function_names": [
@@ -8837,7 +8837,7 @@
       "consumes_workspace_paths": true,
       "default_execution_target": "primary",
       "dependencies": [],
-      "description": "Publish authorized report artifacts through revocable public links",
+      "description": "Share reports through public links that you can revoke",
       "display_name": "Report Publishing",
       "docs_url": null,
       "function_names": [
@@ -8862,7 +8862,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Schedule, edit, list, and cancel tasks and reminders",
+      "description": "Schedule tasks and reminders, and manage upcoming runs",
       "display_name": "Scheduler",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -9073,7 +9073,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "List configured models or switch which model the current Matrix thread uses",
+      "description": "Choose which AI model responds in the current conversation thread",
       "display_name": "Thread Model",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -9098,7 +9098,7 @@
       "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": null,
-      "description": "Create and manage per-thread work plans with dependencies",
+      "description": "Track tasks, progress, and dependencies in a conversation thread",
       "display_name": "Todo",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
@@ -10108,7 +10108,7 @@
       "dependencies": [
         "playwright"
       ],
-      "description": "OpenClaw-style browser control (status/start/stop/profiles/tabs/open/focus/close/snapshot/screenshot/navigate/console/pdf/upload/dialog/act/help/actions)",
+      "description": "Browse websites, fill in forms, and capture screenshots",
       "display_name": "Browser",
       "docs_url": "https://github.com/openclaw/openclaw/blob/main/docs/tools/browser.md",
       "function_names": [
@@ -11066,7 +11066,7 @@
       "dependencies": [
         "scholarly"
       ],
-      "description": "Search academic publications on Google Scholar",
+      "description": "Find academic papers and publications on Google Scholar",
       "display_name": "Google Scholar",
       "docs_url": "https://github.com/scholarly-python-package/scholarly",
       "function_names": [

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -128,6 +128,46 @@ def test_catalog_lists_tools_without_browser_authentication(portal: dict[str, An
     assert tools["matrix_message"]["requires_room_context"] is True
 
 
+@pytest.mark.parametrize("with_oauth", [False, True])
+def test_catalog_uses_mcp_display_metadata_without_exposing_model_instructions(
+    portal: dict[str, Any],
+    with_oauth: bool,
+) -> None:
+    """Tool copy and connection summaries stay separate from OAuth labels and model instructions."""
+    server: dict[str, Any] = {
+        "transport": "streamable-http",
+        "url": "https://mcp.example.test/mcp",
+        "display_name": "  Team Wiki  ",
+        "summary": "  Search and edit team documentation  ",
+    }
+    if with_oauth:
+        server["description"] = "Model-only instructions for handling connection errors"
+        server["auth"] = {
+            "type": "oauth",
+            "display_name": "Wiki sign-in",
+            "discovery": "manual",
+            "authorization_url": "https://auth.example.test/authorize",
+            "token_url": "https://auth.example.test/token",
+        }
+    portal["payload"]["mcp_servers"] = {"wiki": server}
+    portal["payload"]["agents"]["personal"]["tools"] = ["mcp_wiki"]
+    _publish_config(main.app, portal["paths"], portal["payload"])
+    _use_runtime_auth_settings(main.app)
+
+    response = portal["client"].get("/api/connections", headers=portal["headers"]["alice"])
+
+    assert response.status_code == 200, response.text
+    agent = response.json()["agents"][0]
+    assert agent["tools"][0]["display_name"] == "Team Wiki"
+    assert agent["tools"][0]["description"] == "Search and edit team documentation"
+    assert "Model-only" not in response.text
+    if with_oauth:
+        assert agent["services"][0]["display_name"] == "Wiki sign-in"
+        assert agent["services"][0]["description"] == "Search and edit team documentation"
+    else:
+        assert agent["services"] == []
+
+
 @pytest.mark.parametrize("agent_name", ["personal", "research"])
 @pytest.mark.parametrize(
     ("content_type", "body", "expected"),

--- a/tests/api/test_connections_api.py
+++ b/tests/api/test_connections_api.py
@@ -128,10 +128,15 @@ def test_catalog_lists_tools_without_browser_authentication(portal: dict[str, An
     assert tools["matrix_message"]["requires_room_context"] is True
 
 
-@pytest.mark.parametrize("with_oauth", [False, True])
+@pytest.mark.parametrize(
+    ("with_oauth", "provider_name", "expected_provider_name"),
+    [(False, None, None), (True, "  Wiki sign-in  ", "Wiki sign-in"), (True, "   ", "MCP Wiki")],
+)
 def test_catalog_uses_mcp_display_metadata_without_exposing_model_instructions(
     portal: dict[str, Any],
     with_oauth: bool,
+    provider_name: str | None,
+    expected_provider_name: str | None,
 ) -> None:
     """Tool copy and connection summaries stay separate from OAuth labels and model instructions."""
     server: dict[str, Any] = {
@@ -144,7 +149,7 @@ def test_catalog_uses_mcp_display_metadata_without_exposing_model_instructions(
         server["description"] = "Model-only instructions for handling connection errors"
         server["auth"] = {
             "type": "oauth",
-            "display_name": "Wiki sign-in",
+            "display_name": provider_name,
             "discovery": "manual",
             "authorization_url": "https://auth.example.test/authorize",
             "token_url": "https://auth.example.test/token",
@@ -162,7 +167,7 @@ def test_catalog_uses_mcp_display_metadata_without_exposing_model_instructions(
     assert agent["tools"][0]["description"] == "Search and edit team documentation"
     assert "Model-only" not in response.text
     if with_oauth:
-        assert agent["services"][0]["display_name"] == "Wiki sign-in"
+        assert agent["services"][0]["display_name"] == expected_provider_name
         assert agent["services"][0]["description"] == "Search and edit team documentation"
     else:
         assert agent["services"] == []

--- a/tests/test_mcp_registry.py
+++ b/tests/test_mcp_registry.py
@@ -131,6 +131,37 @@ def test_sync_mcp_tool_registry_registers_dynamic_tool(tmp_path: Path) -> None:
     assert TOOL_METADATA[tool_name].agent_override_fields is not None
 
 
+@pytest.mark.parametrize(
+    ("with_oauth", "provider_name", "expected_name"),
+    [
+        (False, None, "MCP Demo"),
+        (True, "  Example Workspace  ", "Example Workspace"),
+        (True, "   ", "MCP Demo"),
+        (True, None, "MCP Demo"),
+    ],
+)
+def test_mcp_display_metadata_falls_back_when_blank(
+    tmp_path: Path,
+    with_oauth: bool,
+    provider_name: str | None,
+    expected_name: str,
+) -> None:
+    """Empty display overrides preserve useful provider or server names."""
+    config = _oauth_config(tmp_path) if with_oauth else _config(tmp_path)
+    payload = config.model_dump()
+    server = payload["mcp_servers"]["demo"]
+    server.update(display_name="  ", summary="  ")
+    if with_oauth:
+        server["auth"]["display_name"] = provider_name
+    config = Config.validate_with_runtime(payload, _runtime_paths(tmp_path))
+
+    sync_mcp_tool_registry(config)
+
+    metadata = TOOL_METADATA["mcp_demo"]
+    assert metadata.display_name == expected_name
+    assert metadata.description == "Tools provided by this MCP server"
+
+
 def test_resolved_mcp_tool_state_ignores_unsynced_bound_manager(tmp_path: Path) -> None:
     """Metadata resolution should stay best-effort when a manager is bound but has no catalog yet."""
 


### PR DESCRIPTION
Connections should explain what each tool helps with. Several entries currently show internal terminology, long action lists, or generic MCP transport descriptions.

Rewrite the built-in descriptions in plain language and add optional `display_name` and `summary` fields for configured MCP servers. Display names fall back to the OAuth provider name, then the server ID. OAuth bridge instructions remain in the separate `description` field; tool IDs and permissions are unchanged.

Validation: 260 focused tests passed across Connections, MCP config/registry/OAuth/toolkits, metadata generation, and import boundaries. All applicable pre-commit hooks passed. Independent review passed. OAuth display names are normalized at config parsing so tool and sign-in labels share the blank-name fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MCP servers can provide custom display names and concise summaries for dashboards and tool catalogs.
  - Display metadata supports sensible fallbacks when values are blank or unspecified.
  - OAuth-specific model instructions remain separate from user-facing catalog information.

- **Improvements**
  - Refined tool names and descriptions across integrations for clearer, more consistent catalog listings.

- **Documentation**
  - Added configuration guidance and examples for MCP display metadata, including remote servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->