### PR TITLE
Initialize room ownership before cleanup

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -213,7 +213,9 @@ After a device change, standalone deliveries that reply outside a journal turn r
 
 On startup, MindRoom detects orphaned bot memberships left over from a previous configuration.
 When an agent is removed from `config.yaml`, its Matrix bot account may still be a member of rooms it previously joined.
-The cleanup process leaves those rooms safely without ejecting currently configured entities from their required rooms.
+The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
+Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
+An entity that cannot start keeps its memberships until its own lifecycle recovers.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -216,6 +216,7 @@ When an agent is removed from `config.yaml`, its Matrix bot account may still be
 The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
 Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
 An entity that cannot start keeps its memberships until its own lifecycle recovers.
+Unreadable or invalid retention files stop membership initialization instead of being treated as empty ownership records.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -583,6 +583,9 @@ Membership mutation methods return a boolean success result and surface transpor
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
+When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
+It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.
+Retention applies only to managed entities with invite acceptance enabled; it does not override disabled invitation policy.
 
 ### Transport objects
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -53,7 +53,9 @@ The hook system has four execution modes, determined by the event, not by indivi
 
 Hooks run serially.
 Each hook sees the context as read-only (except designated mutable fields like `suppress`).
-Failures lose only that hook's side effects; the next hook still runs.
+Ordinary observer failures are isolated and the next hook still runs; completed external side effects are not rolled back.
+An `agent:started` hook can declare `required=True` when startup must not proceed without its initialization.
+Failure or timeout in a required startup hook aborts that bot's startup before its room reconciliation, using the existing startup failure handling.
 
 ```python
 from mindroom.hooks import hook
@@ -233,6 +235,7 @@ async def enrich_weather(ctx):
 | `name` | `str` | function name | Hook identifier (unique within a plugin) |
 | `priority` | `int` | `100` | Execution order; lower values run first |
 | `timeout_ms` | `int \| None` | per-event default | Override the event's default timeout |
+| `required` | `bool` | `False` | For `agent:started` only: abort bot startup if this hook fails or times out |
 | `agents` | `Iterable[str] \| None` | `None` (all) | Only fire for these agent names |
 | `rooms` | `Iterable[str] \| None` | `None` (all) | Only fire for these room IDs |
 
@@ -475,6 +478,8 @@ If you are writing internal code or tests and already have an explicit `HookRegi
 
 Every hook invocation runs inside an `asyncio.timeout()` with structured error logging.
 Ordinary `Exception` and `SystemExit` failures are logged and isolated so later hooks can continue.
+Required startup hooks instead raise a `RuntimeError` with the original failure as its cause, stopping subsequent startup hooks and the bot's room reconciliation.
+Use a short, separate required hook for ownership or other necessary initialization; keep optional backfill, welcomes, and enrichment in ordinary hooks.
 Cancellation follows the caller and event policy, and external side effects completed before a failure cannot be rolled back.
 
 Failure semantics are mode-aware:
@@ -486,7 +491,7 @@ Failure semantics are mode-aware:
 
 ### No quarantine, no cooldown
 
