### PR TITLE
Reconcile startup rooms once using shared fresh state

### DIFF
--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -43,10 +43,10 @@ main() entry
 │ ─────────────────│
 │ 1. try_start()   │
 │    each bot      │
-│ 2. Setup rooms   │
-│    & memberships │
-│ 3. Create sync   │
+│ 2. Create sync   │
 │    tasks         │
+│ 3. Background    │
+│    room setup    │
 └────────┬─────────┘
          │
          ▼
@@ -73,9 +73,18 @@ main() entry
 **Key details:**
 
 - **Entity order**: Router first, then agents, then teams
-- **Room setup** (`_setup_rooms_and_memberships`): Router creates rooms, invites agents, teams, and users, then bots join
+- **Room setup** (`_setup_rooms_and_memberships`): Resolve/create rooms and the root Space, join the router, reconcile managed policy once, then invite and join the remaining identities
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; `matrix_sync.mode: classic` uses Classic `/v3/sync`, while `sliding` uses MSC4186 Simplified Sliding Sync on a homeserver advertising `org.matrix.simplified_msc3575`
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
+
+Room administration uses a fresh, pass-local full-state snapshot for each policy reconciliation instead of separate name, topic, power-level, encryption, and join-rule reads.
+Satisfied power-level policy uses the snapshot fast path; a required power-level write rereads current grants so intervening administrator changes are preserved.
+Root Space child links share one fresh Space snapshot rather than fetching every child separately.
+Managed-room invitations reuse joined and invited memberships from those snapshots; internal-user and configured-user invitations share one roster.
+The internal user logs in once and joins only rooms absent from its fresh joined-room inventory, falling back to idempotent join attempts if that inventory is unavailable.
+Alias resolution and directory visibility still require fresh reads, and the authoritative reply-membership refresh remains a separate startup barrier.
+No configuration hash or persisted state cache suppresses remote drift checks on the next startup or relevant config update.
+The duplicate full pass is removed, including its incidental retry of failed operations; transport retries remain with nio and returned administrative failures are retried on the next setup attempt.
 
 ## Session Storage Recovery
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17643,10 +17643,10 @@ main() entry
 │ ─────────────────│
 │ 1. try_start()   │
 │    each bot      │
-│ 2. Setup rooms   │
-│    & memberships │
-│ 3. Create sync   │
+│ 2. Create sync   │
 │    tasks         │
+│ 3. Background    │
+│    room setup    │
 └────────┬─────────┘
          │
          ▼
@@ -17673,9 +17673,18 @@ main() entry
 **Key details:**
 
 - **Entity order**: Router first, then agents, then teams
-- **Room setup** (`_setup_rooms_and_memberships`): Router creates rooms, invites agents, teams, and users, then bots join
+- **Room setup** (`_setup_rooms_and_memberships`): Resolve/create rooms and the root Space, join the router, reconcile managed policy once, then invite and join the remaining identities
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; `matrix_sync.mode: classic` uses Classic `/v3/sync`, while `sliding` uses MSC4186 Simplified Sliding Sync on a homeserver advertising `org.matrix.simplified_msc3575`
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
+
+Room administration uses a fresh, pass-local full-state snapshot for each policy reconciliation instead of separate name, topic, power-level, encryption, and join-rule reads.
+Satisfied power-level policy uses the snapshot fast path; a required power-level write rereads current grants so intervening administrator changes are preserved.
+Root Space child links share one fresh Space snapshot rather than fetching every child separately.
+Managed-room invitations reuse joined and invited memberships from those snapshots; internal-user and configured-user invitations share one roster.
+The internal user logs in once and joins only rooms absent from its fresh joined-room inventory, falling back to idempotent join attempts if that inventory is unavailable.
+Alias resolution and directory visibility still require fresh reads, and the authoritative reply-membership refresh remains a separate startup barrier.
+No configuration hash or persisted state cache suppresses remote drift checks on the next startup or relevant config update.
+The duplicate full pass is removed, including its incidental retry of failed operations; transport retries remain with nio and returned administrative failures are retried on the next setup attempt.
 
 ## Session Storage Recovery
 

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -39,10 +39,10 @@ main() entry
 │ ─────────────────│
 │ 1. try_start()   │
 │    each bot      │
-│ 2. Setup rooms   │
-│    & memberships │
-│ 3. Create sync   │
+│ 2. Create sync   │
 │    tasks         │
+│ 3. Background    │
+│    room setup    │
 └────────┬─────────┘
          │
          ▼
@@ -69,9 +69,18 @@ main() entry
 **Key details:**
 
 - **Entity order**: Router first, then agents, then teams
-- **Room setup** (`_setup_rooms_and_memberships`): Router creates rooms, invites agents, teams, and users, then bots join
+- **Room setup** (`_setup_rooms_and_memberships`): Resolve/create rooms and the root Space, join the router, reconcile managed policy once, then invite and join the remaining identities
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; `matrix_sync.mode: classic` uses Classic `/v3/sync`, while `sliding` uses MSC4186 Simplified Sliding Sync on a homeserver advertising `org.matrix.simplified_msc3575`
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
+
+Room administration uses a fresh, pass-local full-state snapshot for each policy reconciliation instead of separate name, topic, power-level, encryption, and join-rule reads.
+Satisfied power-level policy uses the snapshot fast path; a required power-level write rereads current grants so intervening administrator changes are preserved.
+Root Space child links share one fresh Space snapshot rather than fetching every child separately.
+Managed-room invitations reuse joined and invited memberships from those snapshots; internal-user and configured-user invitations share one roster.
+The internal user logs in once and joins only rooms absent from its fresh joined-room inventory, falling back to idempotent join attempts if that inventory is unavailable.
+Alias resolution and directory visibility still require fresh reads, and the authoritative reply-membership refresh remains a separate startup barrier.
+No configuration hash or persisted state cache suppresses remote drift checks on the next startup or relevant config update.
+The duplicate full pass is removed, including its incidental retry of failed operations; transport retries remain with nio and returned administrative failures are retried on the next setup attempt.
 
 ## Session Storage Recovery
 

--- a/src/mindroom/matrix/client_room_admin.py
+++ b/src/mindroom/matrix/client_room_admin.py
@@ -11,6 +11,7 @@ import nio
 
 from mindroom.logging_config import get_logger
 from mindroom.matrix.event_types import CALL_MEMBER_EVENT_TYPE
+from mindroom.matrix.room_reconciliation import RoomStateSnapshot, read_state_event
 from mindroom.thread_tags import THREAD_TAGS_EVENT_TYPE
 
 if TYPE_CHECKING:
