### PR TITLE
Bump mindroom-nio to 1.0.6

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -98,11 +98,12 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.6`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
+Nio 1.0.6 uses unfiltered incremental Classic sync for local joins proven fresh at the current cursor, while retaining full-state recovery for stale evidence or incomplete room baselines.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/docs/dev/matrix-event-journal-contracts.md
+++ b/docs/dev/matrix-event-journal-contracts.md
@@ -26,7 +26,7 @@ One shared boundary helper encodes `None` to the empty string and decodes it bac
 ### Durable sync batch boundary
 
 The Matrix client uses `nio.durable.open_durable_sync` with Classic or Simplified Sliding Sync.
-Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.5` package, with no Git source override.
+Both development and published MindRoom wheels pin the released `mindroom-nio[e2e]==1.0.6` package, with no Git source override.
 Account, device, consumer and stream ownership bind once when opening the session.
 Soft-logout renewal requests the existing device; it preserves the bound stream, membership positions, and attempted-delivery sending identity.
 Hard logout, missing device storage, or changed identity stops startup instead of attempting a stream replacement.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==1.0.5",
+  "mindroom-nio[e2e]==1.0.6",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17408,11 +17408,12 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.6`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
+Nio 1.0.6 uses unfiltered incremental Classic sync for local joins proven fresh at the current cursor, while retaining full-state recovery for stale evidence or incomplete room baselines.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -94,11 +94,12 @@ This provenance remains attached across recovery, restart, and decryption indepe
 `matrix/durable_ingestion.py` converts one trusted Nio batch and atomically commits its receipt, ordered membership effects, semantic events, and conversation projection in the MindRoom journal before acknowledging that batch to Nio.
 An admission failure leaves the batch unsettled for retry, and replay after a committed admission returns the original receipt without duplicating semantic work.
 Typing, presence and read receipts are excluded from durable admission.
-MindRoom requires `mindroom-nio[e2e]==1.0.5`, and `uv.lock` pins the same published release.
+MindRoom requires `mindroom-nio[e2e]==1.0.6`, and `uv.lock` pins the same published release.
 Nio 1.0.2 avoids rereading queued payloads for byte accounting on SQLite 3.43 and newer, preserving exact accounting on older drivers.
 Nio 1.0.3 returns typed membership errors for refused durable joined-member queries and preserves Matrix error codes after retry exhaustion.
 Nio 1.0.4 avoids repeated pending-queue size scans during durable sync preparation while preserving queue limits and rollback.
 Nio 1.0.5 moves durable sync response decoding and captured-input replay off the event loop while preserving durable capture and membership ordering.
+Nio 1.0.6 uses unfiltered incremental Classic sync for local joins proven fresh at the current cursor, while retaining full-state recovery for stale evidence or incomplete room baselines.
 It retains the encrypted-attachment and null room-avatar parsing fixes that prevent those event shapes from blocking history hydration.
 Admission is fail-closed at every provenance, not only for recovery, because an event the journal never accepted is one no later process would see again.
 Silent schedules use the custom `io.mindroom.scheduled.trigger` timeline event so clients do not render the task body as a room message.

--- a/tests/test_hatch_build.py
+++ b/tests/test_hatch_build.py
@@ -258,7 +258,7 @@ def test_wheel_force_include_does_not_bundle_avatar_assets() -> None:
 
 
 def test_runtime_dependency_requires_released_durable_nio() -> None:
-    """The wheel pins released durable sync fixes, including off-loop response decoding."""
+    """The wheel pins released durable sync fixes, including cursor-bound join recovery."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
     dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
     requirement = Requirement(
@@ -274,6 +274,7 @@ def test_runtime_dependency_requires_released_durable_nio() -> None:
     assert Version("1.0.2") not in requirement.specifier
     assert Version("1.0.3") not in requirement.specifier
     assert Version("1.0.4") not in requirement.specifier
-    assert Version("1.0.5") in requirement.specifier
-    assert Version("1.0.6") not in requirement.specifier
+    assert Version("1.0.5") not in requirement.specifier
+    assert Version("1.0.6") in requirement.specifier
+    assert Version("1.0.7") not in requirement.specifier
     assert Version("2.0.0") not in requirement.specifier

--- a/uv.lock
+++ b/uv.lock
@@ -4594,7 +4594,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.5" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==1.0.6" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4706,7 +4706,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "1.0.5"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4719,9 +4719,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/d6/9407408727030db9c4574b1f618349fada01180fe9ea2d075072387925f7/mindroom_nio-1.0.5.tar.gz", hash = "sha256:0e33aa54542d55d851a2cf9659f5238b8882ac738f557f035395ddbb18478752", size = 211351, upload-time = "2026-09-12T13:36:42.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/42/76/9ccf4d27335e4e29571a1d4c87984b1bd923b8fe449e22345c9d742bbaa1/mindroom_nio-1.0.6.tar.gz", hash = "sha256:e2565b5765dd9a1b3aa08e2ccdbc5654e31ac98d592106fb3f06cee7907ff82b", size = 211847, upload-time = "2026-09-12T16:16:24.364Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/97/7507e5fc7905c37a58ebe678533a3aa9beb67fd6bd889ff7fb0c993893f3/mindroom_nio-1.0.5-py3-none-any.whl", hash = "sha256:fb63320ac951800f777a96d766e7259a5fcbcbe689346ee58a1ea07c0d13c28d", size = 246587, upload-time = "2026-09-12T13:36:41.082Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/54/e9c170ade42bc44bc23f09bb49ed252a373f604cbcdec4f78b764f188716/mindroom_nio-1.0.6-py3-none-any.whl", hash = "sha256:eebf6bd392b64ef252165ad5de5892ad21204103fdf01ee1953aac35ba25dd22", size = 247129, upload-time = "2026-09-12T16:16:22.537Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Pin `mindroom-nio[e2e]` to 1.0.6 and refresh its locked wheel and source-distribution hashes. Align the dependency contract test, architecture and journal documentation, and generated reference pages with the exact release. No other dependency versions change.

This consumes the fresh-join recovery optimization in [NIO 1.0.6](https://github.com/mindroom-ai/mindroom-nio/releases/tag/1.0.6): joins with current membership evidence avoid an account-wide full-state sync while uncertain cases retain conservative recovery.

Validation: lockfile consistency, dependency installation, repository hooks, and generated-reference checks pass. Durable ingestion, membership metadata, bot frame completion, call reconciliation, and RTC key transport tests pass with the published package. The full packaging-contract test file and both real Olm encrypt/decrypt tests pass without skips. Both locked artifact hashes match PyPI metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Matrix synchronization now uses incremental sync for locally joined rooms when freshness is confirmed, while retaining full-state recovery when room data may be stale or incomplete.
  - Updated the Matrix integration to use the released `mindroom-nio[e2e]` 1.0.6 package.

- **Documentation**
  - Updated Matrix architecture and development documentation to describe the revised synchronization behavior and required package version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->