### PR TITLE
Recover interrupted responses from durable outbox targets

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -261,8 +261,12 @@ The owning turn's typed physical revision map retains edit ordering independentl
 One draining owner folds each source's newest Matrix revision into a complete response request and loops when newer edits arrive.
 Physical source IDs are exclusive turn claims, while discovery aliases are advisory settlement keys observed by `wait_for_turn_settled`.
 A committed service-restart or generic terminal interruption note records its exact source room in `InterruptedTurnRooms`.
-Replacement recovery uses the registered room directly, while next-startup cleanup can rediscover the durable note and an interrupted edit revision remains uncommitted for re-drive.
-Startup scans route repair and relay publication through the same per-delivery owner as normal Matrix delivery.
+Replacement recovery uses the registered room directly, while next-startup cleanup discovers acknowledged INITIAL deliveries without an owning FINAL in the current membership epoch.
+Discovery pages the existing delivery outbox, including acknowledgements made before turn attribution, and an empty inventory requires no Matrix history calls.
+Recovery reads each owned response and its complete same-sender replacement history by exact event ID; unreadable content remains untouched for retry.
+Repair and relay publication use the same per-delivery owner as normal Matrix delivery, with ownership checked inside bounded room tasks and again before mutation.
+Before publishing a continuation, recovery reads the complete candidate thread to check for later human work and an already-published continuation.
+An interrupted edit revision remains uncommitted for re-drive.
 Pending journal replay, active generation, and owed or acknowledged FINAL delivery preclude synthetic continuation.
 Same-requester supersession preserves canonical replay when an INITIAL already owns durable delivery work, including unattempted sends and acknowledgements that precede response attribution.
 When every current source is deleted and no FINAL owns the response, its unfinished INITIAL remains durable cleanup debt until Matrix disappearance and visible-response attribution detachment are confirmed.

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -658,6 +658,37 @@ def deleted_initials(
     return tuple(_recovery_delivery(row) for row in rows)
 
 
+def recovery_initials(
+    transaction: Transaction,
+    principal_id: str,
+    *,
+    after: tuple[int, str] | None = None,
+) -> tuple[MatrixDelivery | UnreadableMatrixDelivery, ...]:
+    """Enumerate owned visible INITIALs without a FINAL, not arbitrary room history."""
+    cursor_clause = "" if after is None else " AND (created_at_ns, delivery_id/*bytes*/) > (?, ?)"
+    rows = transaction.fetchall(
+        f"""
+        SELECT {_OUTBOX_COLUMNS} FROM matrix_delivery_outbox AS delivery
+        WHERE principal_id = ? AND event_type = 'm.room.message' AND stage = 'initial'
+          AND attempted = 1 AND acknowledged_event_id IS NOT NULL AND retired = 0
+          AND EXISTS (
+            SELECT 1 FROM room_membership AS membership
+            WHERE membership.principal_id = delivery.principal_id AND membership.room_id = delivery.room_id
+              AND membership.membership_epoch = delivery.membership_epoch AND membership.departure_fenced = 0
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM matrix_delivery_outbox AS final
+            WHERE final.principal_id = delivery.principal_id AND final.delivery_id = delivery.delivery_id
+              AND final.stage = 'final' AND (final.acknowledged_event_id IS NOT NULL
+                OR (final.retired = 0 AND final.permanent_failure_reason IS NULL))
+          ){cursor_clause}
+        ORDER BY created_at_ns, delivery_id/*bytes*/ LIMIT 100
+        """,  # noqa: S608 - fixed columns and cursor clause
+        (principal_id, *(after or ())),
+    )
+    return tuple(_recovery_delivery(row) for row in rows)
+
+
 def retire_deleted_initial(transaction: Transaction, principal_id: str, delivery_id: str) -> None:
     """Retain exact ACK identity while fencing sends after proven disappearance."""
     _lock_delivery_stages(transaction, principal_id, delivery_id)

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -1048,6 +1048,16 @@ class PrincipalStore:
             ),
         )
 
