### PR TITLE
Reconcile only affected call rooms after membership updates

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -378,7 +378,8 @@ class AgentBot:
     _knowledge_access_support: KnowledgeAccessSupport
     _deferred_overdue_task_drain_task: asyncio.Task[None] | None
     _call_manager: CallManager | None
-    _calls_reconcile_pending: bool
+    _calls_full_reconcile_pending: bool
+    _call_rooms_reconcile_pending: set[str]
     _reply_membership_sync: AgentReplyMembershipSync | None
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
@@ -465,7 +466,8 @@ class AgentBot:
         self._sync_continuity_store = SyncContinuityStore(self.storage_path, self.agent_name)
         self._deferred_overdue_task_drain_task = None
         self._call_manager: CallManager | None = None
-        self._calls_reconcile_pending = False
+        self._calls_full_reconcile_pending = False
+        self._call_rooms_reconcile_pending = set()
         self._local_membership_lock = asyncio.Lock()
         self._ingestion_admission_progress = asyncio.Event()
         self._response_recovery_diagnostic_classes = set()
@@ -1210,8 +1212,7 @@ class AgentBot:
 
     async def _post_join_room_setup(self, room_id: str) -> None:
         """Run room setup that should happen after joins and across restarts."""
-        if self._call_manager is not None:
-            self._calls_reconcile_pending = True
+        self._request_call_reconciliation(room_id)
         if self.agent_name != ROUTER_AGENT_NAME:
             return
 
@@ -1318,7 +1319,7 @@ class AgentBot:
         self._deferred_stop_required = False
         self._deferred_stop_phase = None
         self._response_runner.resume_pending_admissions()
-        self._calls_reconcile_pending = self._call_manager is not None
+        self._request_call_reconciliation()
         if self.agent_name == ROUTER_AGENT_NAME:
             self._invalidate_agent_reply_memberships(reason="sync_loop_started")
         mark_matrix_sync_loop_started(self.agent_name)
@@ -1630,7 +1631,7 @@ class AgentBot:
                 left_room_ids=set() if joined else {room_id},
             )
             if joined:
-                self._calls_reconcile_pending = True
+                self._request_call_reconciliation(room_id)
         if not joined and admission.previous_membership == "join":
             self._room_lifecycle.forget_invited_room(room_id)
 
@@ -1723,15 +1724,31 @@ class AgentBot:
         await self._run_sync_response_side_effects(
             first_sync_response=first_sync_response,
         )
-        if self._calls_reconcile_pending:
-            self._calls_reconcile_pending = False
-            call_manager = self._call_manager
-            if call_manager is not None:
-                create_background_task(
-                    call_manager.reconcile_joined_rooms(),
-                    name=f"matrix_rtc_reconcile_{self.agent_name}",
-                    owner=self._runtime_view,
-                )
+        call_manager = self._call_manager
+        if call_manager is None or (not self._calls_full_reconcile_pending and not self._call_rooms_reconcile_pending):
+            return
+        reconcile_all = self._calls_full_reconcile_pending
+        room_ids = frozenset(self._call_rooms_reconcile_pending)
+        self._calls_full_reconcile_pending = False
+        self._call_rooms_reconcile_pending.clear()
+        reconcile = (
+            call_manager.reconcile_joined_rooms() if reconcile_all else call_manager.reconcile_joined_rooms(room_ids)
+        )
+        create_background_task(
+            reconcile,
+            name=f"matrix_rtc_reconcile_{self.agent_name}",
+            owner=self._runtime_view,
+        )
+
+    def _request_call_reconciliation(self, room_id: str | None = None) -> None:
+        """Retain full or room-scoped reconciliation intent until frame publication."""
+        if self._call_manager is None:
+            return
+        if room_id is None:
+            self._calls_full_reconcile_pending = True
+            self._call_rooms_reconcile_pending.clear()
+        elif not self._calls_full_reconcile_pending:
+            self._call_rooms_reconcile_pending.add(room_id)
 
     async def _open_owned_matrix_client(self) -> nio.AsyncClient:
         """Acquire and retain the bot's exclusive ingestion/client ownership."""
