### PR TITLE
Cache Matrix room aliases to reduce routing stalls

### DIFF
--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -149,8 +149,32 @@ def load_rooms(runtime_paths: constants.RuntimePaths) -> dict[str, MatrixRoom]:
 
 
 def _room_aliases(runtime_paths: constants.RuntimePaths) -> dict[str, str]:
-    """Get mapping of room aliases to room IDs."""
-    return matrix_state_for_runtime(runtime_paths).get_room_aliases()
+    """Return a read-only alias map with the same freshness as cached state."""
+    state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
+    return _room_aliases_cached(
+        *_matrix_state_cache_key(state_file),
+        current_domain=_current_runtime_domain(runtime_paths),
+    )
+
+
+@lru_cache(maxsize=64)
+def _room_aliases_cached(
+    state_file: Path,
+    write_generation: int,
+    mtime_ns: int | None,
+    size: int | None,
+    *,
+    current_domain: str,
+) -> dict[str, str]:
+    """Build the alias map once per persisted state snapshot."""
+    state = _load_matrix_state_file_cached(
+        state_file,
+        write_generation,
+        mtime_ns,
+        size,
+        current_domain=current_domain,
+    )
+    return state.get_room_aliases()
 
 
 def get_room_id(room_key: str, runtime_paths: constants.RuntimePaths) -> str | None:

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -46,6 +46,7 @@ def test_matrix_state_cache_invalidates_after_write(tmp_path: Path) -> None:
     first = matrix_state_for_runtime(runtime_paths)
     assert first.get_room("dev") is not None
     assert first.get_room("research") is None
+    assert matrix_state.resolve_room_id("research", runtime_paths) == "research"
 
     fresh = MatrixState.load(runtime_paths=runtime_paths)
     fresh.add_room("research", room_id="!research:localhost", alias="#research:localhost", name="research")
@@ -54,6 +55,7 @@ def test_matrix_state_cache_invalidates_after_write(tmp_path: Path) -> None:
     second = matrix_state_for_runtime(runtime_paths)
     assert second is not first
     assert second.get_room("research") is not None
+    assert matrix_state.resolve_room_id("research", runtime_paths) == "!research:localhost"
 
 
 def test_matrix_state_load_returns_isolated_deep_copy(tmp_path: Path) -> None:
@@ -161,6 +163,41 @@ def test_matrix_state_cached_reads_do_not_stat_the_file(tmp_path: Path, monkeypa
     assert stat_calls == 0
 
 
+def test_resolve_room_aliases_reuses_mapping_for_unchanged_state(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """Repeated lookups must not rescan every persisted room for every agent."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+    builds = 0
+    original_get_room_aliases = MatrixState.get_room_aliases
+
+    def counted_get_room_aliases(self: MatrixState) -> dict[str, str]:
+        nonlocal builds
+        builds += 1
+        return original_get_room_aliases(self)
+
+    monkeypatch.setattr(MatrixState, "get_room_aliases", counted_get_room_aliases)
+
+    for _ in range(20):
+        resolved = matrix_state.resolve_room_aliases(["dev", "#dev:localhost", "!external:localhost"], runtime_paths)
+        assert resolved == ["!dev:localhost", "!dev:localhost", "!external:localhost"]
+        resolved.clear()
+        assert matrix_state.get_room_alias_from_id("!dev:localhost", runtime_paths) == "dev"
+
+    assert builds == 1
+
+
+def test_room_alias_cache_isolates_runtimes(tmp_path: Path) -> None:
+    """Identical aliases in separate runtime state files must resolve independently."""
+    first_paths = test_runtime_paths(tmp_path / "first")
+    second_paths = test_runtime_paths(tmp_path / "second")
+    _seed_state(first_paths, "dev", "!first:localhost")
+    _seed_state(second_paths, "dev", "!second:localhost")
+
+    for _ in range(2):
+        assert matrix_state.resolve_room_id("dev", first_paths) == "!first:localhost"
+        assert matrix_state.resolve_room_id("dev", second_paths) == "!second:localhost"
+
+
 def test_matrix_state_cache_observes_first_write_after_missing_read(tmp_path: Path) -> None:
     """A write must invalidate a cached empty state for a previously missing file."""
     runtime_paths = test_runtime_paths(tmp_path)
@@ -186,6 +223,7 @@ def test_matrix_state_cache_observes_external_write_after_stat_ttl(tmp_path: Pat
     monkeypatch.setattr(matrix_state, "_MATRIX_STATE_STAT_TTL_SECONDS", 1.0)
 
     first = matrix_state_for_runtime(runtime_paths)
+    assert matrix_state.resolve_room_id("research", runtime_paths) == "research"
     external = first.model_copy(deep=True)
     external.add_room("research", room_id="!research:localhost", alias="#research:localhost", name="research")
     state_file.write_text(
@@ -202,3 +240,4 @@ def test_matrix_state_cache_observes_external_write_after_stat_ttl(tmp_path: Pat
 
     assert second is not first
     assert second.get_room("research") is not None
+    assert matrix_state.resolve_room_id("research", runtime_paths) == "!research:localhost"


### PR DESCRIPTION
Room matching rebuilt the complete persisted alias map for every agent lookup, even when Matrix state had not changed. Cache that map using the existing state file path, write generation, file signature, and runtime domain; keep the same local-write invalidation and external-write freshness.

A local synthetic call-owner sweep with 1,000 persisted rooms and 100 configured agents dropped from 9.44s to 0.87s (median of three runs, about 11× faster). This measures synchronous lookup work; it does not establish end-to-end call latency improvement.

Regression coverage checks reuse without timing assertions, refresh after local and external writes, independent runtime aliases, and isolated result lists. Existing call ownership and ambiguity tests remain unchanged.

Validation: 167 focused cache, entity-resolution, and call-manager tests pass; all pre-commit hooks pass; independent review approved with no findings. Full suite: 18,530 passed, 10 skipped, four failures in browser/dynamic-tool/subagent description expectations. All four reproduce unchanged on clean main (`a68a905f4`); the alias-cache patch introduces no additional failures.

## Summary by Sourcery

Cache Matrix room alias mappings to avoid rebuilding persisted room data on every lookup while retaining state freshness and runtime isolation.

Enhancements:
- Cache Matrix room alias mappings by persisted state snapshot while preserving invalidation after local and external state changes.
- Keep alias resolution isolated across runtime domains and return independent lookup results.

Tests:
- Add regression coverage for alias-map reuse, runtime isolation, local-write invalidation, external-write freshness, and result-list isolation.