-A hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](plugins.md#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
+An ordinary hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](plugins.md#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
 
 ### No automatic retries
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -576,12 +576,13 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `get_joined_rooms()`, `retain_room(room_id)`, `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_joined_rooms()` returns the bound account's joined room IDs, or `None` when the request fails; plugins can use one lookup to verify membership across their recorded rooms.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
-Transport exceptions from both read methods propagate to the caller.
+Transport exceptions from read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
 It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12988,7 +12988,9 @@ The hook system has four execution modes, determined by the event, not by indivi
 
 Hooks run serially.
 Each hook sees the context as read-only (except designated mutable fields like `suppress`).
-Failures lose only that hook's side effects; the next hook still runs.
+Ordinary observer failures are isolated and the next hook still runs; completed external side effects are not rolled back.
+An `agent:started` hook can declare `required=True` when startup must not proceed without its initialization.
+Failure or timeout in a required startup hook aborts that bot's startup before its room reconciliation, using the existing startup failure handling.
 
 ```python
 from mindroom.hooks import hook
@@ -13168,6 +13170,7 @@ async def enrich_weather(ctx):
 | `name` | `str` | function name | Hook identifier (unique within a plugin) |
 | `priority` | `int` | `100` | Execution order; lower values run first |
 | `timeout_ms` | `int \| None` | per-event default | Override the event's default timeout |
+| `required` | `bool` | `False` | For `agent:started` only: abort bot startup if this hook fails or times out |
 | `agents` | `Iterable[str] \| None` | `None` (all) | Only fire for these agent names |
 | `rooms` | `Iterable[str] \| None` | `None` (all) | Only fire for these room IDs |
 
@@ -13410,6 +13413,8 @@ If you are writing internal code or tests and already have an explicit `HookRegi
 
 Every hook invocation runs inside an `asyncio.timeout()` with structured error logging.
 Ordinary `Exception` and `SystemExit` failures are logged and isolated so later hooks can continue.
+Required startup hooks instead raise a `RuntimeError` with the original failure as its cause, stopping subsequent startup hooks and the bot's room reconciliation.
+Use a short, separate required hook for ownership or other necessary initialization; keep optional backfill, welcomes, and enrichment in ordinary hooks.
 Cancellation follows the caller and event policy, and external side effects completed before a failure cannot be rolled back.
 
 Failure semantics are mode-aware:
@@ -13421,7 +13426,7 @@ Failure semantics are mode-aware:
 
 ### No quarantine, no cooldown
 
-A hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](https://docs.mindroom.chat/plugins/#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
+An ordinary hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](https://docs.mindroom.chat/plugins/#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
 
 ### No automatic retries
 
@@ -17519,6 +17524,7 @@ When an agent is removed from `config.yaml`, its Matrix bot account may still be
 The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
 Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
 An entity that cannot start keeps its memberships until its own lifecycle recovers.
+Unreadable or invalid retention files stop membership initialization instead of being treated as empty ownership records.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13511,12 +13511,13 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `get_joined_rooms()`, `retain_room(room_id)`, `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_joined_rooms()` returns the bound account's joined room IDs, or `None` when the request fails; plugins can use one lookup to verify membership across their recorded rooms.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
-Transport exceptions from both read methods propagate to the caller.
+Transport exceptions from read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
 It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13518,6 +13518,9 @@ Membership mutation methods return a boolean success result and surface transpor
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
+When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
+It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.
+Retention applies only to managed entities with invite acceptance enabled; it does not override disabled invitation policy.
 
 ### Transport objects
 
@@ -17512,7 +17515,9 @@ After a device change, standalone deliveries that reply outside a journal turn r
 
 On startup, MindRoom detects orphaned bot memberships left over from a previous configuration.
 When an agent is removed from `config.yaml`, its Matrix bot account may still be a member of rooms it previously joined.
-The cleanup process leaves those rooms safely without ejecting currently configured entities from their required rooms.
+The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
+Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
+An entity that cannot start keeps its memberships until its own lifecycle recovers.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -212,6 +212,7 @@ When an agent is removed from `config.yaml`, its Matrix bot account may still be
 The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
 Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
 An entity that cannot start keeps its memberships until its own lifecycle recovers.
+Unreadable or invalid retention files stop membership initialization instead of being treated as empty ownership records.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -209,7 +209,9 @@ After a device change, standalone deliveries that reply outside a journal turn r
 
 On startup, MindRoom detects orphaned bot memberships left over from a previous configuration.
 When an agent is removed from `config.yaml`, its Matrix bot account may still be a member of rooms it previously joined.
-The cleanup process leaves those rooms safely without ejecting currently configured entities from their required rooms.
+The global sweep removes only persisted bot identities that no longer belong to a configured router, agent, or team.
+Current entities reconcile their own configured and retained rooms after startup hooks and invitation handling, so the early global sweep cannot remove them before that reconciliation.
+An entity that cannot start keeps its memberships until its own lifecycle recovers.
 This runs automatically — no manual intervention is needed.
 
 ## Identity Management

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -572,12 +572,13 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `get_joined_rooms()`, `retain_room(room_id)`, `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_joined_rooms()` returns the bound account's joined room IDs, or `None` when the request fails; plugins can use one lookup to verify membership across their recorded rooms.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
-Transport exceptions from both read methods propagate to the caller.
+Transport exceptions from read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
 It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -49,7 +49,9 @@ The hook system has four execution modes, determined by the event, not by indivi
 
 Hooks run serially.
 Each hook sees the context as read-only (except designated mutable fields like `suppress`).
-Failures lose only that hook's side effects; the next hook still runs.
+Ordinary observer failures are isolated and the next hook still runs; completed external side effects are not rolled back.
+An `agent:started` hook can declare `required=True` when startup must not proceed without its initialization.
+Failure or timeout in a required startup hook aborts that bot's startup before its room reconciliation, using the existing startup failure handling.
 
 ```python
 from mindroom.hooks import hook
@@ -229,6 +231,7 @@ async def enrich_weather(ctx):
 | `name` | `str` | function name | Hook identifier (unique within a plugin) |
 | `priority` | `int` | `100` | Execution order; lower values run first |
 | `timeout_ms` | `int \| None` | per-event default | Override the event's default timeout |
+| `required` | `bool` | `False` | For `agent:started` only: abort bot startup if this hook fails or times out |
 | `agents` | `Iterable[str] \| None` | `None` (all) | Only fire for these agent names |
 | `rooms` | `Iterable[str] \| None` | `None` (all) | Only fire for these room IDs |
 
@@ -471,6 +474,8 @@ If you are writing internal code or tests and already have an explicit `HookRegi
 
 Every hook invocation runs inside an `asyncio.timeout()` with structured error logging.
 Ordinary `Exception` and `SystemExit` failures are logged and isolated so later hooks can continue.
+Required startup hooks instead raise a `RuntimeError` with the original failure as its cause, stopping subsequent startup hooks and the bot's room reconciliation.
+Use a short, separate required hook for ownership or other necessary initialization; keep optional backfill, welcomes, and enrichment in ordinary hooks.
 Cancellation follows the caller and event policy, and external side effects completed before a failure cannot be rolled back.
 
 Failure semantics are mode-aware:
@@ -482,7 +487,7 @@ Failure semantics are mode-aware:
 
 ### No quarantine, no cooldown
 
-A hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](https://docs.mindroom.chat/plugins/#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
+An ordinary hook that raises is logged and skipped for that one event. The next event invokes it again. If it keeps raising, you keep getting logs — fix it (combined with [plugin hot reload](https://docs.mindroom.chat/plugins/#live-development-hot-reload), the next save is live within ~1s) and the next invocation just works. There is no failure threshold, no muting, no cooldown to wait out.
 
 ### No automatic retries
 

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -579,6 +579,9 @@ Membership mutation methods return a boolean success result and surface transpor
 `get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
+When reconciling an existing plugin-owned room, call the synchronous `retain_room(room_id)` after verifying the bound bot is still a member.
+It restores the same local retention record used by the bot's membership lifecycle, changes no Matrix membership, and raises `OSError` if persistence fails.
+Retention applies only to managed entities with invite acceptance enabled; it does not override disabled invitation policy.
 
 ### Transport objects
 

--- a/src/mindroom/hooks/decorators.py
+++ b/src/mindroom/hooks/decorators.py
@@ -6,7 +6,7 @@ import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
-from .types import HookCallback, validate_event_name
+from .types import EVENT_AGENT_STARTED, HookCallback, validate_event_name
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -26,6 +26,7 @@ class _HookMetadata:
     timeout_ms: int | None
     agents: tuple[str, ...] | None
     rooms: tuple[str, ...] | None
+    required: bool
 
 
 def hook(
@@ -36,9 +37,13 @@ def hook(
     timeout_ms: int | None = None,
     agents: Iterable[str] | None = None,
     rooms: Iterable[str] | None = None,
+    required: bool = False,
 ) -> Callable[[HookCallback], HookCallback]:
     """Annotate an async function as a MindRoom hook."""
     event_name = validate_event_name(event)
+    if required and event_name != EVENT_AGENT_STARTED:
+        msg = "required hooks are only supported for agent:started"
+        raise ValueError(msg)
     normalized_agents = tuple(agent.strip() for agent in agents or () if agent.strip()) or None
     normalized_rooms = tuple(room.strip() for room in rooms or () if room.strip()) or None
 
@@ -54,6 +59,7 @@ def hook(
             timeout_ms=timeout_ms,
             agents=normalized_agents,
             rooms=normalized_rooms,
+            required=required,
         )
         setattr(callback, _HOOK_METADATA_ATTR, metadata)
         return callback

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -212,7 +212,7 @@ async def _invoke_hook(hook: RegisteredHook, context: _HookExecutionContext) -> 
             result = await hook.callback(context)
     except asyncio.CancelledError:
         raise
-    except (Exception, SystemExit):
+    except (Exception, SystemExit) as error:
         duration_ms = elapsed_ms_since(started_at, ndigits=2)
         context.logger.exception(
             "Hook execution failed",
@@ -220,6 +220,9 @@ async def _invoke_hook(hook: RegisteredHook, context: _HookExecutionContext) -> 
             duration_ms=duration_ms,
             timeout_ms=_effective_timeout_ms(hook),
         )
+        if hook.required:
+            msg = f"Required startup hook {hook.plugin_name}:{hook.hook_name} failed"
+            raise RuntimeError(msg) from error
         return _HookInvocationResult(succeeded=False)
 
     duration_ms = elapsed_ms_since(started_at, ndigits=2)

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -9,7 +9,13 @@ from urllib.parse import quote
 
 import nio
 
-from mindroom.matrix.client_room_admin import add_room_to_space, create_room, get_room_members, invite_to_room
+from mindroom.matrix.client_room_admin import (
+    add_room_to_space,
+    create_room,
+    get_joined_rooms,
+    get_room_members,
+    invite_to_room,
+)
 from mindroom.matrix.identity import managed_account_key, managed_account_user_id
 from mindroom.matrix.invited_rooms_store import (
     invited_room_entity_names,
@@ -95,6 +101,10 @@ class _BoundHookMatrixAdmin:
     async def get_room_members(self, room_id: str) -> set[str] | None:
         """Return the current joined members for one room, or ``None`` when the fetch fails."""
         return await get_room_members(self.client, room_id)
+
+    async def get_joined_rooms(self) -> list[str] | None:
+        """Return the bound account's joined rooms, or ``None`` when unavailable."""
+        return await get_joined_rooms(self.client)
 
     async def get_profile_avatar(self, user_id: str) -> str | None:
         """Return one user's Matrix avatar content URI, or ``None`` when unavailable."""

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -58,7 +58,7 @@ class _BoundHookMatrixAdmin:
             power_users=power_user_ids,
         )
         if room_id is not None:
-            self._persist_created_room_for_creator(room_id)
+            self.retain_room(room_id)
         return room_id
 
     async def invite_user(self, room_id: str, user_id: str) -> bool:
@@ -141,12 +141,11 @@ class _BoundHookMatrixAdmin:
         )
         return isinstance(response, nio.RoomPutStateResponse)
 
-    def _persist_created_room_for_creator(self, room_id: str) -> None:
-        """Record a room the bound managed entity created so cleanup preserves it.
+    def retain_room(self, room_id: str) -> None:
+        """Retain a plugin-owned room for the bound managed entity across cleanup.
 
-        The creator is never invited into its own room, so the invite-accept
-        lifecycle that records invited rooms never fires for it. Persist here so
-        ``leave_unconfigured_rooms`` keeps plugin-created rooms across restarts.
+        Plugins reconciling existing rooms can restore this local ownership
+        record without creating a room or changing Matrix membership.
         """
         if self.config is None:
             return

--- a/src/mindroom/hooks/registry.py
+++ b/src/mindroom/hooks/registry.py
@@ -86,6 +86,7 @@ class HookRegistry:
                         source_lineno=_callback_source_lineno(callback),
                         agents=metadata.agents,
                         rooms=metadata.rooms,
+                        required=metadata.required,
                     ),
                 )
 

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -115,7 +115,14 @@ class HookMessageSender(Protocol):
 
 
 class HookMatrixAdmin(Protocol):
-    """Async Matrix admin protocol exposed to hook contexts."""
+    """Matrix administration and local room retention exposed to hook contexts."""
+
+    def retain_room(self, room_id: str) -> None:
+        """Persist a plugin-owned room for the bound invite-accepting entity.
+
+        This synchronous local operation changes no Matrix membership and raises
+        ``OSError`` if retention cannot be persisted.
+        """
 
     async def resolve_alias(self, alias: str) -> str | None:
         """Resolve one room alias into a room ID when it exists."""

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -127,6 +127,9 @@ class HookMatrixAdmin(Protocol):
     async def resolve_alias(self, alias: str) -> str | None:
         """Resolve one room alias into a room ID when it exists."""
 
+    async def get_joined_rooms(self) -> list[str] | None:
+        """Return the bound account's joined rooms, or ``None`` when unavailable."""
+
     async def create_room(
         self,
         *,

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -223,6 +223,7 @@ class RegisteredHook:
     source_lineno: int
     agents: tuple[str, ...] | None
     rooms: tuple[str, ...] | None
+    required: bool = False
 
 
 def default_timeout_ms_for_event(event_name: str) -> int:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -113,7 +113,9 @@ def remember_invited_room(path: Path, room_id: str) -> None:
     if room_id in room_ids:
         return
     room_ids.add(room_id)
-    save_invited_rooms(path, room_ids)
+    if not save_invited_rooms(path, room_ids):
+        msg = f"Failed to retain invited room {room_id}"
+        raise OSError(msg)
 
 
 def _invite_acceptance_policy(config: Config, agent_name: str) -> InviteAcceptancePolicy | None:

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from fnmatch import fnmatchcase
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from mindroom.constants import ROUTER_AGENT_NAME, safe_replace
@@ -33,7 +33,7 @@ def pending_room_invites_path(storage_root: Path, agent_name: str) -> Path:
 
 
 def load_invited_rooms(path: Path) -> set[str]:
-    """Load persisted invited rooms, failing open on missing or invalid files."""
+    """Load persisted room ownership, rejecting unreadable or invalid state."""
     if not path.exists():
         return set()
 
@@ -41,18 +41,13 @@ def load_invited_rooms(path: Path) -> set[str]:
         raw = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         logger.warning("failed_to_load_invited_rooms", path=str(path), exc_info=True)
-        return set()
+        raise
 
-    if not isinstance(raw, list):
-        logger.warning("invalid_invited_rooms_file", path=str(path))
-        return set()
+    if not isinstance(raw, list) or any(not isinstance(room_id, str) for room_id in raw):
+        msg = f"Invalid invited-room retention file: {path}"
+        raise ValueError(msg)
 
-    room_ids = [room_id for room_id in raw if isinstance(room_id, str)]
-    if len(room_ids) != len(raw):
-        logger.warning("invalid_invited_rooms_file", path=str(path))
-        return set()
-
-    return set(room_ids)
+    return set(cast("list[str]", raw))
 
 
 def save_invited_rooms(path: Path, room_ids: set[str]) -> bool:

--- a/src/mindroom/matrix/room_cleanup.py
+++ b/src/mindroom/matrix/room_cleanup.py
@@ -13,16 +13,10 @@ from typing import TYPE_CHECKING
 
 import nio
 
-from mindroom.entity_resolution import configured_bot_user_ids_for_room, entity_identity_registry
+from mindroom.entity_resolution import entity_identity_registry
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members
 from mindroom.matrix.identity import MatrixID
-from mindroom.matrix.invited_rooms_store import (
-    invited_room_entity_names,
-    invited_rooms_path,
-    load_invited_rooms,
-    should_persist_invited_rooms,
-)
 from mindroom.matrix.rooms import is_dm_room
 from mindroom.matrix.state import matrix_state_for_runtime
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
@@ -46,31 +40,11 @@ def _get_all_known_bot_user_ids(config: Config, runtime_paths: RuntimePaths) -> 
     }
 
 
-def _load_all_persisted_invited_rooms(
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> dict[str, set[str]]:
-    """Load persisted invited rooms for invite-accepting entities, keyed by bot Matrix user ID."""
-    invited_rooms_by_bot: dict[str, set[str]] = {}
-    config_ids = entity_identity_registry(config, runtime_paths).current_ids
-
-    for entity_name in invited_room_entity_names(config):
-        if not should_persist_invited_rooms(config, entity_name):
-            continue
-
-        rooms = load_invited_rooms(invited_rooms_path(runtime_paths.storage_root, entity_name))
-        if rooms:
-            invited_rooms_by_bot[config_ids[entity_name].full_id] = rooms
-
-    return invited_rooms_by_bot
-
-
 async def _cleanup_orphaned_bots_in_room(
     client: nio.AsyncClient,
     room_id: str,
     config: Config,
     runtime_paths: RuntimePaths,
-    persisted_invited_rooms_by_bot: dict[str, set[str]] | None = None,
 ) -> list[str]:
     """Remove orphaned bots from a single room.
 
@@ -81,14 +55,12 @@ async def _cleanup_orphaned_bots_in_room(
         room_id: The room to check
         config: Current configuration
         runtime_paths: Explicit runtime context for Matrix state and identity resolution
-        persisted_invited_rooms_by_bot: Preloaded persisted invited rooms keyed by bot Matrix user ID
 
     Returns:
         List of bot Matrix user IDs that were removed from the room
 
     """
-    # Never evict bots from the root space — the router is the creator/admin
-    # and no agents are explicitly configured for it, so every bot looks orphaned.
+    # Root-space membership is managed separately from ordinary room cleanup.
     state = matrix_state_for_runtime(runtime_paths)
     if state.space_room_id and room_id == state.space_room_id:
         logger.debug("orphaned_bot_cleanup_skipped_root_space", room_id=room_id)
@@ -105,12 +77,8 @@ async def _cleanup_orphaned_bots_in_room(
         logger.warning("orphaned_bot_cleanup_members_unavailable", room_id=room_id)
         return []
 
-    # Get configured bots for this room
-    configured_bot_ids = configured_bot_user_ids_for_room(config, room_id, runtime_paths)
     known_bot_user_ids = _get_all_known_bot_user_ids(config, runtime_paths)
     registry = entity_identity_registry(config, runtime_paths)
-    if persisted_invited_rooms_by_bot is None:
-        persisted_invited_rooms_by_bot = _load_all_persisted_invited_rooms(config, runtime_paths)
 
     removed_bots = []
 
@@ -119,25 +87,14 @@ async def _cleanup_orphaned_bots_in_room(
     for user_id in sorted(member_ids, key=lambda member_id: member_id == client.user_id):
         matrix_id = MatrixID.parse(user_id)
         agent_name = registry.current_entity_name_for_user_id(user_id)
-        is_configured_current_bot = agent_name is not None and user_id in configured_bot_ids
-
-        # Check if this is a mindroom bot and shouldn't be in this room
-        if user_id in known_bot_user_ids and not is_configured_current_bot:
-            if room_id in persisted_invited_rooms_by_bot.get(user_id, set()):
-                logger.debug(
-                    "orphaned_bot_cleanup_preserved_persisted_invited_room",
-                    agent=matrix_id.username,
-                    user_id=user_id,
-                    room_id=room_id,
-                )
-                continue
-
+        # Current bots reconcile their own memberships after startup hooks and
+        # pending invitations. This earlier sweep only owns retired identities.
+        if user_id in known_bot_user_ids and agent_name is None:
             logger.info(
                 "orphaned_bot_found",
                 agent=matrix_id.username,
                 user_id=user_id,
                 room_id=room_id,
-                configured_bots=sorted(configured_bot_ids),
             )
 
             if await _remove_orphaned_bot(client, room_id, matrix_id):
@@ -186,10 +143,12 @@ async def cleanup_all_orphaned_bots(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> dict[str, list[str]]:
-    """Remove all orphaned bots from all rooms the client has access to.
+    """Remove retired bot identities from all rooms the client has access to.
 
     This should be called by a user or bot with admin/moderator permissions
     in the rooms that need cleaning.
+    Configured entities manage their own memberships, even if startup has not
+    completed or their invited-room retention records have not been restored.
 
     Returns:
         Dictionary mapping room IDs to lists of removed bot Matrix user IDs
@@ -204,7 +163,6 @@ async def cleanup_all_orphaned_bots(
         return kicked_bots
 
     logger.info("orphaned_bot_cleanup_started", room_count=len(joined_rooms))
-    persisted_invited_rooms_by_bot = _load_all_persisted_invited_rooms(config, runtime_paths)
 
     # Only independent rooms overlap. Each room still kicks other orphans
     # before leaving itself, and cancellation drains all workers before return.
@@ -217,7 +175,6 @@ async def cleanup_all_orphaned_bots(
                 room_id,
                 config,
                 runtime_paths,
-                persisted_invited_rooms_by_bot,
             )
             if room_kicked:
                 kicked_bots[room_id] = room_kicked

--- a/tests/test_bot_sync_lifecycle.py
+++ b/tests/test_bot_sync_lifecycle.py
@@ -19,9 +19,10 @@ import pytest
 
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.cancellation import SYNC_RESTART_CANCEL_MSG, current_task_is_process_shutdown
+from mindroom.config.plugin import PluginEntryConfig
 from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
 from mindroom.event_journal import EventClass, EventKind
-from mindroom.hooks import EVENT_AGENT_STARTED
+from mindroom.hooks import EVENT_AGENT_STARTED, HookRegistry, hook
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN, SYNC_RESTART_SHUTDOWN
 from tests.journal_helpers import admit_dispatch_event
 from tests.threading_helpers import (
@@ -148,6 +149,61 @@ class TestBotSyncLifecycle(ThreadingBehaviorTestBase):
         assert bot.running is False
         assert bot.client is None
         assert bot._ingestion_session is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", ["lookup", "write", "timeout", "system_exit"])
+    async def test_required_startup_hook_failure_stops_before_room_reconciliation(
+        self,
+        bot: AgentBot,
+        failure: str,
+    ) -> None:
+        """Failed room ownership initialization must close startup before cleanup."""
+        later_hook = AsyncMock()
+
+        @hook(EVENT_AGENT_STARTED, priority=10, timeout_ms=5, required=True)
+        async def retain_rooms(_ctx: object) -> None:
+            if failure == "timeout":
+                await asyncio.sleep(60)
+            if failure == "system_exit":
+                raise SystemExit(1)
+            msg = f"retention {failure} failed"
+            raise OSError(msg)
+
+        @hook(EVENT_AGENT_STARTED, priority=20)
+        async def backfill(_ctx: object) -> None:
+            await later_hook()
+
+        bot.hook_registry = HookRegistry.from_plugins(
+            [
+                SimpleNamespace(
+                    name="room-owner",
+                    discovered_hooks=(retain_rooms, backfill),
+                    plugin_order=0,
+                    entry_config=PluginEntryConfig(path="./plugins/room-owner"),
+                ),
+            ],
+        )
+        client = _make_client_mock(user_id="@mindroom_general:localhost")
+        session = AsyncMock()
+        with (
+            patch.object(bot, "ensure_user_account", AsyncMock()),
+            patch(
+                "mindroom.bot.login_agent_owned_session",
+                AsyncMock(return_value=SimpleNamespace(client=client, session=session)),
+            ),
+            patch.object(bot, "_set_avatar_if_available", AsyncMock()),
+            patch.object(bot, "_set_presence_with_model_info", AsyncMock()),
+            pytest.raises(RuntimeError, match="Required startup hook") as error,
+        ):
+            await bot.start()
+
+        expected_cause = {"timeout": TimeoutError, "system_exit": SystemExit}.get(failure, OSError)
+        assert isinstance(error.value.__cause__, expected_cause)
+        later_hook.assert_not_awaited()
+        client.close.assert_awaited_once()
+        session.close.assert_awaited_once()
+        assert bot.client is None
+        assert not bot.running
 
     @pytest.mark.asyncio
     async def test_approval_recovery_retains_owned_store_until_final_send_finishes(self, bot: AgentBot) -> None:

--- a/tests/test_dm_room_preservation.py
+++ b/tests/test_dm_room_preservation.py
@@ -10,12 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.config.agent import AgentConfig
+from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.matrix.room_cleanup import _cleanup_orphaned_bots_in_room, cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
-from mindroom.tool_system.worker_routing import agent_state_root_path
 from tests.bot_helpers import make_test_agent_bot
 from tests.conftest import (
     TEST_PASSWORD,
@@ -204,21 +203,17 @@ class TestDMPreservationDuringCleanup:
             },
         )
         # Mock a room with no configured bots (DM room)
-        with patch(
-            "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
-            return_value=set(),  # No bots configured for this room
-        ):
-            kicked_bots = await _cleanup_orphaned_bots_in_room(
-                client,
-                "!dm:server",
-                config,
-                runtime_paths_for(config),
-            )
+        kicked_bots = await _cleanup_orphaned_bots_in_room(
+            client,
+            "!dm:server",
+            config,
+            runtime_paths_for(config),
+        )
 
-            # Should not kick anyone from DM room
-            assert kicked_bots == []
-            # Should not even try to kick
-            assert not client.room_kick.called
+        # Should not kick anyone from DM room
+        assert kicked_bots == []
+        # Should not even try to kick
+        assert not client.room_kick.called
 
     async def test_orphaned_bot_cleanup_processes_regular_rooms(self, tmp_path: Path) -> None:
         """Test that orphaned bot cleanup processes rooms when DM mode is disabled."""
@@ -244,10 +239,6 @@ class TestDMPreservationDuringCleanup:
             patch(
                 "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
                 return_value={"@mindroom_orphaned:server", f"@mindroom_configured_agent:{current_domain}"},
-            ),
-            patch(
-                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
-                return_value={f"@mindroom_configured_agent:{current_domain}"},
             ),
         ):
             client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
@@ -292,10 +283,6 @@ class TestDMPreservationDuringCleanup:
                 "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
                 return_value={"@mindroom_orphaned:server", f"@mindroom_configured_agent:{current_domain}"},
             ),
-            patch(
-                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
-                return_value={f"@mindroom_configured_agent:{current_domain}"},
-            ),
         ):
             client.room_leave = AsyncMock(return_value=nio.RoomLeaveResponse())
 
@@ -324,7 +311,6 @@ class TestDMPreservationDuringCleanup:
                 ),
             },
         )
-        current_domain = config.get_domain(runtime_paths_for(config))
         # The client's own account comes first so a naive sweep would leave before kicking
         members = ["@mindroom_self:server", "@mindroom_orphaned:server"]
 
@@ -336,10 +322,6 @@ class TestDMPreservationDuringCleanup:
             patch(
                 "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
                 return_value={"@mindroom_self:server", "@mindroom_orphaned:server"},
-            ),
-            patch(
-                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
-                return_value={f"@mindroom_configured_agent:{current_domain}"},
             ),
         ):
             client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
@@ -372,7 +354,7 @@ class TestDMPreservationDuringCleanup:
                 "configured_agent": AgentConfig(
                     display_name="Configured Agent",
                     role="Agent that should be in rooms",
-                    rooms=["!regular:server"],
+                    rooms=[],
                 ),
             },
         )
@@ -400,6 +382,39 @@ class TestDMPreservationDuringCleanup:
 
         assert kicked_bots == []
         assert not client.room_kick.called
+
+    async def test_global_cleanup_defers_current_identities_to_their_own_lifecycle(self, tmp_path: Path) -> None:
+        """Missing room-retention records cannot turn current bots into orphans."""
+        config = _config_with_runtime_paths(
+            tmp_path,
+            agents={"agent": AgentConfig(display_name="Agent", rooms=[], accept_invites=False)},
+            teams={"team": TeamConfig(display_name="Team", role="Test team", agents=["agent"], rooms=[])},
+        )
+        runtime_paths = runtime_paths_for(config)
+        domain = config.get_domain(runtime_paths)
+        state = MatrixState.load(runtime_paths=runtime_paths)
+        for name in ("router", "agent", "team", "retired"):
+            state.add_account(f"agent_{name}", f"mindroom_{name}", TEST_PASSWORD, domain=domain)
+        state.save(runtime_paths=runtime_paths)
+        client = AsyncMock(user_id=f"@mindroom_router:{domain}")
+        client.room_kick.return_value = nio.RoomKickResponse()
+        room_id = "!dynamic:server"
+        members = {f"@mindroom_{name}:{domain}" for name in ("router", "agent", "team", "retired")}
+
+        with (
+            patch("mindroom.matrix.room_cleanup.get_joined_rooms", return_value=[room_id]),
+            patch("mindroom.matrix.room_cleanup.get_room_members", return_value=members),
+            patch("mindroom.matrix.room_cleanup.is_dm_room", return_value=False),
+        ):
+            result = await cleanup_all_orphaned_bots(client, config, runtime_paths)
+
+        assert result == {room_id: [f"@mindroom_retired:{domain}"]}
+        client.room_leave.assert_not_awaited()
+        client.room_kick.assert_awaited_once_with(
+            room_id,
+            f"@mindroom_retired:{domain}",
+            reason="Bot no longer configured for this room",
+        )
 
     async def test_orphaned_bot_cleanup_does_not_match_remote_user_by_localpart(self, tmp_path: Path) -> None:
         """Cleanup must compare full Matrix IDs, not username localparts."""
@@ -449,13 +464,6 @@ class TestDMPreservationDuringCleanup:
         # Mock joined rooms - mix of configured and DM rooms
         joined_rooms = ["!configured:server", "!dm:server", "!another_dm:server"]
 
-        def mock_get_configured_bots(_config: Config, room_id: str, runtime_paths: object | None = None) -> set[str]:
-            del runtime_paths
-            # Only !configured:server has configured bots
-            if room_id == "!configured:server":
-                return {"@mindroom_agent:server"}
-            return set()  # DM rooms have no configured bots
-
         # Mock is_dm_room to return True for DM rooms
         async def mock_is_dm_room(client: Any, room_id: str) -> bool:  # noqa: ARG001, ANN401
             return room_id in ["!dm:server", "!another_dm:server"]
@@ -470,10 +478,6 @@ class TestDMPreservationDuringCleanup:
                 "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
                 return_value={"@mindroom_orphaned:server", "@mindroom_agent:server"},
             ),
-            patch(
-                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
-                side_effect=mock_get_configured_bots,
-            ),
             patch("mindroom.matrix.room_cleanup.is_dm_room", side_effect=mock_is_dm_room),
         ):
             client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
@@ -487,74 +491,6 @@ class TestDMPreservationDuringCleanup:
             # Should only kick from configured room
             assert client.room_kick.call_count == 1
             assert client.room_kick.call_args[0][0] == "!configured:server"
-
-    async def test_cleanup_all_orphaned_bots_preserves_persisted_invited_room(self, tmp_path: Path) -> None:
-        """Persisted ad-hoc invited rooms should not be treated as orphaned during cleanup."""
-        client = AsyncMock()
-        config = _config_with_runtime_paths(
-            tmp_path,
-            agents={
-                "agent": AgentConfig(
-                    display_name="Agent",
-                    role="Test agent",
-                ),
-            },
-        )
-        rp = runtime_paths_for(config)
-        invited_rooms_path = agent_state_root_path(rp.storage_root, "agent") / "invited_rooms.json"
-        invited_rooms_path.parent.mkdir(parents=True, exist_ok=True)
-        invited_rooms_path.write_text('[\n  "!ad-hoc:server"\n]\n', encoding="utf-8")
-
-        with (
-            patch("mindroom.matrix.room_cleanup.get_joined_rooms", return_value=["!ad-hoc:server"]),
-            patch(
-                "mindroom.matrix.room_cleanup.get_room_members",
-                return_value=[f"@mindroom_agent:{config.get_domain(rp)}"],
-            ),
-            patch("mindroom.matrix.room_cleanup.is_dm_room", new=AsyncMock(return_value=False)),
-        ):
-            client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
-            result = await cleanup_all_orphaned_bots(client, config, rp)
-
-        assert result == {}
-        client.room_kick.assert_not_called()
-
-    async def test_cleanup_all_orphaned_bots_preserves_drifted_persisted_invited_room(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        """Persisted ad-hoc invited rooms should follow the current live bot username."""
-        client = AsyncMock()
-        config = _config_with_runtime_paths(
-            tmp_path,
-            agents={
-                "agent": AgentConfig(
-                    display_name="Agent",
-                    role="Test agent",
-                ),
-            },
-        )
-        rp = runtime_paths_for(config)
-        state = MatrixState.load(runtime_paths=rp)
-        state.add_account("agent_agent", "mindroom_agent_oldns", "pw", domain=config.get_domain(rp))
-        state.save(runtime_paths=rp)
-        invited_rooms_path = agent_state_root_path(rp.storage_root, "agent") / "invited_rooms.json"
-        invited_rooms_path.parent.mkdir(parents=True, exist_ok=True)
-        invited_rooms_path.write_text('[\n  "!ad-hoc:server"\n]\n', encoding="utf-8")
-
-        with (
-            patch("mindroom.matrix.room_cleanup.get_joined_rooms", return_value=["!ad-hoc:server"]),
-            patch(
-                "mindroom.matrix.room_cleanup.get_room_members",
-                return_value=[f"@mindroom_agent_oldns:{config.get_domain(rp)}"],
-            ),
-            patch("mindroom.matrix.room_cleanup.is_dm_room", new=AsyncMock(return_value=False)),
-        ):
-            client.room_kick = AsyncMock(return_value=nio.RoomKickResponse())
-            result = await cleanup_all_orphaned_bots(client, config, rp)
-
-        assert result == {}
-        client.room_kick.assert_not_called()
 
     async def test_orphaned_bot_cleanup_skips_root_space(self, tmp_path: Path) -> None:
         """Test that orphaned bot cleanup skips the root space room.
@@ -634,10 +570,6 @@ class TestDMPreservationDuringCleanup:
             ),
             patch(
                 "mindroom.matrix.room_cleanup._get_all_known_bot_user_ids",
-                return_value={f"@mindroom_router:{current_domain}"},
-            ),
-            patch(
-                "mindroom.matrix.room_cleanup.configured_bot_user_ids_for_room",
                 return_value={f"@mindroom_router:{current_domain}"},
             ),
             patch("mindroom.matrix.room_cleanup.is_dm_room", side_effect=mock_is_dm_room),

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -20,6 +20,7 @@ from mindroom.hooks.registry import HookRegistry, HookRegistryState
 from mindroom.logging_config import get_logger
 from mindroom.matrix.agent_message_snapshot import AgentMessageSnapshot
 from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms
+from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestrator import _MultiAgentOrchestrator
@@ -480,11 +481,13 @@ async def test_hook_matrix_admin_create_room_does_not_persist_for_unmanaged_crea
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("new_room", [True, False])
 async def test_hook_matrix_admin_created_room_survives_lifecycle_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    new_room: bool,
 ) -> None:
-    """A room the router creates must survive its own lifecycle cleanup."""
+    """New and reconciled plugin rooms must survive the bot's own cleanup."""
     module = _matrix_admin_module()
     config = _private_room_config(tmp_path)
     runtime_paths = runtime_paths_for(config)
@@ -493,9 +496,23 @@ async def test_hook_matrix_admin_created_room_survives_lifecycle_cleanup(
     client.homeserver = "http://localhost:8008"
     client.user_id = ids[ROUTER_AGENT_NAME].full_id
 
+    # Startup sweeps before plugins reconcile existing rooms. The active bot
+    # must keep control of its own membership even without a retention record.
+    with (
+        patch("mindroom.matrix.room_cleanup.get_joined_rooms", return_value=["!private:localhost"]),
+        patch("mindroom.matrix.room_cleanup.get_room_members", return_value={client.user_id}),
+        patch("mindroom.matrix.room_cleanup.is_dm_room", return_value=False),
+    ):
+        assert await cleanup_all_orphaned_bots(client, config, runtime_paths) == {}
+    client.room_leave.assert_not_awaited()
+    client.room_kick.assert_not_awaited()
+
     with patch("mindroom.hooks.matrix_admin.create_room", new=AsyncMock(return_value="!private:localhost")):
         admin = module.build_hook_matrix_admin(client, runtime_paths=runtime_paths, config=config)
-        await admin.create_room(name="Private Room", alias_localpart="private-user")
+        if new_room:
+            await admin.create_room(name="Private Room", alias_localpart="private-user")
+        else:
+            admin.retain_room("!private:localhost")
 
     bot = make_test_agent_bot(
         agent_user=_router_user(ids[ROUTER_AGENT_NAME].full_id),
@@ -529,6 +546,63 @@ async def test_hook_matrix_admin_created_room_survives_lifecycle_cleanup(
 
     assert bot._room_lifecycle.invited_rooms == {"!private:localhost"}
     assert left_room_ids == ["!old:localhost"]
+
+
+def test_hook_matrix_admin_retention_preserves_other_rooms(tmp_path: Path) -> None:
+    """Reconciliation adds to durable retention without dropping earlier rooms."""
+    module = _matrix_admin_module()
+    config = _private_room_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.user_id = entity_ids(config, runtime_paths)[ROUTER_AGENT_NAME].full_id
+    admin = module.build_hook_matrix_admin(client, runtime_paths=runtime_paths, config=config)
+
+    for room_id in ("!first:localhost", "!second:localhost", "!first:localhost"):
+        admin.retain_room(room_id)
+
+    assert load_invited_rooms(invited_rooms_path(runtime_paths.storage_root, ROUTER_AGENT_NAME)) == {
+        "!first:localhost",
+        "!second:localhost",
+    }
+    assert load_invited_rooms(invited_rooms_path(runtime_paths.storage_root, "general")) == set()
+
+
+def test_hook_matrix_admin_retention_surfaces_storage_failure(tmp_path: Path) -> None:
+    """A failed retention write must not let a plugin report reconciliation success."""
+    module = _matrix_admin_module()
+    config = _private_room_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.user_id = entity_ids(config, runtime_paths)[ROUTER_AGENT_NAME].full_id
+    admin = module.build_hook_matrix_admin(client, runtime_paths=runtime_paths, config=config)
+
+    with (
+        patch("mindroom.matrix.invited_rooms_store.save_invited_rooms", return_value=False),
+        pytest.raises(OSError, match="retain invited room"),
+    ):
+        admin.retain_room("!private:localhost")
+
+    assert load_invited_rooms(invited_rooms_path(runtime_paths.storage_root, ROUTER_AGENT_NAME)) == set()
+
+
+@pytest.mark.parametrize(("managed", "accept_invites"), [(False, True), (True, False)])
+def test_hook_matrix_admin_retention_respects_entity_policy(
+    tmp_path: Path,
+    managed: bool,
+    accept_invites: bool,
+) -> None:
+    """Retention cannot enroll unmanaged accounts or override disabled invites."""
+    module = _matrix_admin_module()
+    config = _private_room_config(tmp_path)
+    config.router.accept_invites = accept_invites
+    runtime_paths = runtime_paths_for(config)
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.user_id = entity_ids(config, runtime_paths)[ROUTER_AGENT_NAME].full_id if managed else "@outsider:localhost"
+    admin = module.build_hook_matrix_admin(client, runtime_paths=runtime_paths, config=config)
+
+    admin.retain_room("!private:localhost")
+
+    assert load_invited_rooms(invited_rooms_path(runtime_paths.storage_root, ROUTER_AGENT_NAME)) == set()
 
 
 def test_hook_context_support_prefers_orchestrator_router_matrix_admin(tmp_path: Path) -> None:

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -128,6 +128,22 @@ async def test_hook_context_delegates_latest_agent_message_snapshot_reads(tmp_pa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("available", [True, False])
+async def test_hook_matrix_admin_reads_bound_account_joined_rooms(tmp_path: Path, available: bool) -> None:
+    """Plugins can distinguish current memberships from an unavailable snapshot."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.joined_rooms.return_value = (
+        nio.JoinedRoomsResponse(rooms=["!existing:localhost"])
+        if available
+        else nio.JoinedRoomsError("unavailable", status_code="M_UNKNOWN")
+    )
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_joined_rooms() == (["!existing:localhost"] if available else None)
+
+
+@pytest.mark.asyncio
 async def test_build_hook_matrix_admin_resolve_alias_returns_room_id(tmp_path: Path) -> None:
     """Alias resolution should return the resolved room ID on success."""
     module = _matrix_admin_module()

--- a/tests/test_hook_registry.py
+++ b/tests/test_hook_registry.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.plugin import HookOverrideConfig, PluginEntryConfig
@@ -82,6 +84,13 @@ def _message_received_context(
             origin=message_origin(sender_id="@user:localhost", requester_id="@user:localhost", source_kind="message"),
         ),
     )
+
+
+@pytest.mark.parametrize("event_name", [EVENT_MESSAGE_RECEIVED, "agent:stopped", "custom:test"])
+def test_required_hooks_are_limited_to_startup(event_name: str) -> None:
+    """Required initialization must not change ordinary observer fault isolation."""
+    with pytest.raises(ValueError, match="required hooks are only supported for agent:started"):
+        hook(event_name, required=True)
 
 
 def test_hook_registry_orders_by_priority_plugin_order_and_lineno() -> None:

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -2844,8 +2844,17 @@ async def test_leave_unconfigured_rooms_preserves_persisted_invited_room(
     assert left_room_ids == ["!old-room:localhost"]
 
 
-def test_load_invited_rooms_returns_empty_set_for_invalid_utf8(tmp_path: Path) -> None:
-    """Invalid UTF-8 in the persisted invite file should be ignored."""
+@pytest.mark.parametrize(
+    ("contents", "message"),
+    [
+        (b"\x80", "codec can't decode"),
+        (b"{", "Expecting property name"),
+        (b"{}", "Invalid invited-room retention file"),
+        (b'["!kept:localhost", null]', "Invalid invited-room retention file"),
+    ],
+)
+def test_corrupt_retention_stops_lifecycle_initialization(tmp_path: Path, contents: bytes, message: str) -> None:
+    """Unreadable ownership records must never become an empty desired-room set."""
     agent_user = AgentMatrixUser(
         agent_name="agent1",
         user_id="@mindroom_agent1:localhost",
@@ -2866,13 +2875,12 @@ def test_load_invited_rooms_returns_empty_set_for_invalid_utf8(tmp_path: Path) -
     )
     invited_rooms_path = _invited_rooms_path(config, "agent1")
     invited_rooms_path.parent.mkdir(parents=True, exist_ok=True)
-    invited_rooms_path.write_bytes(b"\x80")
-    bot = make_test_agent_bot(
-        agent_user=agent_user,
-        storage_path=tmp_path,
-        config=config,
-        runtime_paths=runtime_paths_for(config),
-    )
-
-    assert bot._room_lifecycle._load_invited_rooms() == set()
-    assert bot._room_lifecycle.invited_rooms == set()
+    invited_rooms_path.write_bytes(contents)
+    with pytest.raises(ValueError, match=message):
+        make_test_agent_bot(
+            agent_user=agent_user,
+            storage_path=tmp_path,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+        )
+    assert invited_rooms_path.read_bytes() == contents


### PR DESCRIPTION
Startup cleanup could remove a current bot from an ad-hoc room before its ownership was reconciled. The global sweep now removes only retired identities; each current bot remains responsible for its own configured and retained rooms. This removes the duplicate room-policy snapshot from global cleanup.

Plugins can reconcile existing ownership through the shared `retain_room()` and `get_joined_rooms()` hook APIs. A short `agent:started` hook can declare `required=True`: lookup failures, persistence errors, or timeouts then abort bot startup before room reconciliation. Ordinary observers keep their existing fault isolation. Unreadable or invalid retention files now fail explicitly instead of becoming empty ownership records.

Validation: 166 focused tests covering startup failure, hook execution/registration, cleanup, invitation handling, and identity resolution; applicable pre-commit hooks pass. Regressions cover cleanup before retention exists, retired identities, required-hook lookup/write/timeout failures, and corrupt ownership records.

This does not automatically restore missing Matrix memberships. A bot whose required initialization fails retains its memberships until startup recovers.

## Summary by Sourcery

Initialize room ownership before reconciliation so current bots retain their memberships while global cleanup removes only retired identities.

New Features:
- Expose room membership lookup and durable room-retention APIs to plugins for ownership reconciliation.
- Allow `agent:started` hooks to be marked as required, preventing bot startup when initialization fails or times out.

Bug Fixes:
- Prevent global cleanup from removing current bots before their room ownership is reconciled.
- Fail startup explicitly when room-retention files are unreadable, malformed, or cannot be persisted.

Enhancements:
- Limit global cleanup to retired bot identities while leaving current bots responsible for reconciling their own memberships.
- Preserve ordinary hook fault isolation while propagating failures from required startup hooks.

Documentation:
- Document current-bot cleanup behavior, required startup hooks, retention APIs, and invalid retention-file handling.

Tests:
- Add coverage for startup-hook failures, hook registration, membership lookup, retention behavior, cleanup ordering, invitation policy, and corrupt ownership records.