@@ -2061,7 +2078,8 @@ class AgentBot:
 
         call_manager = self._call_manager
         self._call_manager = None
-        self._calls_reconcile_pending = False
+        self._calls_full_reconcile_pending = False
+        self._call_rooms_reconcile_pending = set()
         if call_manager is not None:
             await call_manager.shutdown()
 

--- a/src/mindroom/matrix_rtc/call_manager.py
+++ b/src/mindroom/matrix_rtc/call_manager.py
@@ -386,11 +386,16 @@ class CallManager:
         if room is not None:
             await self._reconcile(room)
 
-    async def reconcile_joined_rooms(self) -> None:
-        """Reconcile configured calls after a successful Matrix sync response."""
+    async def reconcile_joined_rooms(self, room_ids: AbstractSet[str] | None = None) -> None:
+        """Reconcile all configured calls, or only the requested joined rooms."""
         if self._shutting_down:
             return
-        rooms = [room for room in self._client.rooms.values() if self._is_configured_call_room(room)]
+        candidates = (
+            self._client.rooms.values()
+            if room_ids is None
+            else (room for room_id in room_ids if (room := self._client.rooms.get(room_id)) is not None)
+        )
+        rooms = [room for room in candidates if self._is_configured_call_room(room)]
         self._observed_rooms.update((room.room_id, room) for room in rooms)
         await asyncio.gather(*(self._reconcile(room) for room in rooms))
 

--- a/tests/test_bot_ingestion_effects.py
+++ b/tests/test_bot_ingestion_effects.py
@@ -11,6 +11,7 @@ import pytest
 
 from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.event_journal import AdmissionFacts, IngestionBatchAdmission, RoomMembershipPosition
