### PR TITLE
Bump mindroom-nio to 1.0.5

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -98,10 +98,11 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
+Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/docs/dev/matrix-event-journal-contracts.md
+++ b/docs/dev/matrix-event-journal-contracts.md
@@ -26,7 +26,7 @@ One shared boundary helper encodes `None` to the empty string and decodes it bac
 ### Durable sync batch boundary
 
 The Matrix client uses `nio.durable.open_durable_sync` with Classic or Simplified Sliding Sync.
-Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.4` package, with no Git source override.
+Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.5` package, with no Git source override.
 Account, device, consumer and stream ownership bind once when opening the session.
 Soft-logout renewal requests the existing device; it preserves the bound stream, membership positions, and attempted-delivery sending identity.
 Hard logout, missing device storage, or changed identity stops startup instead of attempting a stream replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==1.0.4",
+  "mindroom-nio[e2e]==1.0.5",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17397,10 +17397,11 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
+Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -94,10 +94,11 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.4`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
+Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -258,7 +258,7 @@ def test_wheel_force_include_does_not_bundle_avatar_assets() -> None:
 
 
 def test_runtime_dependency_requires_released_durable_nio() -> None:
-    """The wheel pins the released durable sync, history, byte-accounting, and membership-error fixes."""
+    """The wheel pins released durable sync fixes, including off-loop response decoding."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
     requirement = Requirement(
@@ -273,6 +273,7 @@ def test_runtime_dependency_requires_released_durable_nio() -> None:
     assert Version("1.0.1") not in requirement.specifier
     assert Version("1.0.2") not in requirement.specifier
     assert Version("1.0.3") not in requirement.specifier
-    assert Version("1.0.4") in requirement.specifier
-    assert Version("1.0.5") not in requirement.specifier
+    assert Version("1.0.4") not in requirement.specifier
+    assert Version("1.0.5") in requirement.specifier
+    assert Version("1.0.6") not in requirement.specifier
     assert Version("2.0.0") not in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -4594,7 +4594,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.4" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.5" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4706,7 +4706,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "1.0.4"
+version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4719,9 +4719,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/e7/2554b5c138174bc47630932f18f8ac5d40ad6412528ac4f3e2326647acbb/mindroom_nio-1.0.4.tar.gz", hash = "sha256:6f62350e1a2d82e82322a8332bacd20732c66100cfb924c34befce74b8c6a6eb", size = 211230, upload-time = "2026-09-11T09:36:53.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/d6/9407408727030db9c4574b1f618349fada01180fe9ea2d075072387925f7/mindroom_nio-1.0.5.tar.gz", hash = "sha256:0e33aa54542d55d851a2cf9659f5238b8882ac738f557f035395ddbb18478752", size = 211351, upload-time = "2026-09-12T13:36:42.615Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/09/75e54b03ee70f976351de65aea35e17794aaf1739f73bfb597a214627835/mindroom_nio-1.0.4-py3-none-any.whl", hash = "sha256:bb0a1c90e91caadc9493824f1134fb736722952d9dc6f6e359578265966a85dd", size = 246431, upload-time = "2026-09-11T09:36:51.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/97/7507e5fc7905c37a58ebe678533a3aa9beb67fd6bd889ff7fb0c993893f3/mindroom_nio-1.0.5-py3-none-any.whl", hash = "sha256:fb63320ac951800f777a96d766e7259a5fcbcbe689346ee58a1ea07c0d13c28d", size = 246587, upload-time = "2026-09-12T13:36:41.082Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Pin `mindroom-nio[e2e]` to the published 1.0.5 release so durable Classic and Sliding Sync response decoding, including captured-input replay, runs off the event loop. The upstream fix preserves durable capture, membership ordering, and cancellation and shutdown behavior: https://github.com/mindroom-ai/mindroom-nio/pull/66.

Regenerate the PyPI lockfile, update the existing exact-version packaging test, and refresh the architecture and contract documentation with generated references. No unrelated dependency versions change.

Validation:
- Full test run: 18,665 passed and 10 skipped; two disk-exhaustion failures passed on rerun with sufficient temporary space.
- All repository hooks passed, including type checks and generated-documentation checks.
- Installed PyPI package source matches the release; lockfile hashes match PyPI.
- Independent review approved after correcting the existing version test and documentation references.

## Summary by Sourcery

Adopt mindroom-nio 1.0.5 for improved durable Matrix synchronization behavior.

Enhancements:
- Update the runtime and lockfile dependency to the released mindroom-nio 1.0.5 package, enabling durable sync response decoding and captured-input replay to run off the event loop while retaining ordering and durability guarantees.

Documentation:
- Refresh architecture, contract, and generated documentation references for mindroom-nio 1.0.5.

Tests:
- Update packaging validation to require exactly mindroom-nio 1.0.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated Matrix integration support to Nio 1.0.5.
  - Sync response processing and replay of captured input now run outside the event loop, helping maintain responsiveness while preserving capture and membership ordering.

- **Documentation**
  - Updated Matrix integration and development documentation to reflect the new supported version and its processing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->