@@ -123,9 +124,14 @@ async def create_room(
     return None
 
 
-async def room_encryption_enabled(client: nio.AsyncClient, room_id: str) -> bool | None:
+async def room_encryption_enabled(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
+) -> bool | None:
     """Return whether a room has encryption enabled, or None when the state is unreadable."""
-    response = await client.room_get_state_event(room_id, _ROOM_ENCRYPTION_EVENT_TYPE)
+    response = await read_state_event(client, room_id, _ROOM_ENCRYPTION_EVENT_TYPE, snapshot=snapshot)
     if isinstance(response, nio.RoomGetStateEventResponse):
         return True
     if isinstance(response, nio.RoomGetStateEventError) and response.status_code == "M_NOT_FOUND":
@@ -134,13 +140,18 @@ async def room_encryption_enabled(client: nio.AsyncClient, room_id: str) -> bool
     return None
 
 
-async def ensure_room_encryption_enabled(client: nio.AsyncClient, room_id: str) -> bool:
+async def ensure_room_encryption_enabled(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
+) -> bool:
     """Enable Matrix encryption on a room if it is not already enabled.
 
     Enabling encryption is irreversible; this helper never disables it.
     Returns whether the room is encrypted after the call.
     """
-    enabled = await room_encryption_enabled(client, room_id)
+    enabled = await room_encryption_enabled(client, room_id, snapshot=snapshot)
     if enabled:
         return True
     if enabled is None:
@@ -177,13 +188,15 @@ async def ensure_managed_room_power_levels(
     client: nio.AsyncClient,
     room_id: str,
     admin_user_ids: Iterable[str] = (),
+    *,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Reconcile managed-room power levels with one read-modify-write.
 
     Applies the PL0 state events used by MindRoom clients and grants configured
     room admins power level 100 in one conditional PUT.
     """
-    current_response = await client.room_get_state_event(room_id, _POWER_LEVELS_EVENT_TYPE)
+    current_response = await read_state_event(client, room_id, _POWER_LEVELS_EVENT_TYPE, snapshot=snapshot)
     if not isinstance(current_response, nio.RoomGetStateEventResponse):
         logger.error(
             "Failed to read room power levels for managed room reconciliation",
@@ -212,6 +225,11 @@ async def ensure_managed_room_power_levels(
             admin_user_ids=sorted(concrete_admin_ids),
         )
         return True
+
+    if snapshot is not None:
+        # Topics and other policy operations may have awaited since this snapshot.
+        # A required read-modify-write must preserve current grants, not restore old ones.
+        return await ensure_managed_room_power_levels(client, room_id, concrete_admin_ids)
 
     response = await client.room_put_state(
         room_id=room_id,
@@ -306,30 +324,26 @@ async def ensure_room_admin_power_levels(
     client: nio.AsyncClient,
     room_id: str,
     user_ids: Iterable[str],
+    *,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Grant Matrix room admin power to users without revoking existing admins."""
     concrete_user_ids = {user_id for user_id in user_ids if user_id}
     if not concrete_user_ids:
         return True
 
-    current_response = await client.room_get_state_event(room_id, _POWER_LEVELS_EVENT_TYPE)
-    if not isinstance(current_response, nio.RoomGetStateEventResponse):
+    current_response = await read_state_event(client, room_id, _POWER_LEVELS_EVENT_TYPE, snapshot=snapshot)
+    if not isinstance(current_response, nio.RoomGetStateEventResponse) or not isinstance(
+        current_response.content,
+        dict,
+    ):
         logger.error(
-            "Failed to read room power levels for admin reconciliation",
+            "Failed to read valid room power levels for admin reconciliation",
             room_id=room_id,
             user_ids=sorted(concrete_user_ids),
             error=_describe_matrix_response_error(current_response),
         )
         return False
-    if not isinstance(current_response.content, dict):
-        logger.error(
-            "Room power levels state has unexpected content shape",
-            room_id=room_id,
-            user_ids=sorted(concrete_user_ids),
-            content=current_response.content,
-        )
-        return False
-
     current_content = current_response.content
     desired_content = _with_room_admin_power_levels(current_content, concrete_user_ids)
     if desired_content == current_content:
@@ -340,6 +354,9 @@ async def ensure_room_admin_power_levels(
             power_level=_ROOM_ADMIN_POWER_LEVEL,
         )
         return True
+
+    if snapshot is not None:
+        return await ensure_room_admin_power_levels(client, room_id, concrete_user_ids)
 
     response = await client.room_put_state(
         room_id=room_id,
@@ -403,9 +420,14 @@ def _describe_matrix_response_error(response: object) -> str:
     return str(response)
 
 
-async def _get_room_join_rule(client: nio.AsyncClient, room_id: str) -> str | None:
+async def _get_room_join_rule(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
+) -> str | None:
     """Read the current join rule from room state."""
-    response = await client.room_get_state_event(room_id, "m.room.join_rules")
+    response = await read_state_event(client, room_id, "m.room.join_rules", snapshot=snapshot)
     if isinstance(response, nio.RoomGetStateEventResponse):
         join_rule = response.content.get("join_rule")
         if isinstance(join_rule, str):
@@ -457,9 +479,11 @@ async def ensure_room_join_rule(
     client: nio.AsyncClient,
     room_id: str,
     target_join_rule: RoomJoinRule,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Ensure a room has the desired join rule."""
-    current_join_rule = await _get_room_join_rule(client, room_id)
+    current_join_rule = await _get_room_join_rule(client, room_id, snapshot=snapshot)
     if current_join_rule == target_join_rule:
         logger.debug("Room join rule already configured", room_id=room_id, join_rule=target_join_rule)
         return True
@@ -546,9 +570,11 @@ async def ensure_room_name(
     client: nio.AsyncClient,
     room_id: str,
     name: str,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Ensure a room or Space has the desired display name."""
-    current_response = await client.room_get_state_event(room_id, "m.room.name")
+    current_response = await read_state_event(client, room_id, "m.room.name", snapshot=snapshot)
     if isinstance(current_response, nio.RoomGetStateEventResponse) and current_response.content.get("name") == name:
         logger.debug("Room name already configured", room_id=room_id, name=name)
         return True
@@ -578,6 +604,7 @@ async def add_room_to_space(
     via_server_name: str,
     *,
     suggested: bool = True,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Ensure a room is linked as a child of a root Space."""
     desired_content = {
@@ -585,7 +612,7 @@ async def add_room_to_space(
         "suggested": suggested,
     }
 
-    current_response = await client.room_get_state_event(space_id, "m.space.child", room_id)
+    current_response = await read_state_event(client, space_id, "m.space.child", room_id, snapshot=snapshot)
     if isinstance(current_response, nio.RoomGetStateEventResponse) and current_response.content == desired_content:
         logger.debug("Room already linked under root space", space_id=space_id, room_id=room_id)
         return True

--- a/src/mindroom/matrix/room_reconciliation.py
+++ b/src/mindroom/matrix/room_reconciliation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import aiohttp
 import nio
 
 from mindroom.logging_config import get_logger
@@ -30,9 +31,17 @@ class RoomStateSnapshot:
 
 async def read_room_state(client: nio.AsyncClient, room_id: str) -> RoomStateSnapshot | None:
     """Fetch complete state; unreadable state is not an empty room."""
-    response = await client.room_get_state(room_id)
+    try:
+        response = await client.room_get_state(room_id)
+    except (aiohttp.ClientError, TimeoutError, ValueError):
+        logger.warning("room_reconciliation_state_read_failed", room_id=room_id, exc_info=True)
+        return None
     if not isinstance(response, nio.RoomGetStateResponse) or response.room_id != room_id:
         logger.warning("room_reconciliation_state_unavailable", room_id=room_id, error=str(response))
+        return None
+    # Nio validates the state envelope, but not the content field.
+    if any(not isinstance(event.get("content"), dict) for event in response.events):
+        logger.warning("room_reconciliation_state_content_invalid", room_id=room_id)
         return None
     return RoomStateSnapshot(
         room_id,

--- a/src/mindroom/matrix/room_reconciliation.py
+++ b/src/mindroom/matrix/room_reconciliation.py
@@ -1,0 +1,60 @@
+"""Pass-local authoritative room state for administration and invitations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import nio
+
+from mindroom.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RoomStateSnapshot:
+    """One complete remote state read; never persisted or inferred from sync defaults."""
+
+    room_id: str
+    events: dict[tuple[str, str], dict[str, Any]]
+
+    def present_user_ids(self) -> set[str]:
+        """Return joined or invited users, both of which already satisfy invitation."""
+        return {
+            state_key
+            for (event_type, state_key), content in self.events.items()
+            if event_type == "m.room.member" and content.get("membership") in {"join", "invite"}
+        }
+
+
+async def read_room_state(client: nio.AsyncClient, room_id: str) -> RoomStateSnapshot | None:
+    """Fetch complete state; unreadable state is not an empty room."""
+    response = await client.room_get_state(room_id)
+    if not isinstance(response, nio.RoomGetStateResponse) or response.room_id != room_id:
+        logger.warning("room_reconciliation_state_unavailable", room_id=room_id, error=str(response))
+        return None
+    return RoomStateSnapshot(
+        room_id,
+        {(event["type"], event["state_key"]): dict(event["content"]) for event in response.events},
+    )
+
+
+async def read_state_event(
+    client: nio.AsyncClient,
+    room_id: str,
+    event_type: str,
+    state_key: str = "",
+    *,
+    snapshot: RoomStateSnapshot | None = None,
+) -> nio.RoomGetStateEventResponse | nio.RoomGetStateEventError:
+    """Read from an explicit complete snapshot or fetch for a standalone caller."""
+    if snapshot is None:
+        return await client.room_get_state_event(room_id, event_type, state_key)
+    if snapshot.room_id != room_id:
+        message = "Room state snapshot belongs to another room"
+        raise ValueError(message)
+    content = snapshot.events.get((event_type, state_key))
+    if content is None:
+        return nio.RoomGetStateEventError("State event absent", "M_NOT_FOUND", room_id=room_id)
+    return nio.RoomGetStateEventResponse(dict(content), event_type, state_key, room_id)

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -29,6 +29,7 @@ from mindroom.matrix.client_room_admin import (
     join_room,
     leave_room,
 )
+from mindroom.matrix.room_reconciliation import RoomStateSnapshot, read_room_state
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY, INTERNAL_USER_AGENT_NAME, AgentMatrixUser, login_agent_user
 from mindroom.matrix_identifiers import (
@@ -92,6 +93,7 @@ async def _configure_managed_room_access(
     room_policy: EffectiveRoomPolicy,
     *,
     context: str,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Apply configured room joinability/discoverability policy for one managed room."""
     target_join_rule = room_policy.join_policy
@@ -107,7 +109,7 @@ async def _configure_managed_room_access(
         context=context,
     )
 
-    join_rule_ok = await ensure_room_join_rule(client, room_id, target_join_rule)
+    join_rule_ok = await ensure_room_join_rule(client, room_id, target_join_rule, snapshot=snapshot)
     visibility_ok = await ensure_room_directory_visibility(client, room_id, target_directory_visibility)
     if join_rule_ok and visibility_ok:
         return True
@@ -196,21 +198,23 @@ async def _reconcile_joined_existing_room(
     explicit_room_name: str | None,
     room_policy: EffectiveRoomPolicy,
     admin_user_ids: Sequence[str] = (),
+    snapshot: RoomStateSnapshot | None = None,
 ) -> None:
     """Reconcile name, topic, power levels, encryption, and access policy for one joined managed room."""
     topic_room_name = explicit_room_name or _room_key_to_name(room_key)
     if explicit_room_name is not None:
-        await ensure_room_name(client, room_id, explicit_room_name)
-    await ensure_room_has_topic(client, room_id, room_key, topic_room_name, config, runtime_paths)
-    await ensure_managed_room_power_levels(client, room_id, admin_user_ids)
+        await ensure_room_name(client, room_id, explicit_room_name, snapshot=snapshot)
+    await ensure_room_has_topic(client, room_id, room_key, topic_room_name, config, runtime_paths, snapshot=snapshot)
+    await ensure_managed_room_power_levels(client, room_id, admin_user_ids, snapshot=snapshot)
     if _managed_room_should_be_encrypted(room_policy):
-        await ensure_room_encryption_enabled(client, room_id)
+        await ensure_room_encryption_enabled(client, room_id, snapshot=snapshot)
     await _configure_managed_room_access(
         client=client,
         room_key=room_key,
         room_id=room_id,
         room_policy=room_policy,
         context="existing_room_reconciliation",
+        snapshot=snapshot,
     )
 
 
@@ -223,8 +227,6 @@ async def _ensure_room_exists(
     room_name: str | None = None,
     power_users: list[str] | None = None,
     admin_user_ids: Sequence[str] = (),
-    *,
-    room_locks: dict[str, asyncio.Lock],
 ) -> str | None:
     """Ensure a room exists, creating it if necessary.
 
@@ -237,7 +239,6 @@ async def _ensure_room_exists(
         power_users: List of user IDs to grant power levels to
         room_policy: Resolved membership room policy
         admin_user_ids: Concrete Matrix user IDs granted room admin power (100)
-        room_locks: Pass-local locks serializing aliases that resolve to the same room
 
     Returns:
         Room ID if room exists or was created, None on failure
@@ -254,7 +255,6 @@ async def _ensure_room_exists(
     response = await client.room_resolve_alias(full_alias)
     if isinstance(response, nio.RoomResolveAliasResponse):
         room_id = str(response.room_id)
-        explicit_room_name = room_name
         logger.debug("managed_room_alias_resolved", room_key=room_key, room_alias=full_alias, room_id=room_id)
 
         # Update our state if needed
@@ -264,37 +264,6 @@ async def _ensure_room_exists(
             _add_room(room_key, room_id, full_alias, room_name, runtime_paths)
             logger.info("managed_room_state_updated", room_key=room_key, room_id=room_id, room_alias=full_alias)
 
-        # Room existence and room membership are separate concerns. Existing
-        # private rooms may be managed outside MindRoom, so don't force a join
-        # attempt here just to record that the alias resolves.
-        joined_room = room_id in client.rooms
-        if not joined_room:
-            joined_room_ids = await get_joined_rooms(client)
-            joined_room = joined_room_ids is not None and room_id in joined_room_ids
-
-        if joined_room:
-            async with room_locks.setdefault(room_id, asyncio.Lock()):
-                await _reconcile_joined_existing_room(
-                    client,
-                    room_key,
-                    room_id,
-                    config,
-                    runtime_paths,
-                    explicit_room_name=explicit_room_name,
-                    room_policy=room_policy,
-                    admin_user_ids=admin_user_ids,
-                )
-        else:
-            logger.warning(
-                "Managed room exists but service account is not joined; skipping existing-room reconciliation",
-                room_key=room_key,
-                room_id=room_id,
-                room_alias=full_alias,
-                hint=(
-                    "If this room should be router-managed, invite the router or make the room joinable. "
-                    "If it is externally managed, this warning is expected."
-                ),
-            )
         return room_id
 
     # Room alias doesn't exist on server, so we can create it
@@ -353,7 +322,7 @@ async def ensure_all_rooms_exist(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> dict[str, str]:
-    """Ensure all configured rooms exist and invite user account.
+    """Resolve or create configured rooms before joining and reconciling them.
 
     Args:
         client: Matrix client to use for room creation
@@ -370,7 +339,6 @@ async def ensure_all_rooms_exist(
     all_rooms = config.get_all_configured_rooms()
 
     pending_rooms = iter(room_key for room_key in all_rooms if not room_key.startswith("!"))
-    room_locks: dict[str, asyncio.Lock] = {}
 
     async def reconcile_rooms() -> None:
         for room_key in pending_rooms:
@@ -389,7 +357,6 @@ async def ensure_all_rooms_exist(
                     power_users=power_users,
                     room_policy=room_policy,
                     admin_user_ids=admin_user_ids,
-                    room_locks=room_locks,
                 )
             except RuntimeError:
                 logger.exception(
@@ -407,6 +374,54 @@ async def ensure_all_rooms_exist(
             workers.create_task(reconcile_rooms())
 
     return room_ids
+
+
+async def reconcile_managed_rooms(
+    client: nio.AsyncClient,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    room_ids: dict[str, str],
+) -> dict[str, RoomStateSnapshot]:
+    """Apply managed policy after joining, retaining fresh state for invitations."""
+    snapshots: dict[str, RoomStateSnapshot] = {}
+    pending = iter(room_ids.items())
+    locks: dict[str, asyncio.Lock] = {}
+
+    async def reconcile_rooms() -> None:
+        for room_key, room_id in pending:
+            try:
+                async with locks.setdefault(room_id, asyncio.Lock()):
+                    snapshot = await read_room_state(client, room_id)
+                    if snapshot is None:
+                        continue
+                    membership = snapshot.events.get(("m.room.member", client.user_id), {})
+                    if membership.get("membership") != "join":
+                        logger.warning("Managed room is not joined; skipping policy", room_id=room_id)
+                        continue
+                    policy = resolve_room_policy(config, room_key)
+                    room_config = config.rooms.get(room_key)
+                    name = (
+                        (room_config.display_name or _room_key_to_name(room_key)) if room_config is not None else None
+                    )
+                    await _reconcile_joined_existing_room(
+                        client,
+                        room_key,
+                        room_id,
+                        config,
+                        runtime_paths,
+                        explicit_room_name=name,
+                        room_policy=policy,
+                        admin_user_ids=_room_admin_user_ids(policy),
+                        snapshot=snapshot,
+                    )
+                    snapshots[room_id] = snapshot
+            except RuntimeError:
+                logger.exception("Failed managed room policy; continuing with remaining rooms", room_id=room_id)
+
+    async with asyncio.TaskGroup() as workers:
+        for _ in range(min(4, len(room_ids))):
+            workers.create_task(reconcile_rooms())
+    return snapshots
 
 
 async def _ensure_root_space_exists(
@@ -469,20 +484,25 @@ async def ensure_root_space(
         return None
 
     root_space_id = await _ensure_root_space_exists(client, config, runtime_paths)
-    if root_space_id is None:
+    snapshot = await read_room_state(client, root_space_id) if root_space_id is not None else None
+    if root_space_id is None or snapshot is None:
         return None
-
-    if not await ensure_room_name(client, root_space_id, config.matrix_space.name):
+    if not await ensure_room_name(client, root_space_id, config.matrix_space.name, snapshot=snapshot):
         logger.warning("Failed to set root space name; skipping child linking", space_id=root_space_id)
         return None
 
-    if admin_user_ids and not await ensure_room_admin_power_levels(client, root_space_id, admin_user_ids):
+    if admin_user_ids and not await ensure_room_admin_power_levels(
+        client,
+        root_space_id,
+        admin_user_ids,
+        snapshot=snapshot,
+    ):
         logger.warning("Failed to grant root space admin power; skipping child linking", space_id=root_space_id)
         return None
 
     server_name = extract_server_name_from_homeserver(client.homeserver, runtime_paths=runtime_paths)
     for room_id in dict.fromkeys(room_ids.values()):
-        if not await add_room_to_space(client, root_space_id, room_id, server_name):
+        if not await add_room_to_space(client, root_space_id, room_id, server_name, snapshot=snapshot):
             logger.warning(
                 "Failed to link room to root space; aborting reconciliation",
                 space_id=root_space_id,
@@ -537,10 +557,13 @@ async def ensure_user_in_rooms(
     )
     try:
         logger.info("matrix_user_logged_in", user_id=user_client.user_id)
-
+        joined_room_ids = set(await get_joined_rooms(user_client) or ())
         for room_key, room_id in room_ids.items():
+            if room_id in joined_room_ids:
+                continue
             join_outcome = await join_room(user_client, room_id)
             if join_outcome is RoomJoinOutcome.JOINED:
+                joined_room_ids.add(room_id)
                 logger.info("matrix_user_joined_room", user_id=user_client.user_id, room_id=room_id, room_key=room_key)
             else:
                 logger.warning(

--- a/src/mindroom/matrix/rooms.py
+++ b/src/mindroom/matrix/rooms.py
@@ -415,7 +415,7 @@ async def reconcile_managed_rooms(
                         snapshot=snapshot,
                     )
                     snapshots[room_id] = snapshot
-            except RuntimeError:
+            except Exception:
                 logger.exception("Failed managed room policy; continuing with remaining rooms", room_id=room_id)
 
     async with asyncio.TaskGroup() as workers:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -50,7 +50,12 @@ from mindroom.legacy_private_storage import migrate_private_storage
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
 from mindroom.matrix.health import reset_matrix_sync_health
 from mindroom.matrix.identity import managed_account_user_id
-from mindroom.matrix.rooms import ensure_all_rooms_exist, ensure_root_space, ensure_user_in_rooms
+from mindroom.matrix.rooms import (
+    ensure_all_rooms_exist,
+    ensure_root_space,
+    ensure_user_in_rooms,
+    reconcile_managed_rooms,
+)
 from mindroom.matrix.stale_stream_cleanup import (
     recover_stale_streaming_messages,
 )
@@ -149,6 +154,7 @@ if TYPE_CHECKING:
     from mindroom.desktop.identity import DesktopControllerIdentity
     from mindroom.event_journal import ApprovalContinuation, ApprovalDeliveryView
     from mindroom.hooks import HookMatrixAdmin, HookMessageSender, HookRoomStatePutter, HookRoomStateQuerier
+    from mindroom.matrix.room_reconciliation import RoomStateSnapshot
 
     from .constants import RuntimePaths
     from .event_journal import EventJournalStore
@@ -1972,8 +1978,10 @@ class _MultiAgentOrchestrator:
         bots_to_setup = self._running_bots_for_entities(changed_entities | plan.entities_to_reconcile_rooms)
         if bots_to_setup or plan.mindroom_user_changed or plan.room_access_changed or plan.authorization_changed:
             await self._setup_rooms_and_memberships(bots_to_setup)
-        if plan.matrix_space_changed or plan.room_metadata_changed:
+        elif plan.matrix_space_changed or plan.room_metadata_changed:
             room_ids = await self._ensure_rooms_exist()
+            if plan.room_metadata_changed:
+                await self._reconcile_managed_rooms(room_ids)
             await self._ensure_root_space(room_ids)
 
     async def _prepare_accounts_for_config_update(self, new_config: Config, plan: ConfigUpdatePlan) -> None:
@@ -2161,24 +2169,15 @@ class _MultiAgentOrchestrator:
                     self.runtime_paths,
                 )
 
-        # First invitation and join pass for rooms the router already manages.
-        await self._ensure_room_invitations()
-        await _ensure_internal_user_memberships()
-        await asyncio.gather(*(bot.ensure_rooms() for bot in bots))
-
-        # Existing invite-only rooms may only become manageable after the router joins.
-        # Rerun room reconciliation so topic and access policy updates apply in that case.
-        if any(bot.agent_name == ROUTER_AGENT_NAME for bot in bots):
-            room_ids = await self._ensure_rooms_exist()
-            await self._ensure_root_space(room_ids)
-
-        # Retry invitations once the router has completed its first join pass.
-        await self._ensure_room_invitations()
+        # Join the router before policy and invitations, including existing private rooms.
+        for bot in bots:
+            if bot.agent_name == ROUTER_AGENT_NAME:
+                await bot.ensure_rooms()
+        snapshots = await self._reconcile_managed_rooms(room_ids)
+        await self._ensure_room_invitations(snapshots)
         await _ensure_internal_user_memberships()
 
-        follow_up_bots = [bot for bot in bots if bot.agent_name != ROUTER_AGENT_NAME]
-        if follow_up_bots:
-            await asyncio.gather(*(bot.ensure_rooms() for bot in follow_up_bots))
+        await asyncio.gather(*(bot.ensure_rooms() for bot in bots if bot.agent_name != ROUTER_AGENT_NAME))
 
         await self.refresh_agent_reply_memberships()
 
@@ -2198,6 +2197,13 @@ class _MultiAgentOrchestrator:
         room_ids = await ensure_all_rooms_exist(router_bot.client, config, self.runtime_paths)
         logger.info("ensured_room_existence", room_count=len(room_ids))
         return room_ids
+
+    async def _reconcile_managed_rooms(self, room_ids: dict[str, str]) -> dict[str, RoomStateSnapshot]:
+        """Wire the router's fresh policy reconciliation into startup and reload."""
+        router = self._router_bot()
+        if router is None or router.client is None:
+            return {}
+        return await reconcile_managed_rooms(router.client, self._require_config(), self.runtime_paths, room_ids)
 
     async def _ensure_root_space(self, room_ids: dict[str, str] | None = None) -> None:
         """Ensure the optional root Matrix Space exists and link the current managed rooms."""
@@ -2265,39 +2271,6 @@ class _MultiAgentOrchestrator:
         else:
             logger.warning(failure_message, **(log_context or {}))
 
-    async def _invite_internal_user_to_rooms(
-        self,
-        config: Config,
-        joined_rooms: list[str],
-    ) -> str | None:
-        """Invite the configured internal user to all joined rooms when needed."""
-        router_bot = self._router_bot()
-        if router_bot is None:
-            return None
-        assert router_bot.client is not None
-
-        server_name = extract_server_name_from_homeserver(
-            constants.runtime_matrix_homeserver(runtime_paths=self.runtime_paths),
-            runtime_paths=self.runtime_paths,
-        )
-        user_id = managed_account_user_id(INTERNAL_USER_ACCOUNT_KEY, server_name, self.runtime_paths)
-        if config.mindroom_user is None or user_id is None:
-            return None
-
-        for room_id in joined_rooms:
-            room_members = await get_room_members(router_bot.client, room_id)
-            if room_members is None:
-                logger.warning("room_invitations_skipped_members_unavailable", room_id=room_id)
-                continue
-            await self._invite_user_if_missing(
-                room_id,
-                user_id,
-                room_members,
-                success_message=f"Invited user {user_id} to room {room_id}",
-                failure_message=f"Failed to invite user {user_id} to room {room_id}",
-            )
-        return user_id
-
     async def _invite_authorized_users_to_room(
         self,
         room_id: str,
@@ -2330,7 +2303,7 @@ class _MultiAgentOrchestrator:
                 failure_message=f"Failed to invite {bot_user_id} to room {room_id}",
             )
 
-    async def _ensure_room_invitations(self) -> None:
+    async def _ensure_room_invitations(self, snapshots: dict[str, RoomStateSnapshot] | None = None) -> None:
         """Ensure all agents and the internal user are invited to their configured rooms.
 
         The router client performs these invitations because it has admin privileges
@@ -2350,20 +2323,34 @@ class _MultiAgentOrchestrator:
         if not joined_rooms:
             return
 
-        internal_user_id = await self._invite_internal_user_to_rooms(config, joined_rooms)
+        server_name = extract_server_name_from_homeserver(
+            constants.runtime_matrix_homeserver(runtime_paths=self.runtime_paths),
+            runtime_paths=self.runtime_paths,
+        )
+        internal_user_id = (
+            managed_account_user_id(INTERNAL_USER_ACCOUNT_KEY, server_name, self.runtime_paths)
+            if config.mindroom_user is not None
+            else None
+        )
 
         for room_id in joined_rooms:
             configured_bots = configured_bot_user_ids_for_room(config, room_id, self.runtime_paths)
-            if not configured_bots and not is_configured_room(config, room_id, self.runtime_paths):
+            managed = bool(configured_bots) or is_configured_room(config, room_id, self.runtime_paths)
+            if not managed and internal_user_id is None:
                 continue
 
-            current_members = await get_room_members(router_bot.client, room_id)
+            snapshot = (snapshots or {}).get(room_id)
+            current_members = (
+                snapshot.present_user_ids()
+                if snapshot is not None
+                else await get_room_members(router_bot.client, room_id)
+            )
             if current_members is None:
                 logger.warning("room_invitations_skipped_members_unavailable", room_id=room_id)
                 continue
-            authorized_user_ids = get_room_user_ids_to_invite(config, room_id, self.runtime_paths)
+            authorized_user_ids = get_room_user_ids_to_invite(config, room_id, self.runtime_paths) if managed else set()
             if internal_user_id is not None:
-                authorized_user_ids.discard(internal_user_id)
+                authorized_user_ids.add(internal_user_id)
             await self._invite_authorized_users_to_room(room_id, current_members, authorized_user_ids)
             if configured_bots:
                 await self._invite_configured_bots_to_room(room_id, current_members, configured_bots)

--- a/src/mindroom/topic_generator.py
+++ b/src/mindroom/topic_generator.py
@@ -13,6 +13,7 @@ from mindroom.ai_runtime import cached_agent_run
 from mindroom.entity_resolution import configured_routable_entity_names_for_room
 from mindroom.logging_config import get_logger
 from mindroom.matrix import state as matrix_state
+from mindroom.matrix.room_reconciliation import RoomStateSnapshot, read_state_event
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -135,6 +136,8 @@ async def ensure_room_has_topic(
     room_name: str,
     config: Config,
     runtime_paths: RuntimePaths,
+    *,
+    snapshot: RoomStateSnapshot | None = None,
 ) -> bool:
     """Ensure a room has a topic set, generating one if needed.
 
@@ -145,12 +148,13 @@ async def ensure_room_has_topic(
         room_name: Display name for the room
         config: Configuration with agent settings
         runtime_paths: Explicit runtime context for topic generation
+        snapshot: Complete pass-local room state, if already read by reconciliation
 
     Returns:
         True if topic was set or already exists, False on error
 
     """
-    response = await client.room_get_state_event(room_id, "m.room.topic")
+    response = await read_state_event(client, room_id, "m.room.topic", snapshot=snapshot)
     if isinstance(response, nio.RoomGetStateEventResponse) and response.content.get("topic"):
         logger.debug(
             "room_topic_already_present",

--- a/src/mindroom/topic_generator.py
+++ b/src/mindroom/topic_generator.py
@@ -171,6 +171,15 @@ async def ensure_room_has_topic(
         logger.warning("generate_room_topic_failed", room_id=room_id, room_key=room_key)
         return False
 
+    # Generation can take seconds; a human topic added meanwhile must win.
+    response = await read_state_event(client, room_id, "m.room.topic")
+    if isinstance(response, nio.RoomGetStateEventResponse):
+        if response.content.get("topic"):
+            return True
+    elif response.status_code != "M_NOT_FOUND":
+        logger.warning("room_topic_recheck_failed", room_id=room_id, error=str(response))
+        return False
+
     # Set the topic
     response = await client.room_put_state(
         room_id=room_id,

--- a/tach.toml
+++ b/tach.toml
@@ -1807,6 +1807,7 @@ depends_on = [
 [[modules]]
 path = "mindroom.matrix.rooms"
 depends_on = [
+    "mindroom.matrix.room_reconciliation",
     "mindroom.constants",
     "mindroom.entity_resolution",
     "mindroom.matrix.client_room_admin",
@@ -1899,6 +1900,7 @@ visibility = ["mindroom.orchestrator"]
 [[modules]]
 path = "mindroom.orchestrator"
 depends_on = [
+    "mindroom.matrix.room_reconciliation",
     "mindroom.config_reload",
     "mindroom.matrix_rtc.call_manager",
     "mindroom.knowledge.status",
@@ -2348,6 +2350,7 @@ visibility = [
 [[modules]]
 path = "mindroom.topic_generator"
 depends_on = [
+    "mindroom.matrix.room_reconciliation",
     "mindroom.ai_runtime",
     "mindroom.entity_resolution",
     "mindroom.logging_config",
@@ -2521,8 +2524,19 @@ depends_on = []
 visibility = ["mindroom.custom_tools.matrix_voice_message"]
 
 [[modules]]
+path = "mindroom.matrix.room_reconciliation"
+depends_on = ["mindroom.logging_config"]
+visibility = [
+    "mindroom.matrix.client_room_admin",
+    "mindroom.matrix.rooms",
+    "mindroom.orchestrator",
+    "mindroom.topic_generator",
+]
+
+[[modules]]
 path = "mindroom.matrix.client_room_admin"
 depends_on = [
+    "mindroom.matrix.room_reconciliation",
     "mindroom.thread_tags",
 ]
 visibility = [

--- a/tests/test_e2ee_phase2.py
+++ b/tests/test_e2ee_phase2.py
@@ -160,7 +160,7 @@ def _bound_config(tmp_path: Path, **config_data: object) -> Config:
 
 
 class TestManagedRoomEncryptionReconcile:
-    """The reconcile wiring in _ensure_room_exists must honor the encryption config."""
+    """Post-join managed policy reconciliation must honor the encryption config."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(("encrypt_managed_rooms", "expected_calls"), [(True, 1), (False, 0)])
@@ -203,13 +203,25 @@ class TestManagedRoomEncryptionReconcile:
             room_policy=resolve_room_policy(config, "lobby"),
             room_name="Lobby",
             power_users=[],
-            room_locks={},
         )
 
         assert room_id == "!lobby:example.com"
+        mock_client.user_id = "@router:example.com"
+        mock_client.room_get_state.return_value = nio.RoomGetStateResponse(
+            [
+                {"type": "m.room.member", "state_key": mock_client.user_id, "content": {"membership": "join"}},
+            ],
+            room_id,
+        )
+        snapshots = await matrix_rooms.reconcile_managed_rooms(
+            mock_client,
+            config,
+            runtime_paths_for(config),
+            {"lobby": room_id},
+        )
         assert enable_encryption.await_count == expected_calls
         if expected_calls:
-            enable_encryption.assert_awaited_once_with(mock_client, "!lobby:example.com")
+            enable_encryption.assert_awaited_once_with(mock_client, room_id, snapshot=snapshots[room_id])
 
     @pytest.mark.asyncio
     async def test_new_room_created_encrypted_when_configured(
@@ -247,7 +259,6 @@ class TestManagedRoomEncryptionReconcile:
             room_policy=resolve_room_policy(config, "vault"),
             room_name="Vault",
             power_users=[],
-            room_locks={},
         )
 
         assert room_id == "!new:example.com"

--- a/tests/test_matrix_room_access.py
+++ b/tests/test_matrix_room_access.py
@@ -51,6 +51,7 @@ async def test_configure_managed_room_access_applies_effective_policy(
         ANY,
         "!lobby:example.com",
         "knock",
+        snapshot=None,
     )
     ensure_visibility.assert_awaited_once_with(
         ANY,
@@ -220,6 +221,7 @@ async def test_existing_room_reconciliation_always_applies_room_policy(
         room_id="!lobby:example.com",
         room_policy=policy,
         context="existing_room_reconciliation",
+        snapshot=None,
     )
 
 
@@ -315,5 +317,13 @@ async def test_aliases_of_same_room_do_not_reconcile_concurrently(
     monkeypatch.setattr(matrix_rooms, "_add_room", Mock())
     monkeypatch.setattr(matrix_rooms, "_reconcile_joined_existing_room", reconcile)
     result = await matrix_rooms.ensure_all_rooms_exist(client, config, runtime_paths_for(config))
+    client.user_id = "@router:example.com"
+    client.room_get_state.return_value = nio.RoomGetStateResponse(
+        [
+            {"type": "m.room.member", "state_key": client.user_id, "content": {"membership": "join"}},
+        ],
+        "!same:example.com",
+    )
+    await matrix_rooms.reconcile_managed_rooms(client, config, runtime_paths_for(config), result)
     assert result == {"first": "!same:example.com", "second": "!same:example.com"}
     assert peak == 1

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, call, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import nio
 import pytest
@@ -79,9 +79,11 @@ def test_matrix_state_load_is_backward_compatible_without_space_room_id(tmp_path
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("already_joined", [False, True])
 async def test_ensure_user_in_rooms_uses_managed_login_boundary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    already_joined: bool,
 ) -> None:
     """The internal user room-join path should share managed Matrix session persistence."""
     runtime_paths = orchestrator_runtime_paths(tmp_path, config_path=tmp_path / "config.yaml")
@@ -122,6 +124,13 @@ async def test_ensure_user_in_rooms_uses_managed_login_boundary(
     join_room = AsyncMock(return_value=RoomJoinOutcome.JOINED)
     monkeypatch.setattr(matrix_rooms, "login_agent_user", _login_user)
     monkeypatch.setattr(matrix_rooms, "join_room", join_room)
+    monkeypatch.setattr(
+        matrix_rooms,
+        "get_joined_rooms",
+        AsyncMock(
+            return_value=["!lobby:localhost"] if already_joined else None,
+        ),
+    )
 
     await matrix_rooms.ensure_user_in_rooms(
         "http://localhost:8008",
@@ -133,7 +142,10 @@ async def test_ensure_user_in_rooms_uses_managed_login_boundary(
     assert login_calls[0].user_id == "@requested_internal:localhost"
     assert login_calls[0].device_id == "old_device"
     assert login_calls[0].access_token == TEST_PASSWORD
-    join_room.assert_awaited_once_with(client, "!lobby:localhost")
+    if already_joined:
+        join_room.assert_not_awaited()
+    else:
+        join_room.assert_awaited_once_with(client, "!lobby:localhost")
     client.close.assert_awaited_once()
 
     persisted = MatrixState.load(runtime_paths=runtime_paths).get_account("agent_user")
@@ -387,6 +399,7 @@ async def test_ensure_root_space_creates_space_links_rooms_and_persists_state(tm
     """Enabled root Space support should create the Space, persist it, and link rooms."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {}
     client.room_resolve_alias.return_value = nio.RoomResolveAliasError("not found", status_code="M_NOT_FOUND")
     state = MatrixState()
@@ -418,11 +431,11 @@ async def test_ensure_root_space_creates_space_links_rooms_and_persists_state(tm
     assert state.space_room_id == "!space:localhost"
     mock_save.assert_called_once_with(state, runtime_paths=runtime_paths_for(config))
     mock_create.assert_awaited_once()
-    mock_name.assert_awaited_once_with(client, "!space:localhost", "MindRoom")
-    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"})
+    mock_name.assert_awaited_once_with(client, "!space:localhost", "MindRoom", snapshot=ANY)
+    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"}, snapshot=ANY)
     assert mock_add.await_args_list == [
-        call(client, "!space:localhost", "!lobby:localhost", "localhost"),
-        call(client, "!space:localhost", "!dev:localhost", "localhost"),
+        call(client, "!space:localhost", "!lobby:localhost", "localhost", snapshot=ANY),
+        call(client, "!space:localhost", "!dev:localhost", "localhost", snapshot=ANY),
     ]
     mock_avatar.assert_awaited_once_with(
         client,
@@ -439,6 +452,7 @@ async def test_ensure_root_space_resolves_existing_alias_without_recreating(tmp_
     """Existing root Spaces should be resolved by alias and reused."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {}
     client.room_resolve_alias.return_value = nio.RoomResolveAliasResponse(
         room_alias="#_mindroom_root_space:localhost",
@@ -479,9 +493,9 @@ async def test_ensure_root_space_resolves_existing_alias_without_recreating(tmp_
     mock_save.assert_called_once_with(state, runtime_paths=runtime_paths_for(config))
     mock_join.assert_awaited_once_with(client, "!space:localhost")
     mock_create.assert_not_awaited()
-    mock_name.assert_awaited_once_with(client, "!space:localhost", "Workspace")
-    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"})
-    mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost")
+    mock_name.assert_awaited_once_with(client, "!space:localhost", "Workspace", snapshot=ANY)
+    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"}, snapshot=ANY)
+    mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost", snapshot=ANY)
     mock_avatar.assert_awaited_once_with(
         client,
         "!space:localhost",
@@ -497,6 +511,7 @@ async def test_ensure_root_space_skips_existing_alias_when_router_cannot_join(tm
     """A private existing root Space should not be reused if the router cannot join it."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {}
     client.room_resolve_alias.return_value = nio.RoomResolveAliasResponse(
         room_alias="#_mindroom_root_space:localhost",
@@ -545,6 +560,7 @@ async def test_ensure_root_space_returns_none_when_name_write_fails(tmp_path) ->
     """If the router lacks permission to set the space name, reconciliation should bail out."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {"!space:localhost": MagicMock()}
     state = MatrixState(space_room_id="!space:localhost")
     config = _config_with_runtime_paths(
@@ -577,6 +593,7 @@ async def test_ensure_root_space_returns_none_when_admin_power_reconciliation_fa
     """If root Space admin promotion fails, reconciliation should skip child linking."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {"!space:localhost": MagicMock()}
     state = MatrixState(space_room_id="!space:localhost")
     config = _config_with_runtime_paths(
@@ -602,7 +619,7 @@ async def test_ensure_root_space_returns_none_when_admin_power_reconciliation_fa
         )
 
     assert space_id is None
-    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"})
+    mock_admins.assert_awaited_once_with(client, "!space:localhost", {"@owner:localhost"}, snapshot=ANY)
     mock_add.assert_not_awaited()
     mock_avatar.assert_not_awaited()
 
@@ -612,6 +629,7 @@ async def test_ensure_root_space_returns_none_when_child_link_fails(tmp_path) ->
     """If the router cannot add child links, reconciliation should fail."""
     client = AsyncMock()
     client.homeserver = "http://localhost:8008"
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], "!space:localhost")
     client.rooms = {"!space:localhost": MagicMock()}
     state = MatrixState(space_room_id="!space:localhost")
     config = _config_with_runtime_paths(
@@ -635,7 +653,7 @@ async def test_ensure_root_space_returns_none_when_child_link_fails(tmp_path) ->
         )
 
     assert space_id is None
-    mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost")
+    mock_add.assert_awaited_once_with(client, "!space:localhost", "!lobby:localhost", "localhost", snapshot=ANY)
     mock_avatar.assert_not_awaited()
 
 
@@ -736,7 +754,7 @@ async def test_orchestrator_ensure_root_space_skips_existing_members(tmp_path) -
 
 
 @pytest.mark.asyncio
-async def test_setup_rooms_and_memberships_runs_root_space_after_each_room_reconciliation(tmp_path) -> None:  # noqa: ANN001
+async def test_setup_rooms_and_memberships_reconciles_root_space_once(tmp_path) -> None:  # noqa: ANN001
     """Space reconciliation should happen as a post-room phase during startup."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
     orchestrator.config = Config(
@@ -770,7 +788,6 @@ async def test_setup_rooms_and_memberships_runs_root_space_after_each_room_recon
         await orchestrator._setup_rooms_and_memberships([router_bot, general_bot])
 
     assert mock_root_space.await_args_list == [
-        call({"lobby": "!room1:localhost"}),
         call({"lobby": "!room1:localhost"}),
     ]
 

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -2066,12 +2066,12 @@ class TestMultiAgentOrchestrator:
 
         assert bot.rooms == ["!room1:localhost"]
         mock_ensure_user_in_rooms.assert_not_awaited()
-        assert bot.ensure_rooms.await_count == 2
+        assert bot.ensure_rooms.await_count == 1
         mock_refresh_agent_reply_memberships.assert_awaited_once_with()
 
     @pytest.mark.asyncio
-    async def test_setup_rooms_and_memberships_retries_invites_after_router_joins(self, tmp_path: Path) -> None:
-        """Invite-only existing rooms should get a second invitation/join pass after router joins."""
+    async def test_setup_rooms_and_memberships_invites_and_joins_once(self, tmp_path: Path) -> None:
+        """Order router membership first instead of replaying invitations and joins."""
         config = _runtime_bound_config(
             Config(
                 agents={
@@ -2110,16 +2110,16 @@ class TestMultiAgentOrchestrator:
         assert router_bot.rooms == ["!room1:localhost"]
         assert general_bot.rooms == ["!room1:localhost"]
         assert router_bot.ensure_rooms.await_count == 1
-        assert general_bot.ensure_rooms.await_count == 2
-        assert mock_invitations.await_count == 2
-        assert mock_ensure_user_in_rooms.await_count == 2
+        assert general_bot.ensure_rooms.await_count == 1
+        assert mock_invitations.await_count == 1
+        assert mock_ensure_user_in_rooms.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_setup_rooms_and_memberships_reruns_room_reconciliation_after_router_joins(
+    async def test_setup_rooms_and_memberships_reconciles_once_after_router_joins(
         self,
         tmp_path: Path,
     ) -> None:
-        """Startup should rerun room reconciliation after the router joins existing rooms."""
+        """Private rooms are reconciled once, after the router can administer them."""
         config = _runtime_bound_config(
             Config(
                 agents={
@@ -2137,8 +2137,9 @@ class TestMultiAgentOrchestrator:
         router_joined = False
         reconciliation_join_states: list[bool] = []
 
-        async def record_room_reconciliation() -> None:
+        async def record_room_reconciliation(_room_ids: dict[str, str]) -> dict:
             reconciliation_join_states.append(router_joined)
+            return {}
 
         async def router_join_rooms() -> None:
             nonlocal router_joined
@@ -2155,7 +2156,16 @@ class TestMultiAgentOrchestrator:
         general_bot.ensure_rooms = AsyncMock()
 
         with (
-            patch.object(orchestrator, "_ensure_rooms_exist", new=AsyncMock(side_effect=record_room_reconciliation)),
+            patch.object(
+                orchestrator,
+                "_ensure_rooms_exist",
+                new=AsyncMock(return_value={"lobby": "!room1:localhost"}),
+            ),
+            patch.object(
+                orchestrator,
+                "_reconcile_managed_rooms",
+                new=AsyncMock(side_effect=record_room_reconciliation),
+            ),
             patch.object(orchestrator, "_ensure_room_invitations", new=AsyncMock()),
             patch("mindroom.orchestrator.get_rooms_for_entity", return_value=["lobby"]),
             patch("mindroom.orchestrator.resolve_room_aliases", return_value=["!room1:localhost"]),
@@ -2164,9 +2174,9 @@ class TestMultiAgentOrchestrator:
         ):
             await orchestrator._setup_rooms_and_memberships([router_bot, general_bot])
 
-        assert reconciliation_join_states == [False, True]
+        assert reconciliation_join_states == [True]
         assert router_bot.ensure_rooms.await_count == 1
-        assert general_bot.ensure_rooms.await_count == 2
+        assert general_bot.ensure_rooms.await_count == 1
 
     @pytest.mark.asyncio
     async def test_reconcile_post_update_rooms_runs_for_room_metadata_changes(

--- a/tests/test_room_reconciliation_snapshot.py
+++ b/tests/test_room_reconciliation_snapshot.py
@@ -154,7 +154,8 @@ async def test_power_write_does_not_restore_revoked_admin_from_snapshot() -> Non
 
 
 @pytest.mark.asyncio
-async def test_one_failed_room_does_not_cancel_healthy_reconciliation(tmp_path: Path) -> None:
+@pytest.mark.parametrize("error", [RuntimeError("policy failed"), ValueError("bad policy"), aiohttp.ClientError()])
+async def test_one_failed_room_does_not_cancel_healthy_reconciliation(tmp_path: Path, error: Exception) -> None:
     """A room-local policy failure cannot abort sibling rooms."""
     config = membership_config(tmp_path, agent_rooms=["broken", "healthy"])
     client = AsyncMock()
@@ -168,8 +169,7 @@ async def test_one_failed_room_does_not_cancel_healthy_reconciliation(tmp_path: 
 
     async def policy(_client: nio.AsyncClient, room_key: str, *_args: object, **_kwargs: object) -> None:
         if room_key == "broken":
-            message = "one room policy unavailable"
-            raise RuntimeError(message)
+            raise error
 
     with patch.object(matrix_rooms, "_reconcile_joined_existing_room", side_effect=policy):
         result = await matrix_rooms.reconcile_managed_rooms(

--- a/tests/test_room_reconciliation_snapshot.py
+++ b/tests/test_room_reconciliation_snapshot.py
@@ -1,0 +1,264 @@
+"""Fresh room snapshots replace repeated state reads, never remote authority."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import nio
+import pytest
+
+from mindroom.matrix import client_room_admin, room_reconciliation
+from mindroom.matrix import rooms as matrix_rooms
+from mindroom.topic_generator import ensure_room_has_topic
+from tests.access_schema_support import membership_config
+from tests.conftest import runtime_paths_for
+
+
+@pytest.mark.asyncio
+async def test_one_snapshot_serves_name_join_rule_and_space_children() -> None:
+    """Satisfied policy uses one complete state GET and no per-event GET or PUT."""
+    client = AsyncMock()
+    room_id = "!space:example.com"
+    client.room_get_state.return_value = nio.RoomGetStateResponse(
+        [
+            {"type": "m.room.name", "state_key": "", "content": {"name": "Workspace"}},
+            {"type": "m.room.join_rules", "state_key": "", "content": {"join_rule": "invite"}},
+            {
+                "type": "m.space.child",
+                "state_key": "!child:example.com",
+                "content": {"via": ["example.com"], "suggested": True},
+            },
+            {"type": "m.room.member", "state_key": "@invited:example.com", "content": {"membership": "invite"}},
+            {"type": "m.room.member", "state_key": "@joined:example.com", "content": {"membership": "join"}},
+            {"type": "m.room.member", "state_key": "@left:example.com", "content": {"membership": "leave"}},
+        ],
+        room_id,
+    )
+    snapshot = await room_reconciliation.read_room_state(client, room_id)
+    assert snapshot is not None
+    assert snapshot.present_user_ids() == {"@invited:example.com", "@joined:example.com"}
+    assert await client_room_admin.ensure_room_name(client, room_id, "Workspace", snapshot=snapshot)
+    assert await client_room_admin.ensure_room_join_rule(client, room_id, "invite", snapshot=snapshot)
+    assert await client_room_admin.add_room_to_space(
+        client,
+        room_id,
+        "!child:example.com",
+        "example.com",
+        snapshot=snapshot,
+    )
+    client.room_get_state.assert_awaited_once_with(room_id)
+    client.room_get_state_event.assert_not_awaited()
+    client.room_put_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unavailable_snapshot_is_not_an_empty_room() -> None:
+    """A state failure cannot turn missing knowledge into permission to write."""
+    client = AsyncMock()
+    client.room_get_state.return_value = nio.RoomGetStateError("forbidden", "M_FORBIDDEN", "!room:example.com")
+    assert await room_reconciliation.read_room_state(client, "!room:example.com") is None
+    client.room_put_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_preserves_power_levels_and_existing_topic(tmp_path: Path) -> None:
+    """Managed policy updates preserve foreign power keys and reuse known topic/encryption."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"])
+    client = AsyncMock()
+    room_id = "!room:example.com"
+    snapshot = room_reconciliation.RoomStateSnapshot(
+        room_id,
+        {
+            ("m.room.power_levels", ""): {"users": {"@owner:example.com": 100}, "custom": "keep"},
+            ("m.room.topic", ""): {"topic": "Existing human topic"},
+            ("m.room.encryption", ""): {"algorithm": "m.megolm.v1.aes-sha2"},
+        },
+    )
+    client.room_put_state.return_value = nio.RoomPutStateResponse("$power", room_id)
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+        {"users": {"@owner:example.com": 100}, "custom": "keep"},
+        "m.room.power_levels",
+        "",
+        room_id,
+    )
+    assert await client_room_admin.ensure_managed_room_power_levels(client, room_id, snapshot=snapshot)
+    assert client.room_put_state.await_args.kwargs["content"]["custom"] == "keep"
+    assert client.room_put_state.await_args.kwargs["content"]["users"] == {"@owner:example.com": 100}
+    assert await client_room_admin.ensure_room_encryption_enabled(client, room_id, snapshot=snapshot)
+    assert await ensure_room_has_topic(
+        client,
+        room_id,
+        "lobby",
+        "Lobby",
+        config,
+        runtime_paths_for(config),
+        snapshot=snapshot,
+    )
+    client.room_get_state_event.assert_awaited_once_with(room_id, "m.room.power_levels", "")
+    assert client.room_put_state.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_power_write_does_not_restore_revoked_admin_from_snapshot() -> None:
+    """A stale policy snapshot may avoid a write but cannot supply a write's user grants."""
+    client = AsyncMock()
+    room_id = "!room:example.com"
+    snapshot = room_reconciliation.RoomStateSnapshot(
+        room_id,
+        {
+            ("m.room.power_levels", ""): {"users": {"@revoked:example.com": 100}},
+        },
+    )
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+        {"users": {}, "new_custom": "preserve"},
+        "m.room.power_levels",
+        "",
+        room_id,
+    )
+    client.room_put_state.return_value = nio.RoomPutStateResponse("$power", room_id)
+    assert await client_room_admin.ensure_managed_room_power_levels(client, room_id, snapshot=snapshot)
+    assert client.room_put_state.await_args.kwargs["content"]["users"] == {}
+    assert client.room_put_state.await_args.kwargs["content"]["new_custom"] == "preserve"
+
+
+@pytest.mark.asyncio
+async def test_one_failed_room_does_not_cancel_healthy_reconciliation(tmp_path: Path) -> None:
+    """A room-local policy failure cannot abort sibling rooms."""
+    config = membership_config(tmp_path, agent_rooms=["broken", "healthy"])
+    client = AsyncMock()
+    client.user_id = "@router:example.com"
+    client.room_get_state.side_effect = lambda room_id: nio.RoomGetStateResponse(
+        [
+            {"type": "m.room.member", "state_key": client.user_id, "content": {"membership": "join"}},
+        ],
+        room_id,
+    )
+
+    async def policy(_client: nio.AsyncClient, room_key: str, *_args: object, **_kwargs: object) -> None:
+        if room_key == "broken":
+            message = "one room policy unavailable"
+            raise RuntimeError(message)
+
+    with patch.object(matrix_rooms, "_reconcile_joined_existing_room", side_effect=policy):
+        result = await matrix_rooms.reconcile_managed_rooms(
+            client,
+            config,
+            runtime_paths_for(config),
+            {"broken": "!broken:example.com", "healthy": "!healthy:example.com"},
+        )
+    assert set(result) == {"!healthy:example.com"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("membership", ["join", "invite", "leave"])
+async def test_readable_unjoined_room_does_not_start_policy_work(tmp_path: Path, membership: str) -> None:
+    """State readability alone does not make a room joined or router-managed."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"])
+    client = AsyncMock()
+    client.user_id = "@router:example.com"
+    room_id = "!room:example.com"
+    client.room_get_state.return_value = nio.RoomGetStateResponse(
+        [
+            {"type": "m.room.member", "state_key": client.user_id, "content": {"membership": membership}},
+        ],
+        room_id,
+    )
+    with patch.object(matrix_rooms, "_reconcile_joined_existing_room", new=AsyncMock()) as policy:
+        result = await matrix_rooms.reconcile_managed_rooms(
+            client,
+            config,
+            runtime_paths_for(config),
+            {"lobby": room_id},
+        )
+    assert policy.await_count == (1 if membership == "join" else 0)
+    assert set(result) == ({room_id} if membership == "join" else set())
+
+
+@pytest.mark.asyncio
+async def test_root_space_reuses_one_fresh_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A large existing Space does not issue one GET per child on each startup."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"])
+    config.matrix_space.enabled = True
+    client = AsyncMock()
+    client.homeserver = "https://example.com"
+    space_id = "!space:example.com"
+    monkeypatch.setattr(matrix_rooms, "_ensure_root_space_exists", AsyncMock(return_value=space_id))
+    monkeypatch.setattr(matrix_rooms, "_set_room_avatar_if_available", AsyncMock())
+    client.room_get_state.return_value = nio.RoomGetStateResponse(
+        [
+            {"type": "m.room.name", "state_key": "", "content": {"name": config.matrix_space.name}},
+            {
+                "type": "m.space.child",
+                "state_key": "!child:example.com",
+                "content": {"via": ["example.com"], "suggested": True},
+            },
+        ],
+        space_id,
+    )
+    result = await matrix_rooms.ensure_root_space(
+        client,
+        config,
+        runtime_paths_for(config),
+        {"lobby": "!child:example.com"},
+    )
+    assert result == space_id
+    client.room_get_state.assert_awaited_once_with(space_id)
+    client.room_get_state_event.assert_not_awaited()
+    client.room_put_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_managed_policy_snapshot_failure_skips_mutations(tmp_path: Path) -> None:
+    """An inaccessible room cannot trigger topic generation or policy writes."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"])
+    client = AsyncMock()
+    client.room_get_state.return_value = nio.RoomGetStateError("forbidden", "M_FORBIDDEN", "!room:example.com")
+    assert (
+        await matrix_rooms.reconcile_managed_rooms(
+            client,
+            config,
+            runtime_paths_for(config),
+            {"lobby": "!room:example.com"},
+        )
+        == {}
+    )
+    client.room_put_state.assert_not_awaited()
+    client.room_get_state_event.assert_not_awaited()
+    client.room_get_visibility.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_each_policy_pass_repairs_fresh_remote_drift(tmp_path: Path) -> None:
+    """An unchanged config does not hide an administrator's later remote change."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"], rooms={"lobby": {"display_name": "Lobby"}})
+    client = AsyncMock()
+    client.user_id = "@router:example.com"
+    room_id = "!room:example.com"
+    client.room_get_state.side_effect = [
+        nio.RoomGetStateResponse(
+            [
+                {"type": "m.room.member", "state_key": client.user_id, "content": {"membership": "join"}},
+                {"type": "m.room.name", "state_key": "", "content": {"name": name}},
+                {"type": "m.room.topic", "state_key": "", "content": {"topic": "Human topic"}},
+                {"type": "m.room.power_levels", "state_key": "", "content": {}},
+                {"type": "m.room.join_rules", "state_key": "", "content": {"join_rule": "invite"}},
+            ],
+            room_id,
+        )
+        for name in ("Lobby", "Remote change")
+    ]
+    client.room_get_visibility.return_value = nio.RoomGetVisibilityResponse(room_id=room_id, visibility="private")
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse({}, "m.room.power_levels", "", room_id)
+    client.room_put_state.return_value = nio.RoomPutStateResponse("$updated", room_id)
+    for _ in range(2):
+        await matrix_rooms.reconcile_managed_rooms(client, config, runtime_paths_for(config), {"lobby": room_id})
+    names = [
+        call.kwargs["content"]
+        for call in client.room_put_state.await_args_list
+        if call.kwargs.get("event_type") == "m.room.name"
+    ]
+    assert names == [{"name": "Lobby"}]
+    assert client.room_get_state.await_count == 2
+    assert [call.args[1] for call in client.room_get_state_event.await_args_list] == [
+        "m.room.power_levels",
+        "m.room.power_levels",
+    ]

--- a/tests/test_room_reconciliation_snapshot.py
+++ b/tests/test_room_reconciliation_snapshot.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import aiohttp
 import nio
 import pytest
 
@@ -57,6 +58,38 @@ async def test_unavailable_snapshot_is_not_an_empty_room() -> None:
     client.room_get_state.return_value = nio.RoomGetStateError("forbidden", "M_FORBIDDEN", "!room:example.com")
     assert await room_reconciliation.read_room_state(client, "!room:example.com") is None
     client.room_put_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content", [None, [], "invalid"])
+async def test_snapshot_rejects_content_not_validated_by_nio(content: object) -> None:
+    """Nio validates the state envelope but leaves content shape unchecked."""
+    client = AsyncMock()
+    room_id = "!room:example.com"
+    client.room_get_state.return_value = nio.RoomGetStateResponse.from_dict(
+        [
+            {
+                "event_id": "$state",
+                "sender": "@a:example.com",
+                "type": "m.room.topic",
+                "state_key": "",
+                "origin_server_ts": 1,
+                "content": content,
+            },
+        ],
+        room_id,
+    )
+    assert isinstance(client.room_get_state.return_value, nio.RoomGetStateResponse)
+    assert await room_reconciliation.read_room_state(client, room_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [aiohttp.ClientConnectionError(), TimeoutError(), ValueError("bad JSON")])
+async def test_snapshot_transport_failure_is_unavailable(error: Exception) -> None:
+    """A failed external read cannot abort unrelated room administration."""
+    client = AsyncMock()
+    client.room_get_state.side_effect = error
+    assert await room_reconciliation.read_room_state(client, "!room:example.com") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_topic_generator.py
+++ b/tests/test_topic_generator.py
@@ -3,16 +3,85 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
+import nio
 import pytest
 
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
+from mindroom.matrix.room_reconciliation import RoomStateSnapshot
 from mindroom.matrix.state import MatrixState
-from mindroom.topic_generator import generate_room_topic_ai
+from mindroom.topic_generator import ensure_room_has_topic, generate_room_topic_ai
+from tests.access_schema_support import membership_config
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_snapshot", [False, True])
+@pytest.mark.parametrize("final_state", ["human_topic", "empty", "missing", "forbidden"])
+async def test_topic_generation_rechecks_remote_state_before_writing(
+    tmp_path: Path,
+    use_snapshot: bool,
+    final_state: str,
+) -> None:
+    """A human topic added during generation wins; an unreadable final state forbids writes."""
+    config = membership_config(tmp_path, agent_rooms=["lobby"])
+    client = AsyncMock(spec=nio.AsyncClient)
+    room_id = "!lobby:example.com"
+    current: nio.RoomGetStateEventResponse | nio.RoomGetStateEventError = nio.RoomGetStateEventResponse(
+        {},
+        "m.room.topic",
+        "",
+        room_id,
+    )
+
+    async def read(_room: str, _event_type: str, _state_key: str = "") -> object:
+        return current
+
+    async def generate(*_args: object) -> str:
+        nonlocal current
+        if final_state in {"human_topic", "empty"}:
+            current = nio.RoomGetStateEventResponse(
+                {"topic": "Human topic" if final_state == "human_topic" else ""},
+                "m.room.topic",
+                "",
+                room_id,
+            )
+        else:
+            current = nio.RoomGetStateEventError(
+                "unavailable",
+                "M_NOT_FOUND" if final_state == "missing" else "M_FORBIDDEN",
+                room_id,
+            )
+        return "AI topic"
+
+    client.room_get_state_event.side_effect = read
+    client.room_put_state.return_value = nio.RoomPutStateResponse("$topic", room_id)
+    with patch("mindroom.topic_generator.generate_room_topic_ai", side_effect=generate):
+        result = await ensure_room_has_topic(
+            client,
+            room_id,
+            "lobby",
+            "Lobby",
+            config,
+            runtime_paths_for(config),
+            snapshot=RoomStateSnapshot(room_id, {}) if use_snapshot else None,
+        )
+    assert result is (final_state != "forbidden")
+    if final_state in {"human_topic", "forbidden"}:
+        client.room_put_state.assert_not_awaited()
+    else:
+        client.room_put_state.assert_awaited_once_with(
+            room_id=room_id,
+            event_type="m.room.topic",
+            content={"topic": "AI topic"},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Separate room existence from policy reconciliation, join the router first, then run policy, invitations, internal-user joins and remaining bot joins once.
- Share one fresh full-state snapshot per managed room for metadata and invitation membership, including pending invitations. Root Space child links share one snapshot too.
- Reread power levels before required writes so intervening administrator changes are preserved; skip unreadable or unjoined rooms and isolate per-room failures.
- Join the internal user only to rooms absent from its joined-room inventory. Keep authoritative alias, directory visibility and authorization reads.

No persistent cache, config hash, generic retry framework or migration. Removing the duplicate pass also removes its incidental second attempt; returned administrative failures wait for the next startup/config reconciliation, as documented.

## Scope and size

Independent of recovery PR #2040. Production source: +248/-129, net **+119 lines**, including the 69-line room snapshot module. No benchmark scripts, debugging documents or development plans are committed.

## Verification

- Focused room/orchestrator coverage passed, including regressions for stale power-level grants, per-room failure isolation and unjoined-room policy writes.
- Commit hooks passed (format, types, unused code, architecture boundaries and generated documentation).
- Broad suite: 18,530 passed, 204 skipped; one unchanged OAuth reentrancy process test hit its deadline under parallel load. Both sync/async reentrancy tests passed in isolation (sync 1.04 seconds).
- The unchanged 180-day OAuth quota stress test was excluded from this broad run after its disk-backed timeout on the recovery branch; it passed separately on a memory-backed test filesystem in 70.55 seconds. No OAuth production code or test deadlines changed.
- Malformed-content and HTTP/timeout/JSON snapshot failures have red/green regression coverage; final focused tests and commit hooks passed. Two fresh independent reviewers approved final head `03da523ed29f2e397eaeb06926880651f2b9557b` after the final external-review fixes (topic recheck after generation and ordinary per-room exception isolation); both reran focused tests. No findings remain from these reviews.

## Summary by Sourcery

Reconcile managed Matrix rooms once after the router joins, using fresh shared state to make policy, membership, and Space administration authoritative and non-redundant.

Bug Fixes:
- Prevent stale or unreadable room state from causing incorrect policy writes, while preserving administrator changes made during reconciliation.
- Avoid redundant invitations and joins by checking current memberships, including pending invitations and the internal user's joined-room inventory.

Enhancements:
- Reorganize startup room setup so the router joins before a single managed-room policy reconciliation, followed by invitations and remaining bot joins.
- Use one fresh full-state snapshot per managed room for policy and invitation decisions, and share a snapshot when linking rooms under the root Space.
- Isolate failures during individual room reconciliation and continue processing other rooms.
- Recheck remote topic and power-level state before writes to protect intervening human or administrator changes.

Documentation:
- Update orchestration documentation to describe the reordered startup flow, snapshot-based reconciliation, membership handling, and retry behavior.

Tests:
- Add coverage for snapshot validation, remote-state failures, stale power-level protection, topic races, unjoined rooms, per-room failure isolation, root Space reuse, and single-pass startup behavior.