+from tests.conftest import install_call_manager_mock
 from tests.journal_membership_helpers import admit_room_membership
 from tests.test_bot_ready_hook import (
     _CONSUMER_GENERATION,
@@ -215,10 +216,7 @@ async def test_authoritative_join_requests_call_reconciliation_after_frame_publi
     manager = MagicMock()
     manager.on_sync_room_membership = AsyncMock()
     manager.reconcile_joined_rooms = AsyncMock()
-    bot._call_manager = manager
-    client = MagicMock(spec=nio.AsyncClient)
-    client.rooms = {room_id: nio.MatrixRoom(room_id, bot.matrix_id.full_id)}
-    bot.client = client
+    install_call_manager_mock(bot, manager)
     with (
         patch.object(bot, "journal_principal", return_value=principal),
         patch.object(bot, "_run_sync_response_side_effects", new=AsyncMock()),
@@ -236,11 +234,6 @@ async def test_call_room_updates_are_preserved_while_reconciliation_is_running(t
     bot = _agent_bot(tmp_path)
     first_room_id = "!first-call:localhost"
     second_room_id = "!second-call:localhost"
-    client = MagicMock(spec=nio.AsyncClient)
-    client.rooms = {
-        room_id: nio.MatrixRoom(room_id, bot.matrix_id.full_id) for room_id in (first_room_id, second_room_id)
-    }
-    bot.client = client
     first_started = asyncio.Event()
     second_started = asyncio.Event()
     release_first = asyncio.Event()
@@ -256,7 +249,7 @@ async def test_call_room_updates_are_preserved_while_reconciliation_is_running(t
 
     manager = MagicMock()
     manager.reconcile_joined_rooms = AsyncMock(side_effect=reconcile)
-    bot._call_manager = manager
+    install_call_manager_mock(bot, manager)
 
     with patch.object(bot, "_run_sync_response_side_effects", new=AsyncMock()):
         try:

--- a/tests/test_bot_ingestion_effects.py
+++ b/tests/test_bot_ingestion_effects.py
@@ -202,9 +202,10 @@ async def test_queued_own_departure_cannot_undo_authoritative_rejoin(tmp_path: P
 async def test_authoritative_join_requests_call_reconciliation_after_frame_publication(tmp_path: Path) -> None:
     """A state-only rejoin must discover calls after Nio publishes current room state."""
     bot = _agent_bot(tmp_path)
+    room_id = "!rejoined:localhost"
     admission = _validated_reported_membership_admission(
         bot,
-        "!rejoined:localhost",
+        room_id,
         previous_membership="leave",
         membership="join",
         previous_epoch=1,
@@ -213,8 +214,62 @@ async def test_authoritative_join_requests_call_reconciliation_after_frame_publi
     principal.ingestion_membership_position = AsyncMock(return_value=RoomMembershipPosition("join", 1))
     manager = MagicMock()
     manager.on_sync_room_membership = AsyncMock()
+    manager.reconcile_joined_rooms = AsyncMock()
     bot._call_manager = manager
-    bot._calls_reconcile_pending = False
-    with patch.object(bot, "journal_principal", return_value=principal):
+    client = MagicMock(spec=nio.AsyncClient)
+    client.rooms = {room_id: nio.MatrixRoom(room_id, bot.matrix_id.full_id)}
+    bot.client = client
+    with (
+        patch.object(bot, "journal_principal", return_value=principal),
+        patch.object(bot, "_run_sync_response_side_effects", new=AsyncMock()),
+    ):
         await bot._after_ingestion_admission(admission, AdmissionFacts(True, False), None)
-    assert bot._calls_reconcile_pending
+        await _complete_frame(bot)
+        assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+    manager.reconcile_joined_rooms.assert_awaited_once_with(frozenset({room_id}))
+
+
+@pytest.mark.asyncio
+async def test_call_room_updates_are_preserved_while_reconciliation_is_running(tmp_path: Path) -> None:
+    """A later frame must retain new room work while an earlier scoped pass awaits."""
+    bot = _agent_bot(tmp_path)
+    first_room_id = "!first-call:localhost"
+    second_room_id = "!second-call:localhost"
+    client = MagicMock(spec=nio.AsyncClient)
+    client.rooms = {
+        room_id: nio.MatrixRoom(room_id, bot.matrix_id.full_id) for room_id in (first_room_id, second_room_id)
+    }
+    bot.client = client
+    first_started = asyncio.Event()
+    second_started = asyncio.Event()
+    release_first = asyncio.Event()
+    reconciled_scopes: list[frozenset[str] | None] = []
+
+    async def reconcile(room_ids: frozenset[str] | None = None) -> None:
+        reconciled_scopes.append(room_ids)
+        if len(reconciled_scopes) == 1:
+            first_started.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+
+    manager = MagicMock()
+    manager.reconcile_joined_rooms = AsyncMock(side_effect=reconcile)
+    bot._call_manager = manager
+
+    with patch.object(bot, "_run_sync_response_side_effects", new=AsyncMock()):
+        try:
+            await bot._post_join_room_setup(first_room_id)
+            await bot._post_join_room_setup(first_room_id)
+            await _complete_frame(bot)
+            await asyncio.wait_for(first_started.wait(), timeout=1)
+
+            await bot._post_join_room_setup(second_room_id)
+            await _complete_frame(bot, 1)
+            await asyncio.wait_for(second_started.wait(), timeout=1)
+        finally:
+            release_first.set()
+            assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+    assert reconciled_scopes == [frozenset({first_room_id}), frozenset({second_room_id})]

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -421,6 +421,7 @@ async def test_call_reconciliation_runs_once_per_sync_loop(tmp_path: Path) -> No
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert call_manager.reconcile_joined_rooms.await_count == 2
+    assert [request.args for request in call_manager.reconcile_joined_rooms.await_args_list] == [(), ()]
 
 
 def test_router_sync_loop_start_revokes_room_backed_grants(tmp_path: Path) -> None:

--- a/tests/test_matrix_rtc_call_manager.py
+++ b/tests/test_matrix_rtc_call_manager.py
@@ -1840,6 +1840,90 @@ async def test_manager_reconciles_active_calls_after_sync(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_manager_reconciles_only_requested_joined_rooms(tmp_path: Path) -> None:
+    """A scoped pass must not refresh an unrelated configured call room."""
+    other_room_id = "!other-call:example.org"
+    config = _config()
+    config.agents["helper"].rooms.append(other_room_id)
+    client = _client()
+    client.rooms = {
+        ROOM_ID: _room(),
+        other_room_id: _room(room_id=other_room_id),
+    }
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], ROOM_ID)
+    manager = _manager(client, FakeBridge(), tmp_path, config)
+
+    await manager.reconcile_joined_rooms({ROOM_ID})
+
+    assert [request.args[0] for request in client.room_get_state.await_args_list] == [ROOM_ID]
+
+
+@pytest.mark.asyncio
+async def test_manager_explicit_empty_reconciliation_scope_does_no_work(tmp_path: Path) -> None:
+    """An empty scoped pass is distinct from a full startup pass."""
+    client = _client()
+    client.rooms = {ROOM_ID: _room()}
+    manager = _manager(client, FakeBridge(), tmp_path)
+
+    await manager.reconcile_joined_rooms(set())
+
+    client.room_get_state.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_manager_full_reconciliation_visits_every_configured_room(tmp_path: Path) -> None:
+    """The no-argument startup path must retain whole-account discovery."""
+    other_room_id = "!other-call:example.org"
+    config = _config()
+    config.agents["helper"].rooms.append(other_room_id)
+    client = _client()
+    client.rooms = {
+        ROOM_ID: _room(),
+        other_room_id: _room(room_id=other_room_id),
+    }
+    client.room_get_state.return_value = nio.RoomGetStateResponse([], ROOM_ID)
+    manager = _manager(client, FakeBridge(), tmp_path, config)
+
+    await manager.reconcile_joined_rooms()
+
+    assert {request.args[0] for request in client.room_get_state.await_args_list} == {ROOM_ID, other_room_id}
+
+
+@pytest.mark.asyncio
+async def test_scoped_reconciliation_does_not_join_after_room_leave(tmp_path: Path) -> None:
+    """A departure while admission is closed must fence an in-flight scoped pass."""
+    client = _client()
+    client.rooms = {ROOM_ID: _room()}
+    bridge = FakeBridge()
+    gate = ResponseAdmissionGate()
+    assert gate.close_if_idle()
+    wait_started = asyncio.Event()
+
+    async def wait_for_admission() -> bool:
+        wait_started.set()
+        await gate.wait_until_open()
+        return True
+
+    manager = _manager(
+        client,
+        bridge,
+        tmp_path,
+        response_admission_gate=gate,
+        wait_for_admission_or_shutdown=wait_for_admission,
+    )
+    reconcile = asyncio.create_task(manager.reconcile_joined_rooms({ROOM_ID}))
+    await asyncio.wait_for(wait_started.wait(), timeout=1)
+
+    await manager.on_sync_room_membership(joined_room_ids=set(), left_room_ids={ROOM_ID})
+    gate.reopen()
+    await reconcile
+
+    client.room_get_state.assert_not_awaited()
+    assert bridge.connected_grant is None
+    assert manager._sessions == {}
+
+
+@pytest.mark.asyncio
 async def test_manager_skips_join_without_openai_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Manager skips join without openai key."""
     monkeypatch.setattr("mindroom.matrix_rtc.call_manager.get_api_key_for_service", lambda _service, _paths: None)


### PR DESCRIPTION
Joining one call room currently schedules reconciliation of every configured joined room, causing unrelated room-state requests. Track affected room IDs until frame publication and pass that scope to the existing call manager.

Keep full discovery for startup, sync-loop recovery, and reply-authorization changes. Both paths share the existing ownership, permission, admission, and leave/rejoin checks. Snapshot pending work before starting background reconciliation so later room updates remain queued. This change works with the currently pinned NIO version.

Validation: focused regressions, the three owning test files, shutdown tests, and applicable pre-commit hooks pass. Independent implementation and final reviews approved the change.

The full local suite collected 18,753 tests: 18,725 passed, 22 skipped, and six failed. Four shutdown failures were fixed and pass on rerun. Two timeout failures remain outside the call changes: both the room-member baseline test and the 180-day gateway refresh test fail identically on the untouched base. No timeout thresholds or unrelated code were changed. The follow-up test-seam cleanup passes all 15 ingestion-effect tests and applicable hooks; independent scoped review approved it. The full local suite is not green because of the two reproduced baseline timeouts.