+    async def recovery_initial_deliveries(
+        self,
+        *,
+        after: tuple[int, str] | None = None,
+    ) -> tuple[MatrixDelivery | UnreadableMatrixDelivery, ...]:
+        """Page exact acknowledged INITIALs still lacking FINAL delivery ownership."""
+        return await self._backend.read(
+            lambda transaction: outbox.recovery_initials(transaction, self._principal_id, after=after),
+        )
+
     async def retire_deleted_initial(self, *, delivery_id: str) -> None:
         """Fence an INITIAL whose visible cleanup and record detachment finished."""
         await self._backend.write(

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -324,6 +324,79 @@ async def _latest_relation_or_original_body(
     return body
 
 
+async def fetch_latest_visible_message(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    event_id: str,
+    trusted_sender_ids: Collection[str] = (),
+) -> ResolvedVisibleMessage | None:
+    """Read one exact original and its complete replacement state, failing closed."""
+    response = await client.room_get_event(room_id, event_id)
+    if not isinstance(response, nio.RoomGetEventResponse):
+        return None
+    original = response.event
+    if isinstance(original, nio.MegolmEvent):
+        original = client.decrypt_event(original)
+    if not is_visible_room_message(original) or original.event_id != event_id:
+        return None
+    info = EventInfo.from_event(original.source)
+    if info.is_edit:
+        return None
+
+    edits = await _fetch_exact_replacements(client, room_id=room_id, original=original)
+    if edits is None:
+        return None
+    data = await extract_and_resolve_message(original, client, trusted_sender_ids=trusted_sender_ids)
+    message = ResolvedVisibleMessage.from_message_data(data, thread_id=info.thread_id, latest_event_id=event_id)
+    winner = edits.winner_for(event_id, sender=original.sender)
+    await apply_latest_edits_to_messages(
+        client,
+        messages_by_event_id={event_id: message},
+        edit_candidates=edits,
+        synthesize_unseen_originals=False,
+        trusted_sender_ids=trusted_sender_ids,
+    )
+    if winner is not None and message.latest_event_id != winner.event_id:
+        return None
+    # Replacements cannot change the original conversation or reply target.
+    original_relation = original.source["content"].get("m.relates_to")
+    message.content = dict(message.content)
+    message.content.pop("m.relates_to", None)
+    if original_relation is not None:
+        message.content["m.relates_to"] = original_relation
+    return None if holds_unresolved_sidecar(message.content) else message
+
+
+async def _fetch_exact_replacements(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    original: nio.RoomMessage,
+) -> ThreadEditCandidates | None:
+    """Collect complete same-sender edits, refusing unreadable replacement state."""
+    edits = ThreadEditCandidates()
+    relations = client.room_get_event_relations(
+        room_id,
+        original.event_id,
+        RelationshipType.replacement,
+        direction=nio.MessageDirection.back,
+    )
+    async with contextlib.aclosing(relations):
+        async for event in relations:
+            if event.sender != original.sender:
+                continue
+            candidate = client.decrypt_event(event) if isinstance(event, nio.MegolmEvent) else event
+            if isinstance(candidate, nio.RedactedEvent):
+                continue
+            if not is_visible_room_message(candidate):
+                return None
+            candidate_info = EventInfo.from_event(candidate.source)
+            if candidate_info.is_edit and candidate_info.original_event_id == original.event_id:
+                edits.record(candidate, event_info=candidate_info)
+    return edits
+
+
 async def fetch_latest_visible_body(
     client: nio.AsyncClient,
     *,
@@ -772,6 +845,7 @@ __all__ = [
     "extract_visible_edit_body",
     "extract_visible_message",
     "fetch_latest_visible_body",
+    "fetch_latest_visible_message",
     "is_visible_room_message",
     "message_preview",
     "replace_visible_message",

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -263,6 +263,7 @@ async def recover_stale_streaming_messages(
             cleaned = 0
             interrupted: list[_InterruptedThread] = []
             failed = room_id in failed_room_ids
+            prior_edit_succeeded_by_bot: set[str] = set()
             for event_id, (bot_user_id, thread_id) in targets.items():
                 try:
                     async with response_recovery_scope(agent_names[bot_user_id], room_id, event_id) as permitted:
@@ -273,6 +274,7 @@ async def recover_stale_streaming_messages(
                         room_id=room_id,
                         actors={bot_user_id: actors[bot_user_id]},
                         target_thread_ids={event_id: thread_id},
+                        prior_edit_succeeded_by_bot=prior_edit_succeeded_by_bot,
                         bot_user_ids=set(actors),
                         config=config,
                         runtime_paths=runtime_paths,
@@ -545,6 +547,7 @@ async def _cleanup_stale_streaming_room(
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
     response_recovery_scope: _ResponseRecoveryScope,
+    prior_edit_succeeded_by_bot: set[str] | None = None,
 ) -> tuple[int, list[_InterruptedThread]]:
     """Resolve owned targets and let each bot account repair its own messages."""
     if not actors:
@@ -570,7 +573,8 @@ async def _cleanup_stale_streaming_room(
         return 0, []
 
     cleaned_count = 0
-    prior_edit_succeeded_by_bot: set[str] = set()
+    if prior_edit_succeeded_by_bot is None:
+        prior_edit_succeeded_by_bot = set()
     interrupted_threads: list[_InterruptedThread] = []
     candidate_items = sorted(
         ((k, v) for k, v in message_states.items() if v.latest_body is not None),

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable
+from collections.abc import Set as AbstractSet
 from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -37,38 +38,34 @@ from mindroom.entity_resolution import (
     current_internal_sender_ids,
     entity_identity_registry,
 )
+from mindroom.event_journal.models import UnreadableMatrixDelivery
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_delivery import edit_message_result, send_message_result
 from mindroom.matrix.client_room_admin import get_joined_rooms
-from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, resolve_latest_visible_messages
+from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, fetch_latest_visible_message
 from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.matrix.message_content import extract_and_resolve_message, extract_edit_body
 from mindroom.matrix.room_history_reads import fetch_thread_messages_from_source
-from mindroom.matrix.thread_projection import (
-    ordered_event_ids_from_scanned_event_sources,
-    resolve_thread_ids_for_event_infos,
-)
 from mindroom.streaming import (
     INTERRUPTED_RESPONSE_NOTE,
     RESTART_INTERRUPTED_RESPONSE_NOTE,
     build_restart_interrupted_body,
     clean_partial_reply_text,
 )
-from mindroom.timing import emit_elapsed_timing
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable, Sequence
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+    from mindroom.event_journal.store import PrincipalStore
 
 logger = get_logger(__name__)
 
 type _ResponseRecoveryScope = Callable[[str, str, str], AbstractAsyncContextManager[bool]]
 
-_ROOM_HISTORY_PAGE_SIZE = 100
 # Startup cleanup receives a pre-sync cutoff and ignores messages at or after
 # that timestamp, so post-sync cleanup cannot clobber streams created by this
 # process. The remaining race is another concurrently running instance cleaning
@@ -83,7 +80,6 @@ _RATE_LIMIT_DELAY_SECONDS = 0.15
 _RECOVERY_ROOM_CONCURRENCY = 8
 _STOP_REACTION_KEYS = frozenset({"🛑", "⏹️"})
 _MAX_REQUESTER_RESOLUTION_DEPTH = 10
-_MAX_EXTRA_INTERRUPTED_HISTORY_PAGES = 10
 _INTERRUPTED_PARTIAL_TEXT_LIMIT = 280
 _TERMINAL_STREAM_STATUSES = frozenset(
     {STREAM_STATUS_CANCELLED, STREAM_STATUS_COMPLETED, STREAM_STATUS_ERROR, STREAM_STATUS_INTERRUPTED},
@@ -124,15 +120,6 @@ class _MessageState:
     stream_status: str | None = None
     requester_user_id: str | None = None
     bot_user_id: str | None = None
-    stop_reaction_event_ids_by_sender: dict[str, set[str]] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class _ScannedRoomMessageStates:
-    """Cleanup state plus already-sent auto-resume targets in one room."""
-
-    message_states: dict[str, _MessageState]
-    auto_resume_target_event_ids: set[str]
 
 
 @dataclass(frozen=True)
@@ -142,15 +129,6 @@ class _CleanupScanPolicy:
     startup_cutoff_ms: int | None
     collect_terminal_interrupted_for_resume: bool
     terminal_interrupted_only: bool
-    max_extra_old_pages: int
-
-
-@dataclass(frozen=True)
-class _JoinedRoomState:
-    """Actor rooms to scan plus the independent resume identity membership."""
-
-    room_actors: dict[str, dict[str, nio.AsyncClient]]
-    resume_room_ids: frozenset[str] | None
 
 
 def _cleanup_scan_policy(
@@ -165,7 +143,6 @@ def _cleanup_scan_policy(
         startup_cutoff_ms=startup_cutoff_ms,
         collect_terminal_interrupted_for_resume=collect_terminal_interrupted_for_resume,
         terminal_interrupted_only=terminal_interrupted_only,
-        max_extra_old_pages=(_MAX_EXTRA_INTERRUPTED_HISTORY_PAGES if collect_terminal_interrupted_for_resume else 0),
     )
 
 
@@ -219,9 +196,34 @@ def _requester_resolution_message(
     )
 
 
+async def _recovery_room_targets(
+    principals: dict[str, PrincipalStore],
+    target_room_ids: set[str] | None,
+) -> tuple[dict[str, dict[str, tuple[str, str | None]]], set[str]]:
+    """Page durable candidates without waiting on individual response locks."""
+    room_targets: dict[str, dict[str, tuple[str, str | None]]] = {}
+    failed_room_ids: set[str] = set()
+    for bot_user_id, principal in principals.items():
+        cursor: tuple[int, str] | None = None
+        while batch := await principal.recovery_initial_deliveries(after=cursor):
+            cursor = (batch[-1].created_at_ns, batch[-1].delivery_id)
+            for delivery in batch:
+                if target_room_ids is not None and delivery.room_id not in target_room_ids:
+                    continue
+                if isinstance(delivery, UnreadableMatrixDelivery):
+                    logger.warning("Unreadable startup recovery delivery", delivery_id=delivery.delivery_id)
+                    failed_room_ids.add(delivery.room_id)
+                    continue
+                event_id = delivery.acknowledged_event_id
+                assert event_id is not None
+                room_targets.setdefault(delivery.room_id, {})[event_id] = (bot_user_id, delivery.thread_id)
+    return room_targets, failed_room_ids
+
+
 async def recover_stale_streaming_messages(
     actors: dict[str, nio.AsyncClient],
     *,
+    principals: dict[str, PrincipalStore],
     resume_client: nio.AsyncClient | None,
     response_recovery_scope: _ResponseRecoveryScope,
     config: Config,
@@ -231,128 +233,111 @@ async def recover_stale_streaming_messages(
     target_room_ids: set[str] | None = None,
     room_concurrency: int = _RECOVERY_ROOM_CONCURRENCY,
 ) -> _StaleStreamRecoveryResult:
-    """Recover stale streams through one concurrent Matrix-history path."""
-    joined_room_state = await _joined_room_actors(actors, resume_client=resume_client)
-    room_actors = {
-        room_id: joined_actors
-        for room_id, joined_actors in joined_room_state.room_actors.items()
-        if room_id not in scanned_room_ids and (target_room_ids is None or room_id in target_room_ids)
+    """Recover exact owned INITIALs; an empty outbox needs no Matrix history."""
+    agent_names = {
+        user_id: name
+        for user_id in actors
+        if (name := _agent_name_for_bot_user_id(user_id, config, runtime_paths)) is not None
     }
-    scanned_room_ids.update(room_actors)
-    if not room_actors:
+    room_targets, failed_room_ids = await _recovery_room_targets(
+        {user_id: principal for user_id, principal in principals.items() if user_id in agent_names},
+        target_room_ids,
+    )
+    # This set reports completed replacement rooms; it is not a discovery cache.
+    # A late INITIAL ACK in an already visited room must be visible on the next pass.
+    scanned_room_ids.update(target_room_ids or ())
+    scanned_room_ids.difference_update(failed_room_ids)
+    if not room_targets:
         return _StaleStreamRecoveryResult(room_count=0, cleaned_count=0, resumed_count=0)
 
+    resume_room_ids = await _resume_membership(
+        resume_client if config.defaults.auto_resume_after_restart else None,
+    )
     semaphore = asyncio.Semaphore(max(1, room_concurrency))
-    all_bot_user_ids = set(actors)
-    resume_user_id = resume_client.user_id if resume_client is not None else None
 
     async def recover_room(
         room_id: str,
-        joined_actors: dict[str, nio.AsyncClient],
+        targets: dict[str, tuple[str, str | None]],
     ) -> tuple[int, list[_InterruptedThread]]:
-        scan_client = joined_actors.get(resume_user_id) if isinstance(resume_user_id, str) else None
-        if scan_client is None:
-            scan_client = joined_actors[min(joined_actors)]
         async with semaphore:
-            try:
-                cleaned_count, interrupted_threads = await _cleanup_stale_streaming_room(
-                    scan_client,
-                    room_id=room_id,
-                    actors=joined_actors,
-                    bot_user_ids=all_bot_user_ids,
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    startup_cutoff_ms=startup_cutoff_ms,
-                    terminal_interrupted_only=target_room_ids is not None,
-                    response_recovery_scope=response_recovery_scope,
-                )
-            except Exception:
+            cleaned = 0
+            interrupted: list[_InterruptedThread] = []
+            failed = room_id in failed_room_ids
+            for event_id, (bot_user_id, thread_id) in targets.items():
+                try:
+                    async with response_recovery_scope(agent_names[bot_user_id], room_id, event_id) as permitted:
+                        if not permitted:
+                            continue
+                    count, threads = await _cleanup_stale_streaming_room(
+                        actors[bot_user_id],
+                        room_id=room_id,
+                        actors={bot_user_id: actors[bot_user_id]},
+                        target_thread_ids={event_id: thread_id},
+                        bot_user_ids=set(actors),
+                        config=config,
+                        runtime_paths=runtime_paths,
+                        startup_cutoff_ms=startup_cutoff_ms,
+                        terminal_interrupted_only=target_room_ids is not None,
+                        response_recovery_scope=response_recovery_scope,
+                    )
+                    cleaned += count
+                    interrupted.extend(threads)
+                except Exception:
+                    failed = True
+                    logger.warning(
+                        "Failed exact startup response recovery",
+                        room_id=room_id,
+                        event_id=event_id,
+                        exc_info=True,
+                    )
+            if failed:
                 scanned_room_ids.discard(room_id)
-                logger.warning("Failed stale stream recovery for room", room_id=room_id, exc_info=True)
-                return 0, []
             else:
-                interrupted_threads = _auto_resume_threads_for_room(
-                    room_id,
-                    interrupted_threads,
-                    auto_resume_enabled=config.defaults.auto_resume_after_restart,
-                    resume_client=resume_client,
-                    resume_room_ids=joined_room_state.resume_room_ids,
-                    scanned_room_ids=scanned_room_ids,
-                )
-                return cleaned_count, interrupted_threads
+                scanned_room_ids.add(room_id)
+            return cleaned, _auto_resume_threads_for_room(
+                room_id,
+                interrupted,
+                auto_resume_enabled=config.defaults.auto_resume_after_restart,
+                resume_client=resume_client,
+                resume_room_ids=resume_room_ids,
+                scanned_room_ids=scanned_room_ids,
+            )
 
     tasks = [
-        asyncio.create_task(recover_room(room_id, joined_actors), name=f"stale_stream_recovery:{room_id}")
-        for room_id, joined_actors in room_actors.items()
+        asyncio.create_task(recover_room(room_id, targets), name=f"response_recovery:{room_id}")
+        for room_id, targets in room_targets.items()
     ]
-    cleaned_count = 0
-    resumed_count = 0
+    cleaned_count = resumed_count = 0
     try:
         for completed in asyncio.as_completed(tasks):
-            room_cleaned_count, interrupted_threads = await completed
-            cleaned_count += room_cleaned_count
-            if resume_client is None or not config.defaults.auto_resume_after_restart or not interrupted_threads:
-                continue
-            resumed_count += await _auto_resume_interrupted_threads(
-                resume_client,
-                interrupted_threads,
-                response_recovery_scope=response_recovery_scope,
-                config=config,
-                runtime_paths=runtime_paths,
-                delay_before_first=resumed_count > 0,
-            )
+            cleaned, interrupted = await completed
+            cleaned_count += cleaned
+            if resume_client is not None and config.defaults.auto_resume_after_restart and interrupted:
+                resumed_count += await _auto_resume_interrupted_threads(
+                    resume_client,
+                    interrupted,
+                    response_recovery_scope=response_recovery_scope,
+                    config=config,
+                    runtime_paths=runtime_paths,
+                    delay_before_first=resumed_count > 0,
+                )
     finally:
         for task in tasks:
-            if not task.done():
-                task.cancel()
+            task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
-
-    return _StaleStreamRecoveryResult(
-        room_count=len(room_actors),
-        cleaned_count=cleaned_count,
-        resumed_count=resumed_count,
-    )
+    return _StaleStreamRecoveryResult(len(room_targets), cleaned_count, resumed_count)
 
 
-async def _joined_room_actors(
-    actors: dict[str, nio.AsyncClient],
-    *,
-    resume_client: nio.AsyncClient | None,
-) -> _JoinedRoomState:
-    """Discover actor scan rooms and resume membership without widening scans."""
-
-    async def joined_rooms_for_actor(
-        bot_user_id: str,
-        client: nio.AsyncClient,
-    ) -> tuple[str, nio.AsyncClient, list[str] | None]:
-        try:
-            joined_rooms = await get_joined_rooms(client)
-        except Exception:
-            logger.warning(
-                "Failed to list joined rooms during stale stream recovery",
-                bot_user_id=bot_user_id,
-                exc_info=True,
-            )
-            joined_rooms = None
-        return bot_user_id, client, joined_rooms
-
-    membership_clients = dict(actors)
-    resume_user_id = resume_client.user_id if resume_client is not None else None
-    if isinstance(resume_user_id, str) and resume_client is not None:
-        membership_clients[resume_user_id] = resume_client
-    joined_room_results = await asyncio.gather(
-        *(joined_rooms_for_actor(bot_user_id, client) for bot_user_id, client in membership_clients.items()),
-    )
-    room_actors: dict[str, dict[str, nio.AsyncClient]] = {}
-    resume_room_ids: frozenset[str] | None = None
-    for bot_user_id, client, joined_room_ids in joined_room_results:
-        if bot_user_id == resume_user_id and joined_room_ids is not None:
-            resume_room_ids = frozenset(joined_room_ids)
-        if bot_user_id not in actors:
-            continue
-        for room_id in joined_room_ids or []:
-            room_actors.setdefault(room_id, {})[bot_user_id] = client
-    return _JoinedRoomState(room_actors=room_actors, resume_room_ids=resume_room_ids)
+async def _resume_membership(client: nio.AsyncClient | None) -> frozenset[str] | None:
+    """Keep a resume-identity outage from preventing owned response cleanup."""
+    if client is None:
+        return None
+    try:
+        joined = await get_joined_rooms(client)
+        return frozenset(joined) if joined is not None else None
+    except Exception:
+        logger.warning("Failed to read startup resume membership; retaining recovery", exc_info=True)
+        return None
 
 
 async def _auto_resume_interrupted_threads(
@@ -461,6 +446,11 @@ async def _interrupted_target_remains_latest_human_work(
             history,
             target_event_id=interrupted_thread.target_event_id,
         )
+        if later_messages and interrupted_thread.target_event_id in _auto_resume_target_event_ids(
+            later_messages,
+            bot_user_ids=current_internal_sender_ids(config, runtime_paths),
+        ):
+            return False
         remains_latest = _later_thread_activity_is_internal(
             later_messages,
             config=config,
@@ -548,6 +538,7 @@ async def _cleanup_stale_streaming_room(
     *,
     room_id: str,
     actors: dict[str, nio.AsyncClient],
+    target_thread_ids: dict[str, str | None],
     bot_user_ids: set[str],
     config: Config,
     runtime_paths: RuntimePaths,
@@ -555,7 +546,7 @@ async def _cleanup_stale_streaming_room(
     terminal_interrupted_only: bool = False,
     response_recovery_scope: _ResponseRecoveryScope,
 ) -> tuple[int, list[_InterruptedThread]]:
-    """Scan one room once and let each bot account repair its own messages."""
+    """Resolve owned targets and let each bot account repair its own messages."""
     if not actors:
         return 0, []
     current_time_ms = int(time.time() * 1000)
@@ -564,9 +555,10 @@ async def _cleanup_stale_streaming_room(
         startup_cutoff_ms=startup_cutoff_ms,
         terminal_interrupted_only=terminal_interrupted_only,
     )
-    scanned_state = await _scan_room_message_states(
+    message_states = await _load_recovery_message_states(
         scan_client,
         room_id=room_id,
+        target_thread_ids=target_thread_ids,
         cleanup_bot_user_ids=set(actors),
         bot_user_ids=bot_user_ids,
         config=config,
@@ -574,7 +566,6 @@ async def _cleanup_stale_streaming_room(
         now_ms=current_time_ms,
         scan_policy=scan_policy,
     )
-    message_states = scanned_state.message_states
     if not message_states:
         return 0, []
 
@@ -604,7 +595,6 @@ async def _cleanup_stale_streaming_room(
                 room_id=room_id,
                 target_event_id=target_event_id,
                 state=state,
-                auto_resume_target_event_ids=scanned_state.auto_resume_target_event_ids,
                 bot_user_ids=bot_user_ids,
                 config=config,
                 runtime_paths=runtime_paths,
@@ -628,7 +618,6 @@ async def _process_stale_room_candidate(
     room_id: str,
     target_event_id: str,
     state: _MessageState,
-    auto_resume_target_event_ids: set[str],
     bot_user_ids: set[str],
     config: Config,
     runtime_paths: RuntimePaths,
@@ -658,7 +647,6 @@ async def _process_stale_room_candidate(
         room_id=room_id,
         target_event_id=target_event_id,
         state=state,
-        auto_resume_target_event_ids=auto_resume_target_event_ids,
         can_auto_resume=_has_resumable_interrupted_note(state),
         bot_user_ids=bot_user_ids,
         config=config,
@@ -691,7 +679,6 @@ async def _handle_interrupted_message(
     room_id: str,
     target_event_id: str,
     state: _MessageState,
-    auto_resume_target_event_ids: set[str],
     can_auto_resume: bool,
     bot_user_ids: set[str],
     config: Config,
@@ -701,7 +688,7 @@ async def _handle_interrupted_message(
 ) -> tuple[bool, _InterruptedThread | None]:
     """Handle an interrupted response or restart marker seen during startup cleanup."""
     interrupted = None
-    if can_auto_resume and target_event_id not in auto_resume_target_event_ids:
+    if can_auto_resume:
         interrupted = _interrupted_thread_from_terminal_state(
             room_id=room_id,
             target_event_id=target_event_id,
@@ -721,7 +708,6 @@ async def _handle_interrupted_message(
         client,
         room_id=room_id,
         target_event_id=target_event_id,
-        history_reaction_event_ids=_self_stop_reaction_event_ids(state),
         bot_user_ids=bot_user_ids,
     )
     return repaired, interrupted
@@ -804,7 +790,6 @@ async def _cleanup_one_stale_message(
         client,
         room_id=room_id,
         target_event_id=target_event_id,
-        history_reaction_event_ids=_self_stop_reaction_event_ids(state),
         bot_user_ids=bot_user_ids,
     )
     return True, interrupted
@@ -846,94 +831,63 @@ async def _cleanup_candidate_message(
         return False, None
 
 
-async def _scan_room_message_states(
+async def _load_recovery_message_states(
     client: nio.AsyncClient,
     *,
     room_id: str,
+    target_thread_ids: dict[str, str | None],
     cleanup_bot_user_ids: set[str],
     bot_user_ids: set[str],
     config: Config,
     runtime_paths: RuntimePaths,
     now_ms: int,
     scan_policy: _CleanupScanPolicy,
-) -> _ScannedRoomMessageStates:
-    """Scan room history and return latest state by original event ID."""
-    stage_start = time.monotonic()
-    message_states, message_events = await _collect_room_history_events(
-        client,
-        room_id=room_id,
-        cleanup_bot_user_ids=cleanup_bot_user_ids,
-        now_ms=now_ms,
-        scan_policy=scan_policy,
-    )
-    emit_elapsed_timing("startup_recovery.history", stage_start, room_id=room_id, message_count=len(message_events))
-
-    trusted_sender_ids = _cleanup_trusted_sender_ids(
-        bot_user_ids=bot_user_ids,
-        config=config,
-        runtime_paths=runtime_paths,
-    )
-    bot_message_events = [event for event in message_events if event.sender in cleanup_bot_user_ids]
-    stage_start = time.monotonic()
-    resolved_messages = await resolve_latest_visible_messages(
-        bot_message_events,
-        client,
-        trusted_sender_ids=trusted_sender_ids,
-    )
-    bot_resolved_messages = {
-        event_id: message for event_id, message in resolved_messages.items() if message.sender in cleanup_bot_user_ids
+) -> dict[str, _MessageState]:
+    """Resolve only exact outbox targets, including their newest replacements."""
+    trusted = _cleanup_trusted_sender_ids(bot_user_ids=bot_user_ids, config=config, runtime_paths=runtime_paths)
+    messages: dict[str, ResolvedVisibleMessage] = {}
+    states: dict[str, _MessageState] = {}
+    for event_id, thread_id in target_thread_ids.items():
+        message = await fetch_latest_visible_message(
+            client,
+            room_id=room_id,
+            event_id=event_id,
+            trusted_sender_ids=trusted,
+        )
+        if message is None or message.sender not in cleanup_bot_user_ids:
+            msg = f"Cannot resolve owned recovery response {event_id}"
+            raise RuntimeError(msg)
+        messages[event_id] = message
+        _merge_resolved_message_state(
+            states,
+            target_event_id=event_id,
+            message=message,
+            bot_user_id=message.sender,
+            requester_user_id=None,
+            fallback_thread_id=thread_id,
+        )
+    candidates = {
+        event_id for event_id, state in states.items() if _needs_recovery(state, now_ms=now_ms, scan_policy=scan_policy)
     }
-    emit_elapsed_timing(
-        "startup_recovery.canonical_messages",
-        stage_start,
-        room_id=room_id,
-        message_count=len(bot_resolved_messages),
-    )
-    scanned_message_data_by_event_id = await _scanned_message_data_by_event_id(message_events)
-    auto_resume_target_event_ids = _auto_resume_target_event_ids(
-        scanned_message_data_by_event_id.values(),
-        bot_user_ids=bot_user_ids | set(trusted_sender_ids),
-    )
-    _merge_bot_resolved_message_states(
-        message_states,
-        bot_resolved_messages,
-        bot_user_ids=cleanup_bot_user_ids,
-        scanned_message_data_by_event_id=scanned_message_data_by_event_id,
-    )
-    target_event_ids = {
-        event_id
-        for event_id, state in message_states.items()
-        if _needs_recovery(state, now_ms=now_ms, scan_policy=scan_policy)
-    }
-    stage_start = time.monotonic()
-    requester_ids_by_event_id = await _derive_requester_ids_for_bot_messages(
+    requesters = await _derive_requester_ids_for_bot_messages(
         client,
-        resolved_messages=bot_resolved_messages,
-        target_event_ids=target_event_ids,
-        scanned_message_data_by_event_id=scanned_message_data_by_event_id,
+        messages,
+        messages,
+        target_event_ids=candidates,
         room_id=room_id,
         bot_user_ids=cleanup_bot_user_ids,
         config=config,
         runtime_paths=runtime_paths,
     )
-    for event_id, requester in requester_ids_by_event_id.items():
-        message_states[event_id].requester_user_id = requester
-    emit_elapsed_timing(
-        "startup_recovery.requesters",
-        stage_start,
-        room_id=room_id,
-        candidate_count=len(target_event_ids),
-    )
-    return _ScannedRoomMessageStates(
-        message_states=message_states,
-        auto_resume_target_event_ids=auto_resume_target_event_ids,
-    )
+    for event_id, requester in requesters.items():
+        states[event_id].requester_user_id = requester
+    return states
 
 
 def _auto_resume_target_event_ids(
     messages: Iterable[ResolvedVisibleMessage],
     *,
-    bot_user_ids: set[str],
+    bot_user_ids: AbstractSet[str],
 ) -> set[str]:
     """Return interrupted event IDs that already have a queued auto-resume relay."""
     target_event_ids: set[str] = set()
@@ -944,95 +898,6 @@ def _auto_resume_target_event_ids(
         if reply_to_event_id is not None:
             target_event_ids.add(reply_to_event_id)
     return target_event_ids
-
-
-async def _collect_room_history_events(
-    client: nio.AsyncClient,
-    *,
-    room_id: str,
-    cleanup_bot_user_ids: set[str],
-    now_ms: int,
-    scan_policy: _CleanupScanPolicy,
-) -> tuple[dict[str, _MessageState], list[nio.RoomMessageText | nio.RoomMessageNotice]]:
-    """Return visible room-message events plus tracked stop reactions."""
-    message_states: dict[str, _MessageState] = {}
-    message_events: list[nio.RoomMessageText | nio.RoomMessageNotice] = []
-    from_token: str | None = None
-    lookback_pages_scanned = 0
-
-    while True:
-        response = await client.room_messages(
-            room_id,
-            start=from_token,
-            limit=_ROOM_HISTORY_PAGE_SIZE,
-            direction=nio.MessageDirection.back,
-        )
-        if not isinstance(response, nio.RoomMessagesResponse):
-            logger.warning(
-                "Failed to fetch room history during stale stream cleanup",
-                room_id=room_id,
-                error=str(response),
-            )
-            msg = f"Incomplete room history during stale stream cleanup for {room_id!r}"
-            raise RuntimeError(msg)  # noqa: TRY004 - A homeserver error response, not a caller type error.
-
-        if not response.chunk:
-            break
-
-        for event in response.chunk:
-            try:
-                if isinstance(event, (nio.RoomMessageText, nio.RoomMessageNotice)):
-                    message_events.append(event)
-                elif isinstance(event, nio.Event):
-                    _record_stop_reaction(
-                        message_states,
-                        event=event,
-                        bot_user_ids=cleanup_bot_user_ids,
-                    )
-            except Exception as exc:
-                event_id = event.event_id if isinstance(event, nio.Event) else None
-                logger.warning(
-                    "Failed to inspect room event during stale stream cleanup",
-                    room_id=room_id,
-                    event_id=event_id,
-                    error=str(exc),
-                )
-
-        if not response.end:
-            break
-        lookback_pages_scanned, stop_scan = _lookback_scan_state(
-            response.chunk,
-            now_ms=now_ms,
-            scan_policy=scan_policy,
-            lookback_pages_scanned=lookback_pages_scanned,
-        )
-        if stop_scan:
-            break
-        from_token = response.end
-
-    return message_states, message_events
-
-
-def _merge_bot_resolved_message_states(
-    message_states: dict[str, _MessageState],
-    resolved_messages: dict[str, ResolvedVisibleMessage],
-    *,
-    bot_user_ids: set[str],
-    scanned_message_data_by_event_id: dict[str, ResolvedVisibleMessage],
-) -> None:
-    """Merge resolved bot-authored messages into cleanup state."""
-    for target_event_id, message in resolved_messages.items():
-        if message.sender not in bot_user_ids:
-            continue
-        scanned_message = scanned_message_data_by_event_id.get(target_event_id)
-        _merge_resolved_message_state(
-            message_states,
-            target_event_id=target_event_id,
-            message=message,
-            bot_user_id=message.sender,
-            requester_user_id=None,
-            fallback_thread_id=scanned_message.thread_id if scanned_message is not None else None,
-        )
 
 
 def _merge_resolved_message_state(
@@ -1060,44 +925,6 @@ def _merge_resolved_message_state(
     state.stream_status = message.stream_status
     state.requester_user_id = requester_user_id
     state.bot_user_id = bot_user_id
-
-
-async def _scanned_message_data_by_event_id(
-    message_events: list[nio.RoomMessageText | nio.RoomMessageNotice],
-) -> dict[str, ResolvedVisibleMessage]:
-    """Return raw scanned room-history messages keyed by exact event ID."""
-    event_infos = {
-        event.event_id: EventInfo.from_event(event.source)
-        for event in message_events
-        if isinstance(event.event_id, str)
-    }
-    ordered_event_ids = ordered_event_ids_from_scanned_event_sources(
-        [event.source for event in message_events],
-    )
-    resolved_thread_ids = await resolve_thread_ids_for_event_infos(
-        "",
-        event_infos=event_infos,
-        ordered_event_ids=ordered_event_ids,
-    )
-
-    message_data_by_event_id: dict[str, ResolvedVisibleMessage] = {}
-    for event in message_events:
-        event_id = event.event_id
-        sender = event.sender
-        if not isinstance(event_id, str) or not isinstance(sender, str):
-            continue
-
-        raw_content = _as_string_keyed_dict(event.source.get("content")) or {}
-        event_info = EventInfo.from_event(event.source)
-        message_data_by_event_id[event_id] = _requester_resolution_message(
-            event_id=event_id,
-            sender=sender,
-            content=raw_content,
-            body=event.body,
-            timestamp=event.server_timestamp if isinstance(event.server_timestamp, int) else None,
-            thread_id=resolved_thread_ids.get(event_id) or event_info.thread_id,
-        )
-    return message_data_by_event_id
 
 
 def _scanned_message_requires_exact_requester_fetch(message_data: ResolvedVisibleMessage) -> bool:
@@ -1451,19 +1278,6 @@ async def _fetch_message_data_for_event_id(
     return message_data
 
 
-def _as_string_keyed_dict(value: object) -> dict[str, object] | None:
-    """Normalize one arbitrary JSON-like object into a string-keyed dict."""
-    if not isinstance(value, dict):
-        return None
-
-    normalized: dict[str, object] = {}
-    for key, item in value.items():
-        if not isinstance(key, str):
-            return None
-        normalized[key] = item
-    return normalized
-
-
 def _is_internal_sender(
     sender_id: str,
     config: Config,
@@ -1496,44 +1310,6 @@ def _effective_requester_for_message(
     content = message_data.content
     event_source = {"content": content}
     return get_effective_sender_id_for_reply_permissions(sender, event_source, config, runtime_paths)
-
-
-def _record_stop_reaction(
-    message_states: dict[str, _MessageState],
-    *,
-    event: nio.Event,
-    bot_user_ids: set[str],
-) -> None:
-    """Track self-authored stop reactions by their target message ID."""
-    event_sender = event.sender
-    if event_sender not in bot_user_ids:
-        return
-
-    event_source = event.source
-    if not isinstance(event_source, dict):
-        return
-
-    event_info = EventInfo.from_event(event_source)
-    if not event_info.is_reaction or event_info.reaction_key not in _STOP_REACTION_KEYS:
-        return
-
-    target_event_id = event_info.reaction_target_event_id
-    reaction_event_id = event.event_id
-    if not isinstance(target_event_id, str) or not isinstance(reaction_event_id, str):
-        return
-
-    reaction_ids_by_sender = message_states.setdefault(
-        target_event_id,
-        _MessageState(),
-    ).stop_reaction_event_ids_by_sender
-    reaction_ids_by_sender.setdefault(event_sender, set()).add(reaction_event_id)
-
-
-def _self_stop_reaction_event_ids(state: _MessageState) -> set[str]:
-    """Return stop reactions authored by the bot that owns the target message."""
-    if state.bot_user_id is None:
-        return set()
-    return state.stop_reaction_event_ids_by_sender.get(state.bot_user_id, set())
 
 
 async def _edit_stale_message(
@@ -1626,11 +1402,10 @@ async def _redact_stop_reactions(
     *,
     room_id: str,
     target_event_id: str,
-    history_reaction_event_ids: Iterable[str],
     bot_user_ids: set[str],
 ) -> None:
     """Best-effort removal of stale bot-authored stop reactions."""
-    reaction_event_ids = set(history_reaction_event_ids)
+    reaction_event_ids: set[str] = set()
     try:
         reaction_event_ids.update(
             await _get_stop_reaction_event_ids_from_relations(
@@ -1642,7 +1417,7 @@ async def _redact_stop_reactions(
         )
     except Exception as exc:
         logger.warning(
-            "Failed to fetch stop reactions from relations API, falling back to history scan",
+            "Failed to fetch exact stop reactions; leaving them for recovery retry",
             room_id=room_id,
             event_id=target_event_id,
             error=str(exc),
@@ -1848,31 +1623,6 @@ def _is_older_than_cleanup_window(timestamp_ms: int, *, now_ms: int | None = Non
     """Return whether a timestamp is older than the restart cleanup lookback window."""
     current_time_ms = int(time.time() * 1000) if now_ms is None else now_ms
     return current_time_ms - timestamp_ms > _STALE_STREAM_LOOKBACK_MS
-
-
-def _chunk_reaches_cleanup_lookback_limit(events: list[object], *, now_ms: int) -> bool:
-    """Return whether this history page crosses the cleanup lookback window."""
-    return any(
-        _is_older_than_cleanup_window(event.server_timestamp, now_ms=now_ms)
-        for event in events
-        if isinstance(event, nio.Event) and isinstance(event.server_timestamp, int)
-    )
-
-
-def _lookback_scan_state(
-    events: list[object],
-    *,
-    now_ms: int,
-    scan_policy: _CleanupScanPolicy,
-    lookback_pages_scanned: int,
-) -> tuple[int, bool]:
-    """Return updated old-page count and whether history pagination should stop."""
-    if not _chunk_reaches_cleanup_lookback_limit(events, now_ms=now_ms):
-        return lookback_pages_scanned, False
-    if not scan_policy.collect_terminal_interrupted_for_resume:
-        return lookback_pages_scanned, True
-    updated_count = lookback_pages_scanned + 1
-    return updated_count, updated_count >= scan_policy.max_extra_old_pages
 
 
 def _build_auto_resume_content(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1423,7 +1423,7 @@ class _MultiAgentOrchestrator:
         *,
         target_room_ids: set[str] | None = None,
     ) -> None:
-        """Recover interrupted responses from one concurrent room scan."""
+        """Recover interrupted responses identified by the durable delivery outbox."""
         actors: dict[str, nio.AsyncClient] = {}
         for bot in bots:
             if bot.client is None or not bot.agent_user.user_id:
@@ -1440,6 +1440,9 @@ class _MultiAgentOrchestrator:
 
         result = await recover_stale_streaming_messages(
             actors,
+            principals={
+                bot.agent_user.user_id: bot.journal_principal() for bot in bots if bot.agent_user.user_id in actors
+            },
             resume_client=router_bot.client if router_bot is not None else None,
             response_recovery_scope=response_recovery_scope,
             config=config,

--- a/tach.toml
+++ b/tach.toml
@@ -165,6 +165,7 @@ visibility = [
     "mindroom.matrix.journal_ingress",
     "mindroom.matrix._owned_session",
     "mindroom.matrix.relation_lookup",
+    "mindroom.matrix.stale_stream_cleanup",
     "mindroom.matrix.transport_progress",
     "mindroom.pending_event_worker",
     "mindroom.reaction_dispatch",
@@ -3036,6 +3037,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.matrix.stale_stream_cleanup"
 depends_on = [
+    "mindroom.event_journal",
     "mindroom.matrix.room_history_reads",
     "mindroom.constants",
     "mindroom.entity_resolution",
@@ -3044,7 +3046,6 @@ depends_on = [
     "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.event_info",
     "mindroom.matrix.message_content",
-    "mindroom.matrix.thread_projection",
     "mindroom.matrix.visible_body",
     "mindroom.streaming",
 ]
@@ -4724,6 +4725,7 @@ expose = [
     "extract_visible_edit_body",
     "extract_visible_message",
     "fetch_latest_visible_body",
+    "fetch_latest_visible_message",
     "is_visible_room_message",
     "message_preview",
     "room_message_fallback_body",

--- a/tests/test_exact_recovery_message.py
+++ b/tests/test_exact_recovery_message.py
@@ -1,0 +1,106 @@
+"""Exact recovery must retain the latest complete canonical response."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import nio
+import pytest
+
+from mindroom.constants import STREAM_STATUS_KEY
+from mindroom.matrix import client_visible_messages as visible
+from tests.test_stale_stream_cleanup import (
+    BOT_USER_ID,
+    ROOM_ID,
+    _aiter,
+    _make_client,
+    _make_message_event,
+    _room_get_event_response,
+    _thread_reply_relation,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_exact_response_uses_latest_same_sender_edit_and_original_thread() -> None:
+    """An edit replaces text, never the original conversation or requester link."""
+    client = _make_client()
+    original = _make_message_event(
+        event_id="$initial",
+        body="Thinking...",
+        timestamp_ms=10,
+        relates_to=_thread_reply_relation("$thread", "$request"),
+    )
+    edits = [
+        _make_message_event(
+            event_id=event_id,
+            body="* replacement",
+            timestamp_ms=timestamp,
+            sender=sender,
+            relates_to={"rel_type": "m.replace", "event_id": "$initial"},
+            new_content={
+                "msgtype": "m.text",
+                "body": body,
+                STREAM_STATUS_KEY: "streaming",
+                "m.relates_to": _thread_reply_relation("$forged", "$other"),
+            },
+        )
+        for event_id, timestamp, sender, body in (
+            ("$foreign", 40, "@other:localhost", "foreign"),
+            ("$latest", 30, BOT_USER_ID, "latest complete body"),
+            ("$old", 20, BOT_USER_ID, "old body"),
+        )
+    ]
+    client.room_get_event.side_effect = None
+    client.room_get_event.return_value = _room_get_event_response(original)
+    client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter(*edits))
+    message = await visible.fetch_latest_visible_message(client, room_id=ROOM_ID, event_id="$initial")
+    assert message is not None
+    assert (message.event_id, message.latest_event_id, message.body) == (
+        "$initial",
+        "$latest",
+        "latest complete body",
+    )
+    assert (message.thread_id, message.timestamp, message.edited_timestamp) == ("$thread", 10, 30)
+    assert message.reply_to_event_id == "$request"
+    client.room_messages.assert_not_awaited()
+
+
+async def test_failed_exact_replacement_read_does_not_fall_back_to_original() -> None:
+    """A failed relation page cannot authorize overwriting unseen latest text."""
+    client = _make_client()
+    client.room_get_event.side_effect = None
+    client.room_get_event.return_value = _room_get_event_response(
+        _make_message_event(event_id="$initial", body="Thinking...", timestamp_ms=10),
+    )
+
+    async def failed(*_args: object, **_kwargs: object) -> AsyncIterator[nio.Event]:
+        message = "replacement history unavailable"
+        raise nio.RemoteProtocolError(message)
+        yield  # pragma: no cover
+
+    client.room_get_event_relations = failed
+    with pytest.raises(nio.RemoteProtocolError):
+        await visible.fetch_latest_visible_message(client, room_id=ROOM_ID, event_id="$initial")
+
+
+async def test_malformed_latest_edit_does_not_fall_back_to_an_older_body() -> None:
+    """An unreadable newest edit leaves recovery debt instead of losing content."""
+    client = _make_client()
+    client.room_get_event.side_effect = None
+    client.room_get_event.return_value = _room_get_event_response(
+        _make_message_event(event_id="$initial", body="Thinking...", timestamp_ms=10),
+    )
+    malformed = _make_message_event(
+        event_id="$edit",
+        body="* partial preview",
+        timestamp_ms=20,
+        relates_to={"rel_type": "m.replace", "event_id": "$initial"},
+        new_content={"msgtype": "m.text"},
+    )
+    client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter(malformed))
+    assert await visible.fetch_latest_visible_message(client, room_id=ROOM_ID, event_id="$initial") is None

--- a/tests/test_live_matrix_recovery_audit.py
+++ b/tests/test_live_matrix_recovery_audit.py
@@ -143,6 +143,9 @@ async def _publish_resume(
         *(nio.RoomMessageText.from_dict(event) for event in events.values()),
     )
     client.room_get_event_relations = Mock(side_effect=lambda *_args, **_kwargs: _aiter())
+    client.room_get_event.side_effect = lambda _room_id, event_id: nio.RoomGetEventResponse.from_dict(
+        events[event_id],
+    )
 
     async def send(*_args: object, **kwargs: object) -> nio.RoomSendResponse:
         content = cast("dict[str, Any]", kwargs["content"])
@@ -174,6 +177,7 @@ async def _publish_resume(
             client,
             room_id=ROOM,
             actors={AGENT: client},
+            target_thread_ids={"$interrupted": "$root"},
             bot_user_ids={AGENT, ROUTER},
             config=config,
             runtime_paths=paths,

--- a/tests/test_response_recovery_ownership.py
+++ b/tests/test_response_recovery_ownership.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
@@ -48,11 +48,13 @@ from tests.test_stale_stream_cleanup import (
     ROOM_ID,
     STALE_AGE_MS,
     USER_ID,
+    _aiter,
     _authoritative_history,
     _history_message,
     _make_client,
     _make_config,
     _make_message_event,
+    _room_get_event_response,
     _room_messages_response,
     _thread_reply_relation,
 )
@@ -408,10 +410,10 @@ async def test_startup_snapshot_cannot_overwrite_completed_final(
     captured, release = asyncio.Event(), asyncio.Event()
     editing, release_edit = asyncio.Event(), asyncio.Event()
 
-    async def history(*_args: object, **_kwargs: object) -> nio.RoomMessagesResponse:
+    async def history(*_args: object, **_kwargs: object) -> nio.RoomGetEventResponse:
         captured.set()
         await release.wait()
-        return snapshot
+        return _room_get_event_response(snapshot.chunk[0])
 
     async def edit(*_args: object, **kwargs: object) -> nio.RoomSendResponse:
         editing.set()
@@ -432,7 +434,7 @@ async def test_startup_snapshot_cannot_overwrite_completed_final(
             payload={"msgtype": "m.text", "body": "answer", "m.new_content": {"msgtype": "m.text", "body": "answer"}},
         )
 
-    client.room_messages.side_effect = history
+    client.room_get_event.side_effect = history
     client.room_send.side_effect = edit
     with patch.object(cleanup.time, "time", return_value=NOW_MS / 1000):
         scan = asyncio.create_task(
@@ -440,6 +442,7 @@ async def test_startup_snapshot_cannot_overwrite_completed_final(
                 client,
                 room_id=ROOM_ID,
                 actors={BOT_USER_ID: client},
+                target_thread_ids={INITIAL: "$thread"},
                 bot_user_ids={BOT_USER_ID},
                 config=config,
                 runtime_paths=runtime_paths_for(config),
@@ -750,7 +753,10 @@ async def test_orphaned_relay_is_discovered_after_restart_before_it_finishes(
             ),
         ],
     )
-    client.room_messages.side_effect = lambda *_args, **_kwargs: _room_messages_response(*events)
+    client.room_get_event.side_effect = lambda _room, event_id: _room_get_event_response(
+        next(event for event in events if event.event_id == event_id),
+    )
+    client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter())
     accepted = []
 
     async def send(*_args: object, **kwargs: object) -> nio.RoomSendResponse:
@@ -792,11 +798,21 @@ async def test_orphaned_relay_is_discovered_after_restart_before_it_finishes(
             patch.object(
                 cleanup,
                 "fetch_thread_messages_from_source",
-                return_value=_authoritative_history(_history_message(INITIAL, body=events[0].body)),
+                side_effect=lambda *_args, **_kwargs: [
+                    _history_message(
+                        event.event_id,
+                        sender=event.sender,
+                        timestamp=event.server_timestamp,
+                        content=event.source["content"],
+                        body=event.body,
+                    )
+                    for event in sorted(events, key=lambda event: event.server_timestamp)
+                ],
             ),
         ):
             result = await cleanup.recover_stale_streaming_messages(
                 {BOT_USER_ID: client},
+                principals={BOT_USER_ID: principal},
                 resume_client=router,
                 response_recovery_scope=lambda _agent, room, event, gateway=gateway: gateway.response_recovery_scope(
                     room,

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import inspect
 import json
 from contextlib import asynccontextmanager, suppress
 from dataclasses import replace
@@ -14,6 +15,7 @@ from uuid import uuid4
 
 import nio
 import pytest
+from nio.api import RelationshipType
 from nio.durable import RecordKind, SyncBatch, SyncRecord
 
 from mindroom.bot import AgentBot
@@ -32,6 +34,7 @@ from mindroom.event_journal import DeliveryStage, EventJournalStore
 from mindroom.matrix import stale_stream_cleanup as stale_stream_cleanup_module
 from mindroom.matrix.client import ResolvedVisibleMessage
 from mindroom.matrix.durable_ingestion import validate_ingestion_batch
+from mindroom.matrix.event_info import EventInfo
 from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.room_history_reads import OpaqueEncryptedThreadHistoryError
 from mindroom.matrix.stale_stream_cleanup import (
@@ -45,9 +48,6 @@ from mindroom.matrix.stale_stream_cleanup import (
 )
 from mindroom.matrix.stale_stream_cleanup import (
     _StaleStreamRecoveryResult as StaleStreamRecoveryResult,
-)
-from mindroom.matrix.stale_stream_cleanup import (
-    recover_stale_streaming_messages,
 )
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.thread_history_result import ThreadHistoryResult, thread_history_result
@@ -286,29 +286,8 @@ async def test_requester_fetches_are_only_for_recovery_candidates(tmp_path: Path
         cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID], now_ms=NOW_MS)
     assert cleaned == 1
     assert interrupted[0].original_sender_id == USER_ID
-    client.room_get_event.assert_awaited_once_with(ROOM_ID, "$requester")
-
-
-@pytest.mark.asyncio
-async def test_failed_history_page_remains_retryable(tmp_path: Path) -> None:
-    """An unavailable page is not an empty successful scan of the room."""
-    config = _make_config(tmp_path)
-    client = _make_client()
-    client.room_messages.side_effect = [nio.RoomMessagesError("unavailable"), _room_messages_response()]
-    scanned: set[str] = set()
-    with patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", AsyncMock(return_value=[ROOM_ID])):
-        for attempt in range(2):
-            await recover_stale_streaming_messages(
-                {BOT_USER_ID: client},
-                resume_client=None,
-                response_recovery_scope=_permitted_recovery_scope,
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                startup_cutoff_ms=NOW_MS,
-                scanned_room_ids=scanned,
-            )
-            assert scanned == (set() if attempt == 0 else {ROOM_ID})
-    assert client.room_messages.await_count == 2
+    assert client.room_get_event.await_args_list.count(call(ROOM_ID, "$requester")) == 1
+    assert not any(args.args[1].startswith("$off-page") for args in client.room_get_event.await_args_list)
 
 
 def _thread_reply_relation(thread_id: str, reply_to_event_id: str) -> dict[str, object]:
@@ -336,7 +315,7 @@ async def _permitted_recovery_scope(*_args: str) -> AsyncIterator[bool]:
     yield True
 
 
-async def _run_cleanup(
+async def _run_cleanup(  # noqa: C901 - Adapts static originals, edits and reactions to exact Matrix reads.
     client: AsyncMock,
     config: Config,
     *,
@@ -345,15 +324,73 @@ async def _run_cleanup(
     now_ms: int = NOW_MS,
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
+    target_thread_ids: dict[str, str | None] | None = None,
 ) -> tuple[int, list[InterruptedThread]]:
+    """Exercise exact cleanup using the existing static Matrix event fixtures."""
     client.user_id = BOT_USER_ID
     assert joined_rooms == [ROOM_ID]
+    response = client.room_messages.return_value
+    if client.room_messages.side_effect is not None:
+        pages = list(client.room_messages.side_effect)
+        events = [event for page in pages for event in page.chunk]
+    else:
+        events = list(response.chunk)
+    by_id = {event.event_id: event for event in events}
+    original_get_event = client.room_get_event.side_effect
+    fallback_response = client.room_get_event.return_value
+
+    async def get_event(room_id: str, event_id: str) -> nio.RoomGetEventResponse:
+        if event_id in by_id and (
+            by_id[event_id].sender == BOT_USER_ID or not EventInfo.from_event(by_id[event_id].source).is_edit
+        ):
+            return _room_get_event_response(by_id[event_id])
+        if callable(original_get_event):
+            result = original_get_event(room_id, event_id)
+            return await result if inspect.isawaitable(result) else result
+        if original_get_event is not None:
+            return next(original_get_event)
+        return fallback_response
+
+    original_relations = client.room_get_event_relations
+
+    async def relations(
+        room_id: str,
+        event_id: str,
+        relation_type: object,
+        *args: object,
+        **kwargs: object,
+    ) -> AsyncIterator[nio.Event]:
+        if relation_type == RelationshipType.replacement:
+            for event in events:
+                relation = event.source.get("content", {}).get("m.relates_to", {})
+                if relation.get("rel_type") == "m.replace" and relation.get("event_id") == event_id:
+                    yield event
+        else:
+            for event in events:
+                if (
+                    isinstance(event, nio.ReactionEvent)
+                    and EventInfo.from_event(event.source).reaction_target_event_id == event_id
+                ):
+                    yield event
+            async for event in original_relations(room_id, event_id, relation_type, *args, **kwargs):
+                yield event
+
+    client.room_get_event.side_effect = get_event
+    client.room_get_event_relations = MagicMock(side_effect=relations)
+    targets = {
+        event.event_id: EventInfo.from_event(event.source).thread_id
+        for event in events
+        if isinstance(event, nio.RoomMessageText | nio.RoomMessageNotice)
+        and event.sender == BOT_USER_ID
+        and not EventInfo.from_event(event.source).is_edit
+    }
     with patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=now_ms / 1000):
         return await cleanup_stale_streaming_room(
             client,
             response_recovery_scope=_permitted_recovery_scope,
             room_id=ROOM_ID,
             actors={BOT_USER_ID: client},
+            target_thread_ids=targets if target_thread_ids is None else target_thread_ids,
             bot_user_ids={BOT_USER_ID} if bot_user_ids is None else bot_user_ids,
             config=config,
             runtime_paths=runtime_paths_for(config),
@@ -476,8 +513,8 @@ async def test_relations_api_filters_reactions_and_unions_history_ids(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_relations_api_error_falls_back_to_history_scan_ids(tmp_path: Path) -> None:
-    """Cleanup should still redact history-scanned IDs when relations lookup fails."""
+async def test_relations_api_error_does_not_invent_reaction_targets(tmp_path: Path) -> None:
+    """A failed exact relation lookup must not invent reaction IDs."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     client.room_messages.return_value = _room_messages_response(
@@ -503,8 +540,7 @@ async def test_relations_api_error_falls_back_to_history_scan_ids(tmp_path: Path
         cleaned, _ = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
 
     assert cleaned == 1
-    client.room_redact.assert_awaited_once()
-    assert client.room_redact.await_args.kwargs["event_id"] == "$history-stop"
+    client.room_redact.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -602,46 +638,6 @@ async def test_cleanup_skips_completed_stream_status_even_with_trailing_marker(t
     assert cleaned == 0
     assert interrupted == []
     mock_edit.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_cleanup_scans_until_history_end_for_deep_stale_messages(tmp_path: Path) -> None:
-    """Cleanup should keep paginating until history ends, not stop after an arbitrary page cap."""
-    config = _make_config(tmp_path)
-    client = _make_client()
-    stale_message = _make_message_event(
-        event_id="$page12-stale",
-        body="Deep history partial",
-        timestamp_ms=NOW_MS - STALE_AGE_MS,
-        extra_content={STREAM_STATUS_KEY: "streaming"},
-    )
-    history_pages = [
-        _room_messages_response(
-            _make_message_event(
-                event_id=f"$page{page_number}-filler",
-                body="Ignore me",
-                timestamp_ms=NOW_MS - page_number,
-                sender="@user:example.com",
-            ),
-            end=f"page-{page_number + 1}",
-        )
-        for page_number in range(1, 12)
-    ]
-    client.room_messages = AsyncMock(
-        side_effect=[*history_pages, _room_messages_response(stale_message)],
-    )
-    client.room_get_event_relations = MagicMock(return_value=_aiter())
-
-    with patch(
-        "mindroom.matrix.stale_stream_cleanup.edit_message_result",
-        new=AsyncMock(side_effect=delivered_matrix_side_effect("$edit")),
-    ) as mock_edit:
-        cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
-
-    assert cleaned == 1
-    assert interrupted == []
-    assert client.room_messages.await_count == 12
-    assert mock_edit.await_args.args[2] == "$page12-stale"
 
 
 @pytest.mark.asyncio
@@ -801,7 +797,12 @@ async def test_cleanup_returns_interrupted_thread_for_transitive_plain_reply(tmp
         "mindroom.matrix.stale_stream_cleanup.edit_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$cleanup-edit")),
     ):
-        cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
+        cleaned, interrupted = await _run_cleanup(
+            client,
+            config,
+            joined_rooms=[ROOM_ID],
+            target_thread_ids={"$plain-reply": "$thread-root"},
+        )
 
     assert cleaned == 1
     assert len(interrupted) == 1
@@ -1324,16 +1325,6 @@ def test_ordered_auto_resume_candidates_returns_all_unique_threads_when_unlimite
     assert [thread.target_event_id for thread in selected] == ["$target-two", "$newer-one", "$target-three"]
 
 
-def test_deep_history_scan_limit_is_independent_of_resume_count(tmp_path: Path) -> None:
-    """Uncapped resume delivery must not make each room scan more old pages."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-
-    scan_policy = stale_stream_cleanup_module._cleanup_scan_policy(config, startup_cutoff_ms=NOW_MS)
-
-    assert scan_policy.max_extra_old_pages == 10
-
-
 @pytest.mark.asyncio
 async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
     """Auto-resume should skip interrupted records that do not have a thread ID."""
@@ -1548,7 +1539,7 @@ async def test_cleanup_uses_exact_replied_to_requester_not_latest_thread_speaker
             original_sender_id=USER_ID,
         ),
     ]
-    client.room_get_event.assert_not_called()
+    assert client.room_get_event.await_args_list == [call(ROOM_ID, "$original"), call(ROOM_ID, "$thread-root")]
 
 
 @pytest.mark.asyncio
@@ -1598,7 +1589,7 @@ async def test_cleanup_uses_scanned_history_when_edited_bot_message_lacks_visibl
             original_sender_id=USER_ID,
         ),
     ]
-    client.room_get_event.assert_not_called()
+    assert client.room_get_event.await_args_list == [call(ROOM_ID, "$original"), call(ROOM_ID, "$thread-root")]
 
 
 @pytest.mark.asyncio
@@ -1664,6 +1655,7 @@ async def test_cleanup_follows_agent_reply_chain_outside_scanned_history(tmp_pat
         ),
     ]
     assert [call.args[1] for call in client.room_get_event.await_args_list] == [
+        "$original",
         "$agent-a",
         "$user-root",
     ]
@@ -1832,6 +1824,7 @@ async def test_cleanup_fetches_exact_scanned_edit_ancestor_for_requester_resolut
         ),
     ]
     assert [call.args[1] for call in client.room_get_event.await_args_list] == [
+        "$original",
         "$agent-a-edit",
         "$user-root",
     ]
@@ -2084,43 +2077,6 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
 
 
 @pytest.mark.asyncio
-async def test_targeted_recovery_scans_only_handoff_rooms_without_a_clock_cutoff(tmp_path: Path) -> None:
-    """Replacement recovery must exclude unrelated rooms and preserve the Matrix clock domain."""
-    config = _make_config(tmp_path)
-    client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: client}
-
-    with (
-        patch(
-            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
-            new=AsyncMock(return_value=[ROOM_ID, "!unrelated:example.org"]),
-        ),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [])),
-        ) as cleanup_room,
-    ):
-        scanned_room_ids: set[str] = set()
-        result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=None,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=None,
-            scanned_room_ids=scanned_room_ids,
-            target_room_ids={ROOM_ID},
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
-    cleanup_room.assert_awaited_once()
-    assert cleanup_room.await_args.kwargs["room_id"] == ROOM_ID
-    assert cleanup_room.await_args.kwargs["startup_cutoff_ms"] is None
-    assert cleanup_room.await_args.kwargs["terminal_interrupted_only"] is True
-    assert scanned_room_ids == {ROOM_ID}
-
-
-@pytest.mark.asyncio
 async def test_targeted_recovery_does_not_clobber_live_replacement_stream(tmp_path: Path) -> None:
     """Replacement handoff recovery must ignore active output from the new bot generation."""
     config = _make_config(tmp_path)
@@ -2153,39 +2109,6 @@ async def test_targeted_recovery_does_not_clobber_live_replacement_stream(tmp_pa
     assert cleaned == 0
     assert interrupted == []
     client.room_send.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_failed_targeted_room_scan_remains_unscanned_for_retry(tmp_path: Path) -> None:
-    """A transient room-history failure must leave the claimed handoff retryable."""
-    config = _make_config(tmp_path)
-    client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: client}
-
-    with (
-        patch(
-            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
-            new=AsyncMock(return_value=[ROOM_ID]),
-        ),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(side_effect=RuntimeError("temporary history failure")),
-        ),
-    ):
-        scanned_room_ids: set[str] = set()
-        result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=None,
-            scanned_room_ids=scanned_room_ids,
-            target_room_ids={ROOM_ID},
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
-    assert scanned_room_ids == set()
 
 
 @pytest.mark.asyncio
@@ -2272,130 +2195,6 @@ async def test_cleanup_returns_old_terminal_interrupted_thread_for_auto_resume(t
 
 
 @pytest.mark.asyncio
-async def test_cleanup_scans_past_lookback_page_for_old_terminal_interruption(tmp_path: Path) -> None:
-    """A busy room may push old terminal interrupted notes behind a lookback-crossing page."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    client = _make_client()
-    client.rooms = _joined_room_cache()
-    client.room_messages = AsyncMock(
-        side_effect=[
-            _room_messages_response(
-                _make_message_event(
-                    event_id="$old-filler",
-                    body="Later unrelated chatter",
-                    sender=USER_ID,
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS,
-                ),
-                end="older-page",
-            ),
-            _room_messages_response(
-                _make_message_event(
-                    event_id="$thread-root",
-                    body="Question",
-                    sender=USER_ID,
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS - 20_000,
-                ),
-                _make_message_event(
-                    event_id="$old-interrupted",
-                    body="Partial answer\n\n**[Response interrupted]**",
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS - 10_000,
-                    relates_to=_thread_reply_relation("$thread-root", "$thread-root"),
-                    extra_content={STREAM_STATUS_KEY: STREAM_STATUS_INTERRUPTED},
-                ),
-            ),
-        ],
-    )
-    client.room_get_event_relations = MagicMock(return_value=_aiter())
-
-    cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
-
-    assert cleaned == 0
-    assert client.room_messages.await_count == 2
-    assert [thread.target_event_id for thread in interrupted] == ["$old-interrupted"]
-
-
-@pytest.mark.asyncio
-async def test_cleanup_stops_at_lookback_page_when_auto_resume_disabled(tmp_path: Path) -> None:
-    """Opted-out startup cleanup must not full-scan busy rooms when no resume relay will be queued."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = False
-    client = _make_client()
-    client.rooms = _joined_room_cache()
-    client.room_messages = AsyncMock(
-        side_effect=[
-            _room_messages_response(
-                _make_message_event(
-                    event_id="$old-filler",
-                    body="Later unrelated chatter",
-                    sender=USER_ID,
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS,
-                ),
-                end="older-page",
-            ),
-            _room_messages_response(
-                _make_message_event(
-                    event_id="$old-interrupted",
-                    body="Partial answer\n\n**[Response interrupted]**",
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS - 10_000,
-                    relates_to=_thread_reply_relation("$thread-root", "$thread-root"),
-                    extra_content={STREAM_STATUS_KEY: STREAM_STATUS_INTERRUPTED},
-                ),
-            ),
-        ],
-    )
-    client.room_get_event_relations = MagicMock(return_value=_aiter())
-
-    cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
-
-    assert cleaned == 0
-    assert interrupted == []
-    assert client.room_messages.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_cleanup_caps_old_terminal_interruption_scan_when_auto_resume_enabled(tmp_path: Path) -> None:
-    """Auto-resume opt-in may scan past the outage window, but never the whole room history."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    client = _make_client()
-    client.rooms = _joined_room_cache()
-    old_pages = [
-        _room_messages_response(
-            _make_message_event(
-                event_id=f"$old-filler-{page_number}",
-                body="Later unrelated chatter",
-                sender=USER_ID,
-                timestamp_ms=NOW_MS - OLD_STALE_AGE_MS - page_number,
-            ),
-            end=f"old-page-{page_number}",
-        )
-        for page_number in range(1, 13)
-    ]
-    client.room_messages = AsyncMock(
-        side_effect=[
-            *old_pages,
-            _room_messages_response(
-                _make_message_event(
-                    event_id="$too-deep-interrupted",
-                    body="Partial answer\n\n**[Response interrupted]**",
-                    timestamp_ms=NOW_MS - OLD_STALE_AGE_MS - 20_000,
-                    relates_to=_thread_reply_relation("$thread-root", "$thread-root"),
-                    extra_content={STREAM_STATUS_KEY: STREAM_STATUS_INTERRUPTED},
-                ),
-            ),
-        ],
-    )
-    client.room_get_event_relations = MagicMock(return_value=_aiter())
-
-    cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
-
-    assert cleaned == 0
-    assert interrupted == []
-    assert client.room_messages.await_count == 10
-
-
-@pytest.mark.asyncio
 async def test_cleanup_skips_completed_message_ending_with_generic_interrupted_note(tmp_path: Path) -> None:
     """Completed responses that happen to mention the generic note are not restart-resumable."""
     config = _make_config(tmp_path)
@@ -2458,7 +2257,26 @@ async def test_cleanup_skips_restart_interrupted_thread_after_auto_resume_was_qu
     cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
 
     assert cleaned == 0
-    assert interrupted == []
+    assert len(interrupted) == 1
+    history = [
+        _history_message("$message", body=restart_body),
+        _history_message(
+            "$resume",
+            sender=entity_ids(config, runtime_paths_for(config))[ROUTER_AGENT_NAME].full_id,
+            body=f"@Test Agent {AUTO_RESUME_MESSAGE}",
+            content={"m.relates_to": _thread_reply_relation("$thread-root", "$message")},
+        ),
+    ]
+    with patch("mindroom.matrix.stale_stream_cleanup.fetch_thread_messages_from_source", return_value=history):
+        resumed = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            response_recovery_scope=_permitted_recovery_scope,
+        )
+    assert resumed == 0
+    client.room_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2783,8 +2601,8 @@ async def test_cleanup_does_not_hydrate_sidecars_for_unrelated_user_messages(tmp
 
 
 @pytest.mark.asyncio
-async def test_cleanup_sidecar_hydration_failure_falls_back_gracefully(tmp_path: Path) -> None:
-    """Cleanup should still work when sidecar hydration fails."""
+async def test_cleanup_sidecar_hydration_failure_retains_retryable_response(tmp_path: Path) -> None:
+    """An incomplete preview must never replace the full interrupted response."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     client.rooms = _joined_room_cache()
@@ -2805,23 +2623,9 @@ async def test_cleanup_sidecar_hydration_failure_falls_back_gracefully(tmp_path:
     client.download = AsyncMock(return_value=MagicMock(spec=nio.DownloadError))
     client.room_send = AsyncMock(return_value=nio.RoomSendResponse(event_id="$cleanup", room_id=ROOM_ID))
 
-    cleaned, _ = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
-
-    assert cleaned == 1
-    sent_content = cast("dict[str, object]", client.room_send.await_args.kwargs["content"])
-    _assert_preserved_edit_payload(
-        sent_content,
-        {
-            "io.mindroom.ai_run": {"version": 1, "run_id": "run-preview"},
-            "io.mindroom.stream_status": "error",
-        },
-    )
-    new_content = cast("dict[str, object]", sent_content["m.new_content"])
-    assert "io.mindroom.long_text" not in sent_content
-    assert "io.mindroom.long_text" not in new_content
-    assert "url" not in sent_content
-    assert "url" not in new_content
-    assert "io.mindroom.tool_trace" not in new_content
+    with pytest.raises(RuntimeError, match="Cannot resolve owned recovery response"):
+        await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
+    client.room_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -3057,379 +2861,6 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(tmp_path: Path) -> None:
-    """One shared room scan should serve every bot and stream completed-room resumes."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    router_user_id = "@actual_router:localhost"
-    router_client = make_matrix_client_mock(user_id=router_user_id)
-    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {
-        router_user_id: router_client,
-        BOT_USER_ID: agent_client,
-    }
-    slow_room_started = asyncio.Event()
-    release_slow_room = asyncio.Event()
-    resume_sent = asyncio.Event()
-    scanned_rooms: dict[str, tuple[object, set[str]]] = {}
-    scanned_room_ids: set[str] = set()
-    include_new_room = False
-
-    async def joined_rooms(client: object) -> list[str]:
-        if client is router_client:
-            joined_room_ids = ["!shared:example.com", "!fast:example.com"]
-            if include_new_room:
-                joined_room_ids.append("!new:example.com")
-            return joined_room_ids
-        assert client is agent_client
-        return ["!shared:example.com", "!slow:example.com"]
-
-    async def cleanup_room(scan_client: object, **kwargs: object) -> tuple[int, list[InterruptedThread]]:
-        room_id = cast("str", kwargs["room_id"])
-        room_actors = cast("dict[str, nio.AsyncClient]", kwargs["actors"])
-        scanned_rooms[room_id] = (scan_client, set(room_actors))
-        if room_id == "!slow:example.com":
-            slow_room_started.set()
-            await release_slow_room.wait()
-            return 0, []
-        if room_id == "!fast:example.com":
-            return 1, [
-                InterruptedThread(
-                    room_id=room_id,
-                    thread_id="$thread",
-                    target_event_id="$target",
-                    partial_text="Partial",
-                    agent_name="test_agent",
-                ),
-            ]
-        return 0, []
-
-    async def auto_resume(*_args: object, **_kwargs: object) -> int:
-        resume_sent.set()
-        return 1
-
-    with (
-        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
-        patch("mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room", side_effect=cleanup_room),
-        patch("mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads", side_effect=auto_resume),
-    ):
-        recovery_task = asyncio.create_task(
-            recover_stale_streaming_messages(
-                actors,
-                resume_client=router_client,
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                startup_cutoff_ms=NOW_MS,
-                scanned_room_ids=scanned_room_ids,
-                response_recovery_scope=_permitted_recovery_scope,
-            ),
-        )
-        await asyncio.wait_for(slow_room_started.wait(), timeout=1.0)
-        await asyncio.wait_for(resume_sent.wait(), timeout=1.0)
-        assert not recovery_task.done()
-        release_slow_room.set()
-        result = await asyncio.wait_for(recovery_task, timeout=1.0)
-        include_new_room = True
-        delta_result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=router_client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=3, cleaned_count=1, resumed_count=1)
-    assert delta_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
-    assert set(scanned_rooms) == {
-        "!shared:example.com",
-        "!fast:example.com",
-        "!slow:example.com",
-        "!new:example.com",
-    }
-    assert scanned_rooms["!shared:example.com"] == (router_client, {router_user_id, BOT_USER_ID})
-    assert scanned_rooms["!fast:example.com"] == (router_client, {router_user_id})
-    assert scanned_rooms["!slow:example.com"] == (agent_client, {BOT_USER_ID})
-    assert scanned_rooms["!new:example.com"] == (router_client, {router_user_id})
-    assert scanned_room_ids == set(scanned_rooms)
-
-
-@pytest.mark.asyncio
-async def test_recovery_skips_auto_resume_when_resume_identity_is_not_joined(tmp_path: Path) -> None:
-    """A resume identity must not read or write a room it is not joined to."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
-    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {
-        "@actual_router:localhost": router_client,
-        BOT_USER_ID: agent_client,
-    }
-    interrupted = InterruptedThread(
-        room_id=ROOM_ID,
-        thread_id="$thread",
-        target_event_id="$target",
-        partial_text="Partial",
-        agent_name="test_agent",
-    )
-
-    async def joined_rooms(client: object) -> list[str]:
-        if client is router_client:
-            return []
-        assert client is agent_client
-        return [ROOM_ID]
-
-    with (
-        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(1, [interrupted])),
-        ),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
-            new=AsyncMock(return_value=1),
-        ) as auto_resume,
-    ):
-        scanned_room_ids: set[str] = set()
-        result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=router_client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
-    assert scanned_room_ids == set()
-    auto_resume.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_recovery_retries_auto_resume_after_resume_identity_joins(tmp_path: Path) -> None:
-    """A pre-join cleanup scan must not hide the room from the post-setup delta."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    router_user_id = "@actual_router:localhost"
-    router_client = make_matrix_client_mock(user_id=router_user_id)
-    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {
-        router_user_id: router_client,
-        BOT_USER_ID: agent_client,
-    }
-    interrupted = InterruptedThread(
-        room_id=ROOM_ID,
-        thread_id="$thread",
-        target_event_id="$target",
-        partial_text="Partial",
-        agent_name="test_agent",
-    )
-    router_is_joined = False
-
-    async def joined_rooms(client: object) -> list[str]:
-        if client is router_client:
-            return [ROOM_ID] if router_is_joined else []
-        assert client is agent_client
-        return [ROOM_ID]
-
-    with (
-        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(1, [interrupted])),
-        ) as cleanup_room,
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
-            new=AsyncMock(return_value=1),
-        ) as auto_resume,
-    ):
-        scanned_room_ids: set[str] = set()
-        initial_result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=router_client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-        router_is_joined = True
-        delta_result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=router_client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert initial_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
-    assert delta_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=1)
-    assert cleanup_room.await_count == 2
-    auto_resume.assert_awaited_once()
-    assert scanned_room_ids == {ROOM_ID}
-
-
-@pytest.mark.asyncio
-async def test_targeted_recovery_tracks_resume_membership_outside_scan_actors(tmp_path: Path) -> None:
-    """Replacement recovery must check its separate resume client's membership."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
-    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    interrupted = InterruptedThread(
-        room_id=ROOM_ID,
-        thread_id="$thread",
-        target_event_id="$target",
-        partial_text="Partial",
-        agent_name="test_agent",
-    )
-
-    with (
-        patch(
-            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
-            new=AsyncMock(return_value=[ROOM_ID]),
-        ) as joined_rooms,
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [interrupted])),
-        ),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
-            new=AsyncMock(return_value=1),
-        ) as auto_resume,
-    ):
-        result = await recover_stale_streaming_messages(
-            {BOT_USER_ID: agent_client},
-            resume_client=router_client,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=None,
-            scanned_room_ids=set(),
-            target_room_ids={ROOM_ID},
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
-    assert {call.args[0] for call in joined_rooms.await_args_list} == {agent_client, router_client}
-    auto_resume.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_recovery_resumes_all_51_rooms_even_when_newest_room_finishes_last(tmp_path: Path) -> None:
-    """Completion order must not impose a hidden total resume cap."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
-    actors = {
-        "@actual_router:localhost": router_client,
-    }
-    room_ids = [f"!room-{index}:example.com" for index in range(51)]
-    slow_room_id = room_ids[-1]
-    slow_room_started = asyncio.Event()
-    release_slow_room = asyncio.Event()
-    fast_rooms_resumed = asyncio.Event()
-    resumed_room_ids: list[str] = []
-    scanned_room_ids: set[str] = set()
-
-    async def cleanup_room(_: object, **kwargs: object) -> tuple[int, list[InterruptedThread]]:
-        room_id = cast("str", kwargs["room_id"])
-        room_index = room_ids.index(room_id)
-        if room_id == slow_room_id:
-            slow_room_started.set()
-            await release_slow_room.wait()
-        return 0, [
-            InterruptedThread(
-                room_id=room_id,
-                thread_id=f"$thread-{room_index}",
-                target_event_id=f"$target-{room_index}",
-                partial_text="Partial",
-                agent_name="test_agent",
-                timestamp_ms=room_index,
-            ),
-        ]
-
-    async def auto_resume(_: object, interrupted: list[InterruptedThread], **__: object) -> int:
-        resumed_room_ids.extend(item.room_id for item in interrupted)
-        if len(resumed_room_ids) == 50:
-            fast_rooms_resumed.set()
-        return len(interrupted)
-
-    with (
-        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", new=AsyncMock(return_value=room_ids)),
-        patch("mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room", side_effect=cleanup_room),
-        patch("mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads", side_effect=auto_resume),
-    ):
-        recovery_task = asyncio.create_task(
-            recover_stale_streaming_messages(
-                actors,
-                resume_client=router_client,
-                config=config,
-                runtime_paths=runtime_paths_for(config),
-                startup_cutoff_ms=NOW_MS,
-                scanned_room_ids=scanned_room_ids,
-                room_concurrency=51,
-                response_recovery_scope=_permitted_recovery_scope,
-            ),
-        )
-        await asyncio.wait_for(slow_room_started.wait(), timeout=1.0)
-        await asyncio.wait_for(fast_rooms_resumed.wait(), timeout=1.0)
-        assert not recovery_task.done()
-        release_slow_room.set()
-        result = await asyncio.wait_for(recovery_task, timeout=1.0)
-
-    assert result == StaleStreamRecoveryResult(room_count=51, cleaned_count=0, resumed_count=51)
-    assert set(resumed_room_ids) == set(room_ids)
-    assert resumed_room_ids[-1] == slow_room_id
-    assert scanned_room_ids == set(room_ids)
-
-
-@pytest.mark.asyncio
-async def test_recovery_without_resume_client_still_cleans_rooms(tmp_path: Path) -> None:
-    """Router loss should disable only resume delivery, not Matrix cleanup."""
-    config = _make_config(tmp_path)
-    config.defaults.auto_resume_after_restart = True
-    client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: client}
-    interrupted = InterruptedThread(
-        room_id=ROOM_ID,
-        thread_id="$thread",
-        target_event_id="$target",
-        partial_text="Partial",
-        agent_name="test_agent",
-    )
-
-    with (
-        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", new=AsyncMock(return_value=[ROOM_ID])),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(1, [interrupted])),
-        ),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
-            new=AsyncMock(),
-        ) as auto_resume,
-    ):
-        scanned_room_ids: set[str] = set()
-        result = await recover_stale_streaming_messages(
-            actors,
-            resume_client=None,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
-            response_recovery_scope=_permitted_recovery_scope,
-        )
-
-    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
-    assert scanned_room_ids == {ROOM_ID}
-    auto_resume.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_path: Path) -> None:
     """A shared history scan must use each bot's own client for Matrix edits."""
     config = _make_config(tmp_path)
@@ -3439,30 +2870,27 @@ async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_p
         BOT_USER_ID: first_client,
         OTHER_BOT_USER_ID: second_client,
     }
-    scanned_state = stale_stream_cleanup_module._ScannedRoomMessageStates(
-        message_states={
-            "$first": stale_stream_cleanup_module._MessageState(
-                latest_body="First partial",
-                latest_timestamp=NOW_MS - STALE_AGE_MS,
-                latest_event_id="$first",
-                stream_status="streaming",
-                bot_user_id=BOT_USER_ID,
-            ),
-            "$second": stale_stream_cleanup_module._MessageState(
-                latest_body="Second partial",
-                latest_timestamp=NOW_MS - STALE_AGE_MS + 1,
-                latest_event_id="$second",
-                stream_status="streaming",
-                bot_user_id=OTHER_BOT_USER_ID,
-            ),
-        },
-        auto_resume_target_event_ids=set(),
-    )
+    scanned_state = {
+        "$first": stale_stream_cleanup_module._MessageState(
+            latest_body="First partial",
+            latest_timestamp=NOW_MS - STALE_AGE_MS,
+            latest_event_id="$first",
+            stream_status="streaming",
+            bot_user_id=BOT_USER_ID,
+        ),
+        "$second": stale_stream_cleanup_module._MessageState(
+            latest_body="Second partial",
+            latest_timestamp=NOW_MS - STALE_AGE_MS + 1,
+            latest_event_id="$second",
+            stream_status="streaming",
+            bot_user_id=OTHER_BOT_USER_ID,
+        ),
+    }
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=NOW_MS / 1000),
         patch(
-            "mindroom.matrix.stale_stream_cleanup._scan_room_message_states",
+            "mindroom.matrix.stale_stream_cleanup._load_recovery_message_states",
             new=AsyncMock(return_value=scanned_state),
         ),
         patch(
@@ -3475,6 +2903,7 @@ async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_p
             response_recovery_scope=_permitted_recovery_scope,
             room_id=ROOM_ID,
             actors=actors,
+            target_thread_ids={"$first": None, "$second": None},
             bot_user_ids=set(actors),
             config=config,
             runtime_paths=runtime_paths_for(config),
@@ -3555,7 +2984,8 @@ async def test_orchestrator_runs_two_recovery_waves_around_room_setup(tmp_path: 
     ):
         runtime_task = asyncio.create_task(orchestrator.start())
         try:
-            await asyncio.wait_for(ready.wait(), timeout=1.0)
+            # Ordering is under test, not cold-import or machine scheduling latency.
+            await asyncio.wait_for(ready.wait(), timeout=5.0)
             await asyncio.wait_for(recovery_finished.wait(), timeout=5.0)
             await orchestrator.stop()
             await asyncio.wait_for(runtime_task, timeout=1.0)
@@ -3847,7 +3277,9 @@ async def test_startup_resume_requires_current_journal_ownership_across_restarts
             extra_content={STREAM_STATUS_KEY: status},
         ),
     ]
-    client.room_messages.return_value = _room_messages_response(*events)
+    client.room_get_event.side_effect = lambda _room, event_id: _room_get_event_response(
+        next(event for event in events if event.event_id == event_id),
+    )
     client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter())
     database = tmp_path / "journal.db"
     store = EventJournalStore.open_sqlite(database)

--- a/tests/test_startup_recovery_inventory.py
+++ b/tests/test_startup_recovery_inventory.py
@@ -211,23 +211,25 @@ async def test_busy_room_ownership_does_not_delay_other_rooms(
 
 
 @pytest.mark.parametrize("router_unavailable", [False, True])
+@pytest.mark.parametrize("target_count", [1, 2])
 async def test_exact_inventory_repairs_response_without_room_scan(
     journal_store: EventJournalStore,
     tmp_path: Path,
     router_unavailable: bool,
+    target_count: int,
 ) -> None:
     """Known delivery IDs suffice even when the resume identity is unavailable."""
     principal = journal_store.principal("agent@alice")
-    await _initial(principal, "$orphan")
+    for index in range(target_count):
+        await _initial(principal, f"$orphan-{index}")
     client = _make_client()
     config = _make_config(tmp_path)
     router = _make_client() if router_unavailable else None
     if router is not None:
         router.joined_rooms.side_effect = ConnectionError("router membership unavailable")
-    client.room_get_event.side_effect = None
-    client.room_get_event.return_value = _room_get_event_response(
+    client.room_get_event.side_effect = lambda _room, event_id: _room_get_event_response(
         _make_message_event(
-            event_id="$orphan-response",
+            event_id=event_id,
             body="Thinking...",
             timestamp_ms=NOW_MS - STALE_AGE_MS,
             room_id=ROOM,
@@ -236,6 +238,7 @@ async def test_exact_inventory_repairs_response_without_room_scan(
     )
     client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter())
     with (
+        patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new_callable=AsyncMock) as sleep,
         patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=NOW_MS / 1000),
         patch(
             "mindroom.matrix.stale_stream_cleanup.edit_message_result",
@@ -254,10 +257,11 @@ async def test_exact_inventory_repairs_response_without_room_scan(
             startup_cutoff_ms=NOW_MS,
             scanned_room_ids=set(),
         )
-    assert result.cleaned_count == 1
-    assert edit.await_args.args[2] == "$orphan-response"
+    assert result.cleaned_count == target_count
+    assert edit.await_args.args[2] == f"$orphan-{target_count - 1}-response"
+    assert sleep.await_count == target_count - 1
     client.room_messages.assert_not_awaited()
-    client.room_get_event.assert_awaited_once_with(ROOM, "$orphan-response")
+    assert client.room_get_event.await_count == target_count
 
 
 async def test_failed_ownership_read_does_not_block_other_candidates(

--- a/tests/test_startup_recovery_inventory.py
+++ b/tests/test_startup_recovery_inventory.py
@@ -1,0 +1,294 @@
+"""Startup discovery follows durable visible debt, not room history."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindroom.event_journal import DeliveryStage, DepartureSource
+from mindroom.matrix.stale_stream_cleanup import recover_stale_streaming_messages
+from tests.conftest import delivered_matrix_side_effect, runtime_paths_for
+from tests.journal_membership_helpers import admit_room_membership
+from tests.test_event_journal_store import ROOM, admit
+from tests.test_stale_stream_cleanup import (
+    BOT_USER_ID,
+    NOW_MS,
+    STALE_AGE_MS,
+    _aiter,
+    _make_client,
+    _make_config,
+    _make_message_event,
+    _permitted_recovery_scope,
+    _room_get_event_response,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from mindroom.event_journal import EventJournalStore, PrincipalStore
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _initial(principal: PrincipalStore, source: str, *, acknowledged: bool = True, room_id: str = ROOM) -> None:
+    await admit(principal, source, room_id=room_id)
+    await principal.enqueue_matrix_delivery(
+        delivery_id=source,
+        stage=DeliveryStage.INITIAL,
+        room_id=room_id,
+        thread_id=None,
+        payload={"msgtype": "m.text", "body": "Thinking..."},
+    )
+    await principal.claim_matrix_delivery(delivery_id=source, stage=DeliveryStage.INITIAL)
+    if acknowledged:
+        await principal.acknowledge_matrix_delivery(
+            delivery_id=source,
+            stage=DeliveryStage.INITIAL,
+            event_id=f"{source}-response",
+            delivered_projections=(),
+        )
+
+
+async def test_inventory_keeps_ack_before_turn_binding_and_excludes_other_owners(
+    journal_store: EventJournalStore,
+) -> None:
+    """Recovery owns acknowledged orphans, not pending sends or FINAL-owned work."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$orphan")
+    await _initial(principal, "$unacknowledged", acknowledged=False)
+    await _initial(journal_store.principal("other@alice"), "$other")
+    for source in ("$owed", "$finished"):
+        await _initial(principal, source)
+        await principal.enqueue_matrix_delivery(
+            delivery_id=source,
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload={"msgtype": "m.text", "body": "Answer"},
+        )
+    await principal.claim_matrix_delivery(delivery_id="$finished", stage=DeliveryStage.FINAL)
+    await principal.acknowledge_matrix_delivery(
+        delivery_id="$finished",
+        stage=DeliveryStage.FINAL,
+        event_id="$answer",
+        delivered_projections=(),
+    )
+    candidates = await principal.recovery_initial_deliveries()
+    assert [item.delivery_id for item in candidates] == ["$orphan"]
+    assert candidates[0].acknowledged_event_id == "$orphan-response"
+    assert await journal_store.turn_records("agent").load_all() == ()
+
+
+async def test_inventory_advances_past_a_full_page_and_revisits_late_ack(
+    journal_store: EventJournalStore,
+) -> None:
+    """A new pass sees an INITIAL acknowledged after an earlier inventory read."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$late", acknowledged=False)
+    for index in range(101):
+        await _initial(principal, f"$source-{index:03}")
+    first = await principal.recovery_initial_deliveries()
+    assert len(first) == 100
+    last = first[-1]
+    second = await principal.recovery_initial_deliveries(after=(last.created_at_ns, last.delivery_id))
+    assert [item.delivery_id for item in second] == ["$source-100"]
+    await principal.acknowledge_matrix_delivery(
+        delivery_id="$late",
+        stage=DeliveryStage.INITIAL,
+        event_id="$late-response",
+        delivered_projections=(),
+    )
+    second = await principal.recovery_initial_deliveries(after=(last.created_at_ns, last.delivery_id))
+    assert [item.delivery_id for item in second] == ["$source-100"]
+    fresh_pass = await principal.recovery_initial_deliveries()
+    assert fresh_pass[0].delivery_id == "$late"
+
+
+@pytest.mark.parametrize("state", ["retired", "departed", "rejoined", "failed_final"])
+async def test_inventory_respects_membership_and_delivery_ownership(
+    journal_store: EventJournalStore,
+    state: str,
+) -> None:
+    """Obsolete tenure is excluded; a failed FINAL cannot finish visible debt."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$target", acknowledged=state != "retired")
+    if state == "retired":
+        await principal.retire_matrix_delivery(
+            delivery_id="$target",
+            stage=DeliveryStage.INITIAL,
+            room_id=ROOM,
+            membership_epoch=0,
+        )
+    elif state in {"departed", "rejoined"}:
+        await admit_room_membership(principal, ROOM, "leave", source=DepartureSource.LOCAL)
+        if state == "rejoined":
+            await admit_room_membership(principal, ROOM, "join")
+    else:
+        await principal.enqueue_matrix_delivery(
+            delivery_id="$target",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload={"msgtype": "m.text", "body": "Answer"},
+        )
+        await principal.claim_matrix_delivery(delivery_id="$target", stage=DeliveryStage.FINAL)
+        await principal.record_permanent_matrix_delivery_failure(
+            delivery_id="$target",
+            stage=DeliveryStage.FINAL,
+            reason="unrepresentable payload",
+        )
+    candidates = await principal.recovery_initial_deliveries()
+    assert [item.delivery_id for item in candidates] == (["$target"] if state == "failed_final" else [])
+
+
+async def test_empty_inventory_needs_no_matrix_discovery(journal_store: EventJournalStore, tmp_path: Path) -> None:
+    """No durable debt means no remote discovery calls."""
+    client = _make_client()
+    config = _make_config(tmp_path)
+    result = await recover_stale_streaming_messages(
+        {BOT_USER_ID: client},
+        principals={BOT_USER_ID: journal_store.principal("agent@alice")},
+        resume_client=None,
+        response_recovery_scope=_permitted_recovery_scope,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        startup_cutoff_ms=NOW_MS,
+        scanned_room_ids=set(),
+    )
+    assert result.room_count == result.cleaned_count == result.resumed_count == 0
+    client.joined_rooms.assert_not_awaited()
+    client.room_messages.assert_not_awaited()
+    client.room_get_event.assert_not_awaited()
+
+
+async def test_busy_room_ownership_does_not_delay_other_rooms(
+    journal_store: EventJournalStore,
+    tmp_path: Path,
+) -> None:
+    """One occupied response lock cannot hold up every room's recovery."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$busy")
+    await _initial(principal, "$healthy", room_id="!other:localhost")
+    busy_entered = asyncio.Event()
+    healthy_visited = asyncio.Event()
+    release_busy = asyncio.Event()
+
+    @asynccontextmanager
+    async def ownership(_agent: str, _room: str, event: str) -> AsyncIterator[bool]:
+        if event == "$busy-response":
+            busy_entered.set()
+            await release_busy.wait()
+        else:
+            healthy_visited.set()
+        yield False
+
+    client = _make_client()
+    config = _make_config(tmp_path)
+    task = asyncio.create_task(
+        recover_stale_streaming_messages(
+            {BOT_USER_ID: client},
+            principals={BOT_USER_ID: principal},
+            resume_client=None,
+            response_recovery_scope=ownership,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=set(),
+        ),
+    )
+    try:
+        await asyncio.wait_for(busy_entered.wait(), 2)
+        await asyncio.wait_for(healthy_visited.wait(), 2)
+    finally:
+        release_busy.set()
+        await task
+    client.room_get_event.assert_not_awaited()
+
+
+@pytest.mark.parametrize("router_unavailable", [False, True])
+async def test_exact_inventory_repairs_response_without_room_scan(
+    journal_store: EventJournalStore,
+    tmp_path: Path,
+    router_unavailable: bool,
+) -> None:
+    """Known delivery IDs suffice even when the resume identity is unavailable."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$orphan")
+    client = _make_client()
+    config = _make_config(tmp_path)
+    router = _make_client() if router_unavailable else None
+    if router is not None:
+        router.joined_rooms.side_effect = ConnectionError("router membership unavailable")
+    client.room_get_event.side_effect = None
+    client.room_get_event.return_value = _room_get_event_response(
+        _make_message_event(
+            event_id="$orphan-response",
+            body="Thinking...",
+            timestamp_ms=NOW_MS - STALE_AGE_MS,
+            room_id=ROOM,
+            extra_content={"io.mindroom.stream_status": "pending"},
+        ),
+    )
+    client.room_get_event_relations = MagicMock(side_effect=lambda *_args, **_kwargs: _aiter())
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=NOW_MS / 1000),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.edit_message_result",
+            AsyncMock(
+                side_effect=delivered_matrix_side_effect("$edit"),
+            ),
+        ) as edit,
+    ):
+        result = await recover_stale_streaming_messages(
+            {BOT_USER_ID: client},
+            principals={BOT_USER_ID: principal},
+            resume_client=router,
+            response_recovery_scope=_permitted_recovery_scope,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=set(),
+        )
+    assert result.cleaned_count == 1
+    assert edit.await_args.args[2] == "$orphan-response"
+    client.room_messages.assert_not_awaited()
+    client.room_get_event.assert_awaited_once_with(ROOM, "$orphan-response")
+
+
+async def test_failed_ownership_read_does_not_block_other_candidates(
+    journal_store: EventJournalStore,
+    tmp_path: Path,
+) -> None:
+    """A broken ownership record does not abort later candidate checks."""
+    principal = journal_store.principal("agent@alice")
+    await _initial(principal, "$broken")
+    await _initial(principal, "$healthy")
+    client = _make_client()
+    config = _make_config(tmp_path)
+    visited = []
+
+    @asynccontextmanager
+    async def ownership(_agent: str, _room: str, event: str) -> AsyncIterator[bool]:
+        visited.append(event)
+        if event == "$broken-response":
+            message = "one unavailable ownership record"
+            raise RuntimeError(message)
+        yield False
+
+    await recover_stale_streaming_messages(
+        {BOT_USER_ID: client},
+        principals={BOT_USER_ID: principal},
+        resume_client=None,
+        response_recovery_scope=ownership,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        startup_cutoff_ms=NOW_MS,
+        scanned_room_ids=set(),
+    )
+    assert visited == ["$broken-response", "$healthy-response"]
+    client.room_get_event.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Discover interrupted responses from paginated acknowledged INITIAL outbox rows, including ACK-before-turn-attribution, instead of sweeping every joined room's history.
- Fetch each owned response and complete same-sender replacement history by exact event ID. Keep unreadable content untouched and check the complete candidate thread before publishing a continuation.
- Preserve delivery ownership checks, FINAL/STOP/departure fencing, bounded room concurrency and per-bot cleanup edit pacing. A busy room's ownership lock no longer holds up all other rooms.

No schema, new recovery ledger, or legacy scan migration: current recovery already requires an owned outbox INITIAL. Independent room-maintenance PR: #2041.

Production diff: **+285 / -413 = -128 lines** in `src/mindroom/`. Together with #2041, **18 fewer production lines**.
No benchmark script, debugging document, or development plan is included.

## Verification

- Focused recovery, exact-message, SQLite/Postgres inventory, ownership-race, startup-maintenance, and restart-audit tests passed. Multi-target public-path regression demonstrated the lost pacing, then passed with the fix.
- Full-file pre-commit checks and final commit hooks passed, including types and import boundaries.
- Full Python suite exercised. Two unchanged timing tests failed under disk/load constraints: shutdown publication passed on isolated SQLite/Postgres reruns; the 180-day OAuth refresh test exceeded its 300-second disk deadline but passed in 70.55 seconds with a memory-backed temporary test directory. No production or test timeout was changed for those failures.
- Read-only merge-tree check confirms this PR and #2041 merge without conflicts.
- Two fresh independent native reviewers approved exact head `512a3bc55046dd9a1ab507e67b479246731276c1`. CodeRabbit had no actionable findings on the initial implementation; Qodo dismissed its late-ACK warning after ownership